### PR TITLE
MISO-194: Fix Illumina samplesheet demultiplexing

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/RunProcessingUtils.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/RunProcessingUtils.java
@@ -72,7 +72,7 @@ public class RunProcessingUtils {
               .append(ld.getLibrary().getName()).append("_").append(ld.getName()).append(",")
               .append(ld.getLibrary().getSample().getAlias().replaceAll("\\s", "")).append(",");
 
-          if (ld.getLibrary().getTagBarcodes() != null && !ld.getLibrary().getTagBarcodes().isEmpty() && p.getDilutions().size() > 1) {
+          if (ld.getLibrary().getTagBarcodes() != null && !ld.getLibrary().getTagBarcodes().isEmpty()) {
             Map<Integer, TagBarcode> barcodes = new TreeMap<Integer, TagBarcode>(ld.getLibrary().getTagBarcodes());
             int bcount = 1;
             for (Integer key : barcodes.keySet()) {

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/PoolControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/PoolControllerHelperService.java
@@ -758,28 +758,26 @@ public class PoolControllerHelperService {
                   + dilution.getLibrary().getAlias() + "(" + dilution.getLibrary().getName() + ")</a><br/>");
               info.append("<b>Sample:</b> <a href='/miso/sample/" + dilution.getLibrary().getSample().getId() + "'>"
                   + dilution.getLibrary().getSample().getAlias() + "(" + dilution.getLibrary().getSample().getName() + ")</a><br/>");
-              if (pool.getPoolableElements().size() > 1) {
-                Map<Integer, TagBarcode> barcodes = dilution.getLibrary().getTagBarcodes();
-                if (!barcodes.isEmpty()) {
-                  String out = "<b>Barcodes:</b></br>";
-                  for (Integer key : barcodes.keySet()) {
-                    TagBarcode tb = barcodes.get(key);
-                    if (tb != null) {
-                      out += key + ":" + tb.getName() + " (" + tb.getSequence() + ")<br/>";
-                      out += "<span class='counter'><img src='/styles/images/status/green.png' border='0'></span>";
-                    } else {
-                      out += "Error retrieving barcode [" + key + "] for library " + dilution.getLibrary().getName()
-                          + ". Please check libraries for this pool.";
-                      out += "<span class='counter'><img src='/styles/images/status/red.png' border='0'></span>";
-                      break;
-                    }
+              Map<Integer, TagBarcode> barcodes = dilution.getLibrary().getTagBarcodes();
+              if (!barcodes.isEmpty()) {
+                String out = "<b>Barcodes:</b></br>";
+                for (Integer key : barcodes.keySet()) {
+                  TagBarcode tb = barcodes.get(key);
+                  if (tb != null) {
+                    out += key + ":" + tb.getName() + " (" + tb.getSequence() + ")<br/>";
+                    out += "<span class='counter'><img src='/styles/images/status/green.png' border='0'></span>";
+                  } else {
+                    out += "Error retrieving barcode [" + key + "] for library " + dilution.getLibrary().getName()
+                        + ". Please check libraries for this pool.";
+                    out += "<span class='counter'><img src='/styles/images/status/red.png' border='0'></span>";
+                    break;
                   }
-                  info.append(out);
-                } else {
-                  info.append("<b>Barcode:</b>");
-                  info.append("<b>Library:</b> <a href='/miso/library/" + dilution.getLibrary().getId() + "'>Choose tag barcode</a>");
-                  info.append("<span class='counter'><img src='/styles/images/status/red.png' border='0'></span>");
                 }
+                info.append(out);
+              } else {
+                info.append("<b>Barcode:</b>");
+                info.append("<b>Library:</b> <a href='/miso/library/" + dilution.getLibrary().getId() + "'>Choose tag barcode</a>");
+                info.append("<span class='counter'><img src='/styles/images/status/red.png' border='0'></span>");
               }
             } else {
               info.append("Unrecognised poolable element: " + p.getClass().getSimpleName());


### PR DESCRIPTION
- Fix Illumina samplesheet demultiplexing so that Pools with a barcoded single element will export their barcode correctly.
- Show barcode index information if present for single element pools in Edit Pools page.