### PR TITLE
Replace "Tissue Condition" with "Tissue Type" on front end

### DIFF
--- a/miso-web/src/main/webapp/pages/instituteDefaults.jsp
+++ b/miso-web/src/main/webapp/pages/instituteDefaults.jsp
@@ -37,7 +37,7 @@
   
   <div class="corner-padding">
     <a href="#origins">Tissue Origins</a><br/>
-    <a href="#conditions">Tissue Conditions</a><br/>
+    <a href="#types">Tissue Types</a><br/>
     <a href="#materials">Tissue Materials</a><br/>
     <a href="#purposes">Sample Purposes</a><br/>
     <a href="#qcDetails">QC Details</a><br/>
@@ -63,14 +63,14 @@
   
   <div class="sectionDivider"></div>
   <div class="corner-padding">
-    <h2 id="conditions">Tissue Conditions</h2>
-	  <table id="allConditionsTable" class="clear default-table" data-sortable>
+    <h2 id="types">Tissue Types</h2>
+	  <table id="allTypesTable" class="clear default-table" data-sortable>
 	    <thead>
 	      <tr>
 	        <th>Alias</th><th>Description</th>
 	      </tr>
 	    </thead>
-	    <tbody id="allConditions" class="TC"></tbody>
+	    <tbody id="allTypes" class="TT"></tbody>
 	  </table>
 	</div>
 	
@@ -163,7 +163,7 @@
 <script type="text/javascript">
   jQuery(document).ready(function() {
     Tissue.getTissueOrigins();
-    Tissue.getTissueConditions();
+    Tissue.getTissueTypes();
     Tissue.getTissueMaterials();
     Tissue.getSamplePurposes();
     QC.getQcDetails();

--- a/miso-web/src/main/webapp/pages/myAccount.jsp
+++ b/miso-web/src/main/webapp/pages/myAccount.jsp
@@ -107,7 +107,7 @@
           <div class="portlet-header">Institute Defaults</div>
           <div class="portlet-content">
             <a href="<c:url value='/miso/admin/instituteDefaults#origins'/>">Tissue Origins</a><br/>
-            <a href="<c:url value='/miso/admin/instituteDefaults#conditions'/>">Tissue Types</a><br/>
+            <a href="<c:url value='/miso/admin/instituteDefaults#types'/>">Tissue Types</a><br/>
             <a href="<c:url value='/miso/admin/instituteDefaults#materials'/>">Tissue Materials</a><br/>
             <a href="<c:url value='/miso/admin/instituteDefaults#purposes'/>">Sample Purposes</a><br/>
             <a href="<c:url value='/miso/admin/instituteDefaults#qcDetails'/>">QC Details</a><br/>

--- a/miso-web/src/main/webapp/scripts/instituteDefaults_ajax.js
+++ b/miso-web/src/main/webapp/scripts/instituteDefaults_ajax.js
@@ -32,14 +32,14 @@ var Tissue = Tissue || {
     Tissue.createTable(xhr, 'TO', 'allOrigins', 'Origin', TOtable);
   },
 
-  getTissueConditions: function () {
-    Options.makeXhrRequest('GET', '/miso/rest/tissuetypes', Tissue.createTissueConditionsTable);
+  getTissueTypes: function () {
+    Options.makeXhrRequest('GET', '/miso/rest/tissuetypes', Tissue.createTissueTypesTable);
   },
 
-  createTissueConditionsTable: function (xhr) {
-    var TCtable = [];
+  createTissueTypesTable: function (xhr) {
+    var TTtable = [];
     var id, alias, description, endpoint;
-    Tissue.createTable(xhr, 'TC', 'allConditions', 'Condition', TCtable);
+    Tissue.createTable(xhr, 'TT', 'allTypes', 'Type', TTtable);
   },
 
   getTissueMaterials: function () {
@@ -121,7 +121,7 @@ var Tissue = Tissue || {
     var endpoint = '/miso/rest/';
     if (option == 'TO') {
       endpoint += 'tissueorigin';
-    } else if (option == 'TC') {
+    } else if (option == 'TT') {
       endpoint += 'tissuetype';
     } else if (option == 'TM') {
       endpoint += 'tissuematerial';
@@ -799,7 +799,7 @@ var Options = Options || {
   reloadTable: function (option) {
     var reloadTableFunc;
     if (option == 'TO') { reloadTableFunc = Tissue.getTissueOrigins; }
-    else if (option == 'TC') { reloadTableFunc = Tissue.getTissueConditions; }
+    else if (option == 'TT') { reloadTableFunc = Tissue.getTissueTypes; }
     else if (option == 'TM') { reloadTableFunc = Tissue.getTissueMaterials; }
     else if (option == 'SP') { reloadTableFunc = Tissue.getSamplePurposes; }
     else if (option == 'QC') { reloadTableFunc = QC.getQcDetails; }


### PR DESCRIPTION
We had briefly discussed renaming GSLE "Tissue Type" to "Tissue Condition" (experimental condition of Primary/Reference/Metastatic/Xenograft Tissue) for increased semantic clarity, but decided that would be more of an annoyance than a benefit to the lab.