### PR TITLE
Glt 401 column sizes via dao

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/MisoRequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/MisoRequestManager.java
@@ -102,12 +102,17 @@ import uk.ac.bbsrc.tgac.miso.core.store.RunQcStore;
 import uk.ac.bbsrc.tgac.miso.core.store.RunStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SampleQcStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SampleStore;
+import uk.ac.bbsrc.tgac.miso.core.store.SecurityStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SequencerPartitionContainerStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SequencerReferenceStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SequencerServiceRecordStore;
 import uk.ac.bbsrc.tgac.miso.core.store.StatusStore;
 import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.core.store.StudyStore;
+import uk.ac.bbsrc.tgac.miso.core.store.SubmissionStore;
+
+import com.eaglegenomics.simlims.core.Note;
+import com.eaglegenomics.simlims.core.SecurityProfile;
 
 import com.eaglegenomics.simlims.core.Note;
 import com.eaglegenomics.simlims.core.SecurityProfile;
@@ -174,11 +179,17 @@ public class MisoRequestManager implements RequestManager {
   @Autowired
   private StudyStore studyStore;
   @Autowired
-  private Store<Submission> submissionStore;
+  private SubmissionStore submissionStore;
   @Autowired
   private ChangeLogStore changeLogStore;
   @Autowired
   private BoxStore boxStore;
+  @Autowired
+  private SecurityStore securityStore;
+  
+  public void setSecurityStore(SecurityStore securityStore) {
+    this.securityStore = securityStore;
+  }
 
   public void setBoxStore(BoxStore boxStore) {
     this.boxStore = boxStore;
@@ -288,7 +299,7 @@ public class MisoRequestManager implements RequestManager {
     this.studyStore = studyStore;
   }
 
-  public void setSubmissionStore(Store<Submission> submissionStore) {
+  public void setSubmissionStore(SubmissionStore submissionStore) {
     this.submissionStore = submissionStore;
   }
 
@@ -2603,6 +2614,14 @@ public class MisoRequestManager implements RequestManager {
       throw new IOException("No sequencerServiceRecordStore available. Check that it has been declared in the Spring config.");
     }
   }
+  
+  public Map<String, Integer> getBoxColumnSizes() throws IOException {
+    if (boxStore != null) {
+      return boxStore.getBoxColumnSizes();
+    } else {
+      throw new IOException("No boxStore available. Check that it has been declared in the Spring config.");
+    }
+  }
 
   @Override
   public SequencerServiceRecord getSequencerServiceRecordById(long id) throws IOException {
@@ -2612,6 +2631,14 @@ public class MisoRequestManager implements RequestManager {
       throw new IOException("No sequencerServiceRecordStore available. Check that it has been declared in the Spring config.");
     }
   }
+  
+  public Map<String, Integer> getExperimentColumnSizes() throws IOException {
+    if (experimentStore != null) {
+      return experimentStore.getExperimentColumnSizes();
+    } else {
+      throw new IOException("No experimentStore available. Check that it has been declared in the Spring config.");
+    }
+  }
 
   @Override
   public Collection<SequencerServiceRecord> listAllSequencerServiceRecords() throws IOException {
@@ -2619,6 +2646,14 @@ public class MisoRequestManager implements RequestManager {
       return sequencerServiceRecordStore.listAll();
     } else {
       throw new IOException("No sequencerServiceRecordStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+  
+  public Map<String, Integer> getPoolColumnSizes() throws IOException {
+    if (poolStore != null) {
+      return poolStore.getPoolColumnSizes();
+    } else {
+      throw new IOException("No poolStore available. Check that it has been declared in the Spring config.");
     }
   }
 
@@ -2637,6 +2672,104 @@ public class MisoRequestManager implements RequestManager {
       return sequencerServiceRecordStore.getServiceRecordColumnSizes();
     } else {
       throw new IOException("No sequencerServiceRecordStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+  
+  public Map<String, Integer> getKitDescriptorColumnSizes() throws IOException {
+    if (kitStore != null) {
+      return kitStore.getKitDescriptorColumnSizes();
+    } else {
+      throw new IOException("No kitStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getLibraryColumnSizes() throws IOException {
+    if (libraryStore != null) {
+      return libraryStore.getLibraryColumnSizes();
+    } else {
+      throw new IOException("No libraryStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getPlateColumnSizes() throws IOException {
+    if (plateStore != null) {
+      return plateStore.getPlateColumnSizes();
+    } else {
+      throw new IOException("No plateStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getProjectColumnSizes() throws IOException {
+    if (projectStore != null) {
+      return projectStore.getProjectColumnSizes();
+    } else {
+      throw new IOException("No projectStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getRunColumnSizes() throws IOException {
+    if (runStore != null) {
+      return runStore.getRunColumnSizes();
+    } else {
+      throw new IOException("No runStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getSampleColumnSizes() throws IOException {
+    if (sampleStore != null) {
+      return sampleStore.getSampleColumnSizes();
+    } else {
+      throw new IOException("No sampleStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getStudyColumnSizes() throws IOException {
+    if (studyStore != null) {
+      return studyStore.getStudyColumnSizes();
+    } else {
+      throw new IOException("No studyStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getSequencerReferenceColumnSizes() throws IOException {
+    if (sequencerReferenceStore != null) {
+      return sequencerReferenceStore.getSequencerReferenceColumnSizes();
+    } else {
+      throw new IOException("No sequencerReferenceStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getSubmissionColumnSizes() throws IOException {
+    if (submissionStore != null) {
+      return submissionStore.getSubmissionColumnSizes();
+    } else {
+      throw new IOException("No submissionStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getUserColumnSizes() throws IOException {
+    if (securityStore != null) {
+      return securityStore.getUserColumnSizes();
+    } else {
+      throw new IOException("No securityStore available. Check that it has been declared in the Spring config.");
+    }
+  }
+
+  @Override
+  public Map<String, Integer> getGroupColumnSizes() throws IOException {
+    if (securityStore != null) {
+      return securityStore.getGroupColumnSizes();
+    } else {
+      throw new IOException("No securityStore available. Check that it has been declared in the Spring config.");
     }
   }
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/RequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/RequestManager.java
@@ -597,5 +597,33 @@ public interface RequestManager {
   public void deleteBox(Box box) throws IOException;
   
   public Map<String, Integer> getServiceRecordColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getBoxColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getExperimentColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getPoolColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getKitDescriptorColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getLibraryColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getPlateColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getProjectColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getRunColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getSampleColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getStudyColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getSequencerReferenceColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getSubmissionColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getUserColumnSizes() throws IOException;
+  
+  public Map<String, Integer> getGroupColumnSizes() throws IOException;
 
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/UserAuthMisoRequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/UserAuthMisoRequestManager.java
@@ -2388,4 +2388,73 @@ public class UserAuthMisoRequestManager implements RequestManager {
   public Map<String, Integer> getServiceRecordColumnSizes() throws IOException {
     return backingManager.getServiceRecordColumnSizes();
   }
+  
+  public Map<String, Integer> getBoxColumnSizes() throws IOException {
+    return backingManager.getBoxColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getExperimentColumnSizes() throws IOException {
+    return backingManager.getExperimentColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getPoolColumnSizes() throws IOException {
+    return backingManager.getPoolColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getKitDescriptorColumnSizes() throws IOException {
+    return backingManager.getKitDescriptorColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getLibraryColumnSizes() throws IOException {
+    return backingManager.getLibraryColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getPlateColumnSizes() throws IOException {
+    return backingManager.getPlateColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getProjectColumnSizes() throws IOException {
+    return backingManager.getProjectColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getRunColumnSizes() throws IOException {
+    return backingManager.getRunColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getSampleColumnSizes() throws IOException {
+    return backingManager.getSampleColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getStudyColumnSizes() throws IOException {
+    return backingManager.getStudyColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getSequencerReferenceColumnSizes() throws IOException {
+    return backingManager.getSequencerReferenceColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getSubmissionColumnSizes() throws IOException {
+    return backingManager.getSubmissionColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getUserColumnSizes() throws IOException {
+    return backingManager.getUserColumnSizes();
+  }
+
+  @Override
+  public Map<String, Integer> getGroupColumnSizes() throws IOException {
+    return backingManager.getGroupColumnSizes();
+  }
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/BoxStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/BoxStore.java
@@ -2,6 +2,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Box;
 import uk.ac.bbsrc.tgac.miso.core.data.BoxSize;
@@ -87,4 +88,11 @@ public interface BoxStore extends Store<Box>, Remover<Box>, NamingSchemeAware<Bo
   void emptyAllTubes(Box box) throws IOException;
   
   void removeBoxableFromBox(Boxable boxable) throws IOException;
+
+  /**
+   * @return a map containing all column names and max lengths from the Box table
+   * @throws IOException
+   */
+  public Map<String, Integer> getBoxColumnSizes() throws IOException;
+
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/ExperimentStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/ExperimentStore.java
@@ -25,6 +25,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.NamingSchemeAware;
@@ -88,4 +89,10 @@ public interface ExperimentStore extends Store<Experiment>, Cascadable, Remover<
    *           when the objects cannot be retrieved
    */
   Collection<Experiment> listAllWithLimit(long limit) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Experiments table
+   * @throws IOException
+   */
+  public Map<String, Integer> getExperimentColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/KitStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/KitStore.java
@@ -25,6 +25,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Kit;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
@@ -58,4 +59,10 @@ public interface KitStore extends Store<Kit> {
   List<KitDescriptor> listKitDescriptorsByType(KitType kitType) throws IOException;
 
   long saveKitDescriptor(KitDescriptor kitDescriptor) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Kit Descriptor table
+   * @throws IOException
+   */
+  public Map<String, Integer> getKitDescriptorColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/LibraryStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/LibraryStore.java
@@ -26,6 +26,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
@@ -292,4 +293,10 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
    *           when the objects cannot be retrieved
    */
   Collection<Library> getByBarcodeList(List<String> barcodeList) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Library table
+   * @throws IOException
+   */
+  public Map<String, Integer> getLibraryColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/PlateStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/PlateStore.java
@@ -25,6 +25,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Plate;
 import uk.ac.bbsrc.tgac.miso.core.data.Plateable;
@@ -57,4 +58,10 @@ public interface PlateStore extends Store<Plate<? extends List<? extends Plateab
    *           when
    */
   <T extends List<S>, S extends Plateable> Plate<T, S> getPlateByIdentificationBarcode(String barcode) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Plate table
+   * @throws IOException
+   */
+  public Map<String, Integer> getPlateColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/PoolStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/PoolStore.java
@@ -26,6 +26,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
@@ -178,4 +179,10 @@ public interface PoolStore
    *           when
    */
   Pool<? extends Poolable> getByBarcode(String barcode);
+  
+  /**
+   * @return a map containing all column names and max lengths from the Pool table
+   * @throws IOException
+   */
+  public Map<String, Integer> getPoolColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/ProjectStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/ProjectStore.java
@@ -25,6 +25,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectOverview;
@@ -111,4 +112,10 @@ public interface ProjectStore extends Store<Project>, Cascadable, Remover<Projec
    *           when
    */
   long saveOverview(ProjectOverview overview) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Project table
+   * @throws IOException
+   */
+  public Map<String, Integer> getProjectColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/RunStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/RunStore.java
@@ -26,6 +26,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.NamingSchemeAware;
@@ -166,4 +167,10 @@ public interface RunStore extends Store<Run>, Cascadable, Remover<Run>, NamingSc
   Collection<Run> listAllWithLimit(long limit) throws IOException;
 
   int[] saveAll(Collection<Run> runs) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Run table
+   * @throws IOException
+   */
+  public Map<String, Integer> getRunColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SampleStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SampleStore.java
@@ -26,6 +26,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
@@ -153,4 +154,10 @@ public interface SampleStore extends Store<Sample>, Cascadable, Remover<Sample>,
    *           when the objects cannot be retrieved
    */
   Collection<Sample> getByBarcodeList(List<String> barcodeList) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Sample table
+   * @throws IOException
+   */
+  public Map<String, Integer> getSampleColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SecurityStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SecurityStore.java
@@ -1,0 +1,20 @@
+package uk.ac.bbsrc.tgac.miso.core.store;
+
+import java.io.IOException;
+import java.util.Map;
+
+public interface SecurityStore extends com.eaglegenomics.simlims.core.store.SecurityStore {
+
+  /**
+   * @return a map containing all column names and max lengths from the User table
+   * @throws IOException
+   */
+  public Map<String, Integer> getUserColumnSizes() throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Group table
+   * @throws IOException
+   */
+  public Map<String, Integer> getGroupColumnSizes() throws IOException;
+  
+}

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SequencerReferenceStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SequencerReferenceStore.java
@@ -25,6 +25,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerReference;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
@@ -68,4 +69,10 @@ public interface SequencerReferenceStore extends Store<SequencerReference>, Remo
    *           when
    */
   Collection<SequencerReference> listByPlatformType(PlatformType platformType) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Sequencer Reference table
+   * @throws IOException
+   */
+  public Map<String, Integer> getSequencerReferenceColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/StudyStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/StudyStore.java
@@ -25,6 +25,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Study;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.NamingSchemeAware;
@@ -108,4 +109,10 @@ public interface StudyStore extends Store<Study>, Cascadable, Remover<Study>, Na
    *           when the objects cannot be retrieved
    */
   Collection<Study> listAllWithLimit(long limit) throws IOException;
+  
+  /**
+   * @return a map containing all column names and max lengths from the Study table
+   * @throws IOException
+   */
+  public Map<String, Integer> getStudyColumnSizes() throws IOException;
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SubmissionStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SubmissionStore.java
@@ -1,0 +1,16 @@
+package uk.ac.bbsrc.tgac.miso.core.store;
+
+import java.io.IOException;
+import java.util.Map;
+
+import uk.ac.bbsrc.tgac.miso.core.data.Submission;
+
+public interface SubmissionStore extends Store<Submission> {
+
+  /**
+   * @return a map containing all column names and max lengths from the Submission table
+   * @throws IOException
+   */
+  public Map<String, Integer> getSubmissionColumnSizes() throws IOException;
+  
+}

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditBoxController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditBoxController.java
@@ -11,7 +11,6 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -32,7 +31,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.ChangeLog;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.integration.BoxScanner;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 import uk.ac.bbsrc.tgac.miso.webapp.context.ApplicationContextProvider;
 import uk.ac.bbsrc.tgac.miso.webapp.util.MisoPropertyExporter;
 
@@ -55,14 +53,7 @@ public class EditBoxController {
   private DataObjectFactory dataObjectFactory;
 
   @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  @Autowired
   private BoxScanner boxScanner;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -85,7 +76,7 @@ public class EditBoxController {
   
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Box");
+    return requestManager.getBoxColumnSizes();
   }
 
   public List<String> boxSizesAsRowsByColumns() throws IOException {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditExperimentController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditExperimentController.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -46,10 +45,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.servlet.ModelAndView;
-
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractExperiment;
 import uk.ac.bbsrc.tgac.miso.core.data.ChangeLog;
@@ -63,7 +58,10 @@ import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 @Controller
 @RequestMapping("/experiment")
@@ -80,13 +78,6 @@ public class EditExperimentController {
   @Autowired
   private DataObjectFactory dataObjectFactory;
 
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
-
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
   }
@@ -101,7 +92,7 @@ public class EditExperimentController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Experiment");
+    return requestManager.getExperimentColumnSizes();
   }
 
   @ModelAttribute("platforms")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditGroupController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditGroupController.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -45,7 +44,7 @@ import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.servlet.ModelAndView;
 
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 
 import com.eaglegenomics.simlims.core.Group;
 import com.eaglegenomics.simlims.core.User;
@@ -63,10 +62,10 @@ public class EditGroupController {
   private DataObjectFactory dataObjectFactory;
   
   @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
+  private RequestManager requestManager;
+  
+  public void setRequestManager(RequestManager requestManager) {
+    this.requestManager = requestManager;
   }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
@@ -93,7 +92,7 @@ public class EditGroupController {
   
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "_Group");
+    return requestManager.getGroupColumnSizes();
   }
 
   @RequestMapping(value = "/admin/group/new", method = RequestMethod.GET)

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditIlluminaPoolController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditIlluminaPoolController.java
@@ -35,7 +35,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -59,7 +58,6 @@ import uk.ac.bbsrc.tgac.miso.core.exception.MalformedDilutionException;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
 import com.eaglegenomics.simlims.core.User;
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
@@ -87,13 +85,6 @@ public class EditIlluminaPoolController {
 
   @Autowired
   private DataObjectFactory dataObjectFactory;
-  
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -109,7 +100,7 @@ public class EditIlluminaPoolController {
   
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Pool");
+    return requestManager.getPoolColumnSizes();
   }
 
   private List<? extends Dilution> populateAvailableDilutions(Pool pool) throws IOException {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditKitDescriptorController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditKitDescriptorController.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -47,7 +46,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.KitType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
 @Controller
 @RequestMapping("/kitdescriptor")
@@ -61,16 +59,9 @@ public class EditKitDescriptorController {
   @Autowired
   private DataObjectFactory dataObjectFactory;
   
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
-  
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "KitDescriptor");
+    return requestManager.getKitDescriptorColumnSizes();
   }
 
   @ModelAttribute("kitTypes")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLS454PoolController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLS454PoolController.java
@@ -35,7 +35,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -60,7 +59,6 @@ import uk.ac.bbsrc.tgac.miso.core.exception.MalformedLibraryException;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
 import com.eaglegenomics.simlims.core.User;
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
@@ -88,13 +86,6 @@ public class EditLS454PoolController {
 
   @Autowired
   private DataObjectFactory dataObjectFactory;
-  
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -110,7 +101,7 @@ public class EditLS454PoolController {
   
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Pool");
+    return requestManager.getPoolColumnSizes();
   }
 
   private List<? extends Dilution> populateAvailableDilutions(User user, Pool pool) throws IOException {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLibraryController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLibraryController.java
@@ -42,7 +42,6 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -55,10 +54,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.servlet.ModelAndView;
-
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractLibrary;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractLibraryQC;
@@ -85,9 +80,12 @@ import uk.ac.bbsrc.tgac.miso.core.service.tagbarcode.TagBarcodeStrategy;
 import uk.ac.bbsrc.tgac.miso.core.service.tagbarcode.TagBarcodeStrategyResolverService;
 import uk.ac.bbsrc.tgac.miso.core.util.AliasComparator;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 import uk.ac.bbsrc.tgac.miso.webapp.context.ApplicationContextProvider;
 import uk.ac.bbsrc.tgac.miso.webapp.util.MisoPropertyExporter;
+
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 /**
  * uk.ac.bbsrc.tgac.miso.webapp.controller
@@ -113,14 +111,7 @@ public class EditLibraryController {
   private DataObjectFactory dataObjectFactory;
 
   @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  @Autowired
   private TagBarcodeStrategyResolverService tagBarcodeStrategyResolverService;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -229,7 +220,7 @@ public class EditLibraryController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Library");
+    return requestManager.getLibraryColumnSizes();
   }
 
   @ModelAttribute("platformNames")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPlateController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPlateController.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -55,7 +54,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.TagBarcode;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 import uk.ac.bbsrc.tgac.miso.webapp.context.ApplicationContextProvider;
 import uk.ac.bbsrc.tgac.miso.webapp.util.MisoPropertyExporter;
 
@@ -77,13 +75,6 @@ public class EditPlateController {
   @Autowired
   private DataObjectFactory dataObjectFactory;
 
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
-
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
   }
@@ -103,7 +94,7 @@ public class EditPlateController {
   
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Plate");
+    return requestManager.getPlateColumnSizes();
   }
   
   public Boolean misoPropertyBoolean(String property) {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPoolController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPoolController.java
@@ -35,7 +35,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -64,7 +63,6 @@ import uk.ac.bbsrc.tgac.miso.core.exception.MalformedDilutionException;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 import uk.ac.bbsrc.tgac.miso.webapp.context.ApplicationContextProvider;
 import uk.ac.bbsrc.tgac.miso.webapp.util.MisoPropertyExporter;
 
@@ -90,13 +88,6 @@ public class EditPoolController {
 
   @Autowired
   private DataObjectFactory dataObjectFactory;
-  
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -134,7 +125,7 @@ public class EditPoolController {
   
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Pool");
+    return requestManager.getPoolColumnSizes();
   }
 
   private List<? extends Dilution> populateAvailableDilutions(Pool pool) throws IOException {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditProjectController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditProjectController.java
@@ -37,11 +37,13 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
+import net.sf.json.JSONObject;
+import net.sourceforge.fluxion.ajax.util.JSONUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.propertyeditors.CustomDateEditor;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -56,11 +58,6 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.servlet.ModelAndView;
 
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.manager.SecurityManager;
-
-import net.sf.json.JSONObject;
-import net.sourceforge.fluxion.ajax.util.JSONUtils;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractProject;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractSampleQC;
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
@@ -90,7 +87,8 @@ import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
 import uk.ac.bbsrc.tgac.miso.core.util.AliasComparator;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.service.ReferenceGenomeService;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 @Controller
 @RequestMapping("/project")
@@ -129,13 +127,6 @@ public class EditProjectController {
     this.filesManager = filesManager;
   }
 
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
-
   @InitBinder
   public void initBinder(WebDataBinder binder) {
     CustomDateEditor cde = new CustomDateEditor(new SimpleDateFormat("dd/MM/yyyy"), true);
@@ -158,7 +149,7 @@ public class EditProjectController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Project");
+    return requestManager.getProjectColumnSizes();
   }
 
   @ModelAttribute("sampleQcTypesString")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditRunController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditRunController.java
@@ -37,7 +37,6 @@ import javax.xml.transform.TransformerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -73,7 +72,6 @@ import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.core.util.SubmissionUtils;
 import uk.ac.bbsrc.tgac.miso.runstats.client.RunStatsException;
 import uk.ac.bbsrc.tgac.miso.runstats.client.manager.RunStatsManager;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 import uk.ac.bbsrc.tgac.miso.webapp.context.ApplicationContextProvider;
 import uk.ac.bbsrc.tgac.miso.webapp.util.MisoPropertyExporter;
 import uk.ac.bbsrc.tgac.miso.webapp.util.MisoWebUtils;
@@ -97,9 +95,6 @@ public class EditRunController {
   private DataObjectFactory dataObjectFactory;
 
   @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  @Autowired
   private RunAlertManager runAlertManager;
 
   private RunStatsManager runStatsManager;
@@ -109,10 +104,6 @@ public class EditRunController {
 
   public void setApplicationContextProvider(ApplicationContextProvider applicationContextProvider) {
     this.applicationContextProvider = applicationContextProvider;
-  }
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
   }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
@@ -137,7 +128,7 @@ public class EditRunController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Run");
+    return requestManager.getRunColumnSizes();
   }
 
   @ModelAttribute("platformTypes")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
@@ -37,7 +37,6 @@ import java.util.TreeSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -50,10 +49,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.servlet.ModelAndView;
-
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractSample;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractSampleQC;
@@ -73,9 +68,12 @@ import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 import uk.ac.bbsrc.tgac.miso.webapp.context.ApplicationContextProvider;
 import uk.ac.bbsrc.tgac.miso.webapp.util.MisoPropertyExporter;
+
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 @Controller
 @RequestMapping("/sample")
@@ -91,13 +89,6 @@ public class EditSampleController {
 
   @Autowired
   private DataObjectFactory dataObjectFactory;
-
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -263,7 +254,7 @@ public class EditSampleController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Sample");
+    return requestManager.getSampleColumnSizes();
   }
 
   @ModelAttribute("sampleTypesString")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSolidPoolController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSolidPoolController.java
@@ -35,7 +35,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -60,7 +59,6 @@ import uk.ac.bbsrc.tgac.miso.core.exception.MalformedLibraryException;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
 import com.eaglegenomics.simlims.core.User;
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
@@ -89,16 +87,9 @@ public class EditSolidPoolController {
   @Autowired
   private DataObjectFactory dataObjectFactory;
   
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
-  
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Pool");
+    return requestManager.getPoolColumnSizes();
   }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditStudyController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditStudyController.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -44,10 +43,6 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.servlet.ModelAndView;
 
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.manager.SecurityManager;
-
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractStudy;
 import uk.ac.bbsrc.tgac.miso.core.data.ChangeLog;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
@@ -56,7 +51,10 @@ import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 @Controller
 @RequestMapping("/study")
@@ -72,13 +70,6 @@ public class EditStudyController {
 
   @Autowired
   private DataObjectFactory dataObjectFactory;
-
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -110,7 +101,7 @@ public class EditStudyController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Study");
+    return requestManager.getStudyColumnSizes();
   }
 
   @ModelAttribute("studyTypes")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSubmissionController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSubmissionController.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -44,9 +43,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.servlet.ModelAndView;
-
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
@@ -61,7 +57,9 @@ import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.FilesManager;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.manager.SubmissionManager;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 @Controller
 @RequestMapping("/submission")
@@ -83,13 +81,6 @@ public class EditSubmissionController {
 
   @Autowired
   private SubmissionManager submissionManager;
-
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -113,7 +104,7 @@ public class EditSubmissionController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Submission");
+    return requestManager.getSubmissionColumnSizes();
   }
 
   @ModelAttribute("projects")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditUserController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditUserController.java
@@ -37,7 +37,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.authority.GrantedAuthorityImpl;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
@@ -52,8 +51,8 @@ import org.springframework.web.servlet.ModelAndView;
 
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
+import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.PasswordCodecService;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
 import com.eaglegenomics.simlims.core.Activity;
 import com.eaglegenomics.simlims.core.Group;
@@ -80,10 +79,10 @@ public class EditUserController {
   private DataObjectFactory dataObjectFactory;
   
   @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
+  private RequestManager requestManager;
+  
+  public void setRequestManager(RequestManager requestManager) {
+    this.requestManager = requestManager;
   }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
@@ -104,7 +103,7 @@ public class EditUserController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "User");
+    return requestManager.getUserColumnSizes();
   }
 
   @ModelAttribute("groups")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ExperimentWizardController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ExperimentWizardController.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -43,16 +42,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.servlet.ModelAndView;
 
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.manager.SecurityManager;
-
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Platform;
 import uk.ac.bbsrc.tgac.miso.core.data.Pool;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 @Controller
 @RequestMapping("/experimentwizard")
@@ -68,13 +66,6 @@ public class ExperimentWizardController {
 
   @Autowired
   private DataObjectFactory dataObjectFactory;
-
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
 
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -95,7 +86,7 @@ public class ExperimentWizardController {
 
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "Experiment");
+    return requestManager.getExperimentColumnSizes();
   }
 
   @ModelAttribute("platforms")

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/StatsController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/StatsController.java
@@ -36,7 +36,6 @@ import javax.xml.transform.TransformerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -59,7 +58,6 @@ import uk.ac.bbsrc.tgac.miso.core.service.integration.strategy.interrogator.Sequ
 import uk.ac.bbsrc.tgac.miso.core.service.integration.ws.solid.SolidService;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.core.util.SubmissionUtils;
-import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 import uk.ac.bbsrc.tgac.miso.webapp.util.MisoWebUtils;
 
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
@@ -121,16 +119,9 @@ public class StatsController {
     this.requestManager = requestManager;
   }
   
-  @Autowired
-  private JdbcTemplate interfaceTemplate;
-
-  public void setInterfaceTemplate(JdbcTemplate interfaceTemplate) {
-    this.interfaceTemplate = interfaceTemplate;
-  }
-  
   @ModelAttribute("maxLengths")
   public Map<String, Integer> maxLengths() throws IOException {
-    return DbUtils.getColumnSizes(interfaceTemplate, "SequencerReference");
+    return requestManager.getSequencerReferenceColumnSizes();
   }
 
   public Collection<SequencerReference> populateSequencerReferences() throws IOException {

--- a/miso-web/src/main/resources/sql/db-config.xml
+++ b/miso-web/src/main/resources/sql/db-config.xml
@@ -707,7 +707,7 @@
 
   <bean name="securityStore" class="org.springframework.aop.framework.ProxyFactoryBean">
     <property name="proxyInterfaces">
-      <value>com.eaglegenomics.simlims.core.store.SecurityStore</value>
+      <value>uk.ac.bbsrc.tgac.miso.core.store.SecurityStore</value>
     </property>
     <property name="interceptorNames">
       <list>
@@ -740,7 +740,7 @@
 
   <bean name="submissionStore" class="org.springframework.aop.framework.ProxyFactoryBean">
     <property name="proxyInterfaces">
-      <value>uk.ac.bbsrc.tgac.miso.core.store.Store</value>
+      <value>uk.ac.bbsrc.tgac.miso.core.store.SubmissionStore</value>
     </property>
     <property name="interceptorNames">
       <list>

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLBoxDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLBoxDAO.java
@@ -609,4 +609,9 @@ public class SQLBoxDAO implements BoxStore {
   public void setCacheManager(CacheManager cacheManager) {
     this.cacheManager = cacheManager;
   }
+
+  @Override
+  public Map<String, Integer> getBoxColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
+  }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLExperimentDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLExperimentDAO.java
@@ -27,9 +27,14 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import javax.persistence.CascadeType;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,16 +46,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.store.SecurityStore;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
-
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractExperiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Kit;
@@ -71,6 +66,13 @@ import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.core.store.StudyStore;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.store.SecurityStore;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
 
 /**
  * A data access object designed for retrieving Experiments from the LIMS database. This DAO should be configured with a spring
@@ -510,5 +512,10 @@ public class SQLExperimentDAO implements ExperimentStore {
 
       return e;
     }
+  }
+  
+  @Override
+  public Map<String, Integer> getExperimentColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLLibraryDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLLibraryDAO.java
@@ -28,6 +28,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import javax.persistence.CascadeType;
@@ -848,5 +849,10 @@ public class SQLLibraryDAO implements LibraryStore {
       tb.setStrategyName(rs.getString("strategyName"));
       return tb;
     }
+  }
+  
+  @Override
+  public Map<String, Integer> getLibraryColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlateDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlateDAO.java
@@ -35,6 +35,9 @@ import java.util.Map;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,15 +48,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.store.SecurityStore;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
-
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractPlate;
 import uk.ac.bbsrc.tgac.miso.core.data.Dilution;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
@@ -73,6 +67,13 @@ import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DaoLookup;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.store.SecurityStore;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
 
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
@@ -502,5 +503,10 @@ public class SQLPlateDAO implements PlateStore {
 
   public void setSecurityDAO(SecurityStore securityDAO) {
     this.securityDAO = securityDAO;
+  }
+  
+  @Override
+  public Map<String, Integer> getPlateColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAO.java
@@ -30,6 +30,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
@@ -52,14 +53,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.store.SecurityStore;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractPool;
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
@@ -85,6 +78,14 @@ import uk.ac.bbsrc.tgac.miso.core.util.BoxUtils;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DaoLookup;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.store.SecurityStore;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
 
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
@@ -867,5 +868,10 @@ public class SQLPoolDAO implements PoolStore {
         throw new SQLException("Cannot retrieve poolable element: [" + type + " ] " + elementId);
       }
     }
+  }
+  
+  @Override
+  public Map<String, Integer> getPoolColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLProjectDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLProjectDAO.java
@@ -29,9 +29,14 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import javax.persistence.CascadeType;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,17 +49,6 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.eaglegenomics.simlims.core.Note;
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.User;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
-
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractProject;
 import uk.ac.bbsrc.tgac.miso.core.data.EntityGroup;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
@@ -78,6 +72,14 @@ import uk.ac.bbsrc.tgac.miso.core.store.WatcherStore;
 import uk.ac.bbsrc.tgac.miso.persistence.ReferenceGenomeDao;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.Note;
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.User;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
 
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
@@ -680,5 +682,10 @@ public class SQLProjectDAO implements ProjectStore {
 
       return overview;
     }
+  }
+  
+  @Override
+  public Map<String, Integer> getProjectColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunDAO.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import javax.persistence.CascadeType;
@@ -739,5 +740,10 @@ public class SQLRunDAO implements RunStore {
 
       return r;
     }
+  }
+  
+  @Override
+  public Map<String, Integer> getRunColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleDAO.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import javax.persistence.CascadeType;
@@ -82,7 +83,6 @@ import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.core.util.BoxUtils;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
-
 
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
@@ -664,5 +664,10 @@ public class SQLSampleDAO implements SampleStore {
 
       return s;
     }
+  }
+  
+  @Override
+  public Map<String, Integer> getSampleColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerReferenceDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerReferenceDAO.java
@@ -30,6 +30,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import javax.sql.rowset.serial.SerialBlob;
 
@@ -48,6 +49,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.store.PlatformStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SequencerReferenceStore;
+import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
@@ -259,5 +261,10 @@ public class SQLSequencerReferenceDAO implements SequencerReferenceStore {
       }
       return c;
     }
+  }
+  
+  @Override
+  public Map<String, Integer> getSequencerReferenceColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLStudyDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLStudyDAO.java
@@ -27,9 +27,14 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import javax.persistence.CascadeType;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,16 +46,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.store.SecurityStore;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
-
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractStudy;
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
@@ -66,6 +61,13 @@ import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.core.store.StudyStore;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
+
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.store.SecurityStore;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
 
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
@@ -443,5 +445,10 @@ public class SQLStudyDAO implements StudyStore {
 
       return s;
     }
+  }
+  
+  @Override
+  public Map<String, Integer> getStudyColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLTgacSubmissionDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLTgacSubmissionDAO.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,8 +66,8 @@ import uk.ac.bbsrc.tgac.miso.core.store.LibraryDilutionStore;
 import uk.ac.bbsrc.tgac.miso.core.store.PartitionStore;
 import uk.ac.bbsrc.tgac.miso.core.store.RunStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SampleStore;
-import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.core.store.StudyStore;
+import uk.ac.bbsrc.tgac.miso.core.store.SubmissionStore;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
 /**
@@ -77,7 +78,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
-public class SQLTgacSubmissionDAO implements Store<Submission>, NamingSchemeAware<Submission> {
+public class SQLTgacSubmissionDAO implements SubmissionStore, NamingSchemeAware<Submission> {
   private static final String TABLE_NAME = "Submission";
 
   public static final String SUBMISSION_SELECT = "SELECT submissionId, creationDate, submittedDate, name, alias, title, description, accession, verified, completed "
@@ -435,5 +436,10 @@ public class SQLTgacSubmissionDAO implements Store<Submission>, NamingSchemeAwar
 
       return t;
     }
+  }
+
+  @Override
+  public Map<String, Integer> getSubmissionColumnSizes() throws IOException {
+    return DbUtils.getColumnSizes(template, TABLE_NAME);
   }
 }


### PR DESCRIPTION
Controllers now use RequestManager to get table column size limits for the purpose of showing field length counters. Previously, controllers made JDBC calls via DbUtils and had to include the database table name.