### PR TITLE
GLT-434 improve asset handling

### DIFF
--- a/miso-external-web/src/main/webapp/externalHeader.jsp
+++ b/miso-external-web/src/main/webapp/externalHeader.jsp
@@ -38,10 +38,10 @@
     <%-- timestamp to force browser to reload javascript --%>
     <jsp:useBean id="timestamp" class="java.util.Date" scope="request"/>
 
-    <link rel="stylesheet" href="<c:url value='/styles/style.css?ts=${timestamp.time}'/>" type="text/css">
+    <link rel="stylesheet" href="<c:url value='/styles/style.css'/>" type="text/css">
     <title>MISO LIMS External<c:if test="${not empty title}">- ${title}</c:if></title>
     <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/prototype.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/fluxion-ajax/fluxion-ajax-compiled.js?ts=${timestamp.time}'/>"></script>
+    <script type="text/javascript" src="<c:url value='/scripts/fluxion-ajax/fluxion-ajax-compiled.js'/>"></script>
 
     <!--Scriptaculous JS scripts below -->
     <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/scriptaculous.js'/>"></script>
@@ -70,9 +70,9 @@
 
 
     <!-- LIMS -->
-    <script type="text/javascript" src="<c:url value='/scripts/lims.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/external.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/search.js?ts=${timestamp.time}'/>"></script>
+    <script type="text/javascript" src="<c:url value='/scripts/lims.js'/>"></script>
+    <script type="text/javascript" src="<c:url value='/scripts/external.js'/>"></script>
+    <script type="text/javascript" src="<c:url value='/scripts/search.js'/>"></script>
 
     <!--CryptoJS-->
     <script type="text/javascript" src="<c:url value='/scripts/sha1.js'/>"></script>
@@ -82,13 +82,13 @@
     <!-- give $ back to prototype -->
     <script type="text/javascript">jQuery.noConflict();</script>
 
-    <script type="text/javascript" src="<c:url value='/scripts/multi_select_drag_drop.js?ts=${timestamp.time}'/>"></script>
+    <script type="text/javascript" src="<c:url value='/scripts/multi_select_drag_drop.js'/>"></script>
 
     <link rel="shortcut icon" href="<c:url value='/styles/images/favicon.ico'/>" type="image/x-icon"/>
 
     <!--drop down menu -->
 
-    <script src="<c:url value='/scripts/menus.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+    <script src="<c:url value='/scripts/menus.js'/>" type="text/javascript"></script>
 
     <!-- refresh page every 30mins and 1 sec -->
     <!--<meta http-equiv="refresh" content="1801"/>-->

--- a/miso-web/pom.xml
+++ b/miso-web/pom.xml
@@ -43,6 +43,63 @@
     <finalName>ROOT</finalName>
     <plugins>
       <plugin>
+        <groupId>com.samaxes.maven</groupId>
+        <artifactId>minify-maven-plugin</artifactId>
+        <version>1.7.4</version>
+        <executions>
+          <execution>
+            <id>default-minify</id>
+            <configuration>
+              <charset>UTF-8</charset>
+              <cssSourceDir>styles</cssSourceDir>
+              <cssSourceIncludes>
+                <cssSourceInclude>*.css</cssSourceInclude>
+              </cssSourceIncludes>
+              <cssFinalFile>style.css</cssFinalFile>
+              
+              <jsSourceDir>scripts</jsSourceDir>
+              <jsSourceFiles>
+                <jsSourceFile>scriptaculous/activityInput.js</jsSourceFile>
+                <jsSourceFile>scriptaculous/effects.js</jsSourceFile>
+                <jsSourceFile>scriptaculous/dragdrop.js</jsSourceFile>
+                <jsSourceFile>scriptaculous/slider.js</jsSourceFile>
+                <jsSourceFile>scriptaculous/sound.js</jsSourceFile>
+                <jsSourceFile>scriptaculous/controls.js</jsSourceFile>
+                <jsSourceFile>lims.js</jsSourceFile>
+                <jsSourceFile>search.js</jsSourceFile>
+                <jsSourceFile>experiment_ajax.js</jsSourceFile>
+                <jsSourceFile>library_ajax.js</jsSourceFile>
+                <jsSourceFile>pool_ajax.js</jsSourceFile>
+                <jsSourceFile>project_ajax.js</jsSourceFile>
+                <jsSourceFile>reporting_ajax.js</jsSourceFile>
+                <jsSourceFile>run_ajax.js</jsSourceFile>
+                <jsSourceFile>sample_ajax.js</jsSourceFile>
+                <jsSourceFile>sequencer_partition_container_ajax.js</jsSourceFile>
+                <jsSourceFile>sequencer_reference_ajax.js</jsSourceFile>
+                <jsSourceFile>study_ajax.js</jsSourceFile>
+                <jsSourceFile>parsley_form_validations.js</jsSourceFile>
+                <jsSourceFile>multi_select_drag_drop.js</jsSourceFile>
+                <jsSourceFile>menus.js</jsSourceFile>
+              </jsSourceFiles>
+              <jsSourceIncludes>
+                <jsSourceInclude>*.js</jsSourceInclude>
+              </jsSourceIncludes>
+              <jsSourceExcludes>
+                <jsSourceExclude>datatables_utils.js</jsSourceExclude>
+                <jsSourceExclude>natural_sort.js</jsSourceExclude>
+                <jsSourceExclude>xregexp-all-min.js</jsSourceExclude>
+                <jsSourceExclude>runCalendar.js</jsSourceExclude>
+                <jsSourceExclude>sortable.js</jsSourceExclude>
+              </jsSourceExcludes>
+              <jsFinalFile>header_script.js</jsFinalFile>
+            </configuration>
+            <goals>
+              <goal>minify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/miso-web/src/main/webapp/header.jsp
+++ b/miso-web/src/main/webapp/header.jsp
@@ -21,8 +21,7 @@
   ~ **********************************************************************
   --%>
 
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!DOCTYPE html>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
@@ -36,10 +35,6 @@
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-  <meta http-equiv="Pragma" content="no-cache">
-  <meta http-equiv="Expires" content="0">
 
   <%-- timestamp to force browser to reload javascript --%>
   <jsp:useBean id="timestamp" class="java.util.Date" scope="request"/>
@@ -47,79 +42,42 @@
   <title>MISO LIMS <c:if test="${not empty title}">- ${title}</c:if></title>
   <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/prototype.js'/>"></script>
   <script type="text/javascript"
-          src="<c:url value='/scripts/fluxion-ajax/fluxion-ajax.js?ts=${timestamp.time}'/>"></script>
-
-  <!--Scriptaculous JS scripts below -->
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/scriptaculous.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/activityInput.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/effects.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/unittest.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/dragdrop.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/slider.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/builder.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/sound.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/controls.js'/>"></script>
-
+          src="<c:url value='/scripts/fluxion-ajax/fluxion-ajax.js'/>"></script>
+          
   <!-- jQuery -->
   <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery-1.8.3.min.js'/>"></script>
   <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery-ui-1.9.2.custom.min.js'/>"></script>
+  <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.validate.min.js'/>"></script>
+  <script type="text/javascript" src="<c:url value='/scripts/jquery/colorbox/jquery.colorbox-min-1.4.16.js'/>"></script>
+  <link rel="stylesheet" href="<c:url value='/scripts/jquery/css/smoothness/jquery-ui-1.9.2.custom.min.css'/>"
+    type="text/css">  
+  <link rel="stylesheet" href="<c:url value='/scripts/jquery/colorbox/colorbox-1.4.16.css'/>"
+    type="text/css">
+  <!-- give $ back to prototype -->
+  <script type="text/javascript">jQuery.noConflict();</script>
+  
   <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.simplyCountable.js'/>"></script>
   <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.tinysort.min.js'/>"></script>
   <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.typewatch.js'/>"></script>
   <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.uitablefilter.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.validate.min.js'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/jquery/colorbox/jquery.colorbox-min-1.4.16.js'/>"></script>
-  <link rel="stylesheet" href="<c:url value='/scripts/jquery/css/smoothness/jquery-ui-1.9.2.custom.min.css'/>"
-        type="text/css">
-  <link rel="stylesheet" href="<c:url value='/scripts/jquery/colorbox/colorbox-1.4.16.css'/>"
-        type="text/css">
-        <link rel="stylesheet" href="<c:url value='/styles/style.css?ts=${timestamp.time}'/>" type="text/css">
+ 
   <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.tablesorter.min.js'/>"></script>
   <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.metadata.js'/>"></script>
-
-  <!-- Parsley -->
-  <script type="text/javascript" src="<c:url value='/scripts/parsley/parsley.min.js'/>"></script>
-
-  <!-- D3.js for Graphics -->
-  <script type="text/javascript" src="<c:url value='/scripts/d3v2/d3.v2.min.js'/>"></script>
-
+  
   <!-- unicode regexs for il8n validation -->
   <script type="text/javascript" src="<c:url value='/scripts/xregexp-all-min.js'/>"></script>
-
-  <!-- MISO objects -->
-  <script type="text/javascript" src="<c:url value='/scripts/lims.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/search.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/experiment_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/library_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/pool_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/project_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/reporting_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/sample_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/run_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/box_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript"
-          src="<c:url value='/scripts/sequencer_partition_container_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript"
-          src="<c:url value='/scripts/sequencer_reference_ajax.js?ts=${timestamp.time}'/>"></script>
-  <script type="text/javascript" src="<c:url value='/scripts/study_ajax.js?ts=${timestamp.time}'/>"></script>
-
-  <!-- form validations -->
-  <script type="text/javascript"
-          src="<c:url value='/scripts/parsley_form_validations.js?ts=${timestamp.time}'/>"></script>
   
-  <!-- give $ back to prototype -->
-  <script type="text/javascript">jQuery.noConflict();</script>
-
-  <!--multi-select drag drop -->
-  <script type="text/javascript"
-          src="<c:url value='/scripts/multi_select_drag_drop.js?ts=${timestamp.time}'/>"></script>
-
-  <!--drop down menu -->
-  <script src="<c:url value='/scripts/menus.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-
-  <!-- high charts-->
+  <!-- D3.js for Graphics -->
+  <script type="text/javascript" src="<c:url value='/scripts/d3v2/d3.v2.min.js'/>"></script>
+  
+  <!-- high charts -->
   <script type="text/javascript" src="<c:url value='/scripts/highcharts/highcharts.js'/>"></script>
   <script type="text/javascript" src="<c:url value='/scripts/highcharts/highcharts-more.js'/>"></script>
+          
+  <!-- concatenated MISO stylesheets and scripts -->
+  <link rel="stylesheet" href="<c:url value='/styles/style.css'/>" type="text/css">
+  <script type="text/javascript" src="<c:url value='/scripts/header_script.js'/>"></script>
+
 
   <link rel="shortcut icon" href="<c:url value='/styles/images/favicon.ico'/>" type="image/x-icon"/>
 

--- a/miso-web/src/main/webapp/pages/createAnalysisTask.jsp
+++ b/miso-web/src/main/webapp/pages/createAnalysisTask.jsp
@@ -22,8 +22,6 @@
   --%>
 
 <%@ include file="../header.jsp" %>
-<script type="text/javascript" src="<c:url value='/scripts/run_ajax.js?ts=${timestamp.time}'/>"></script>
-<script type="text/javascript" src="<c:url value='/scripts/task_ajax.js?ts=${timestamp.time}'/>"></script>
 <div id="maincontent">
 <div id="contentcolumn">
 

--- a/miso-web/src/main/webapp/pages/customBarcodePrinting.jsp
+++ b/miso-web/src/main/webapp/pages/customBarcodePrinting.jsp
@@ -28,8 +28,6 @@
 --%>
 <%@ include file="../header.jsp" %>
 
-<script type="text/javascript" src="<c:url value='/scripts/printer_ajax.js?ts=${timestamp.time}'/>"></script>
-
 <div id="maincontent">
   <div id="contentcolumn">
     <h1>Custom Barcode Printing</h1>

--- a/miso-web/src/main/webapp/pages/editBox.jsp
+++ b/miso-web/src/main/webapp/pages/editBox.jsp
@@ -36,12 +36,8 @@
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.checkbox.js'/>" type="text/javascript"></script>
 <link href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" rel="stylesheet" type="text/css">
 
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/natural_sort.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-
-<script src="<c:url value='/scripts/stats_ajax.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-
-<script src="<c:url value='/scripts/box_visualization.js'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/natural_sort.js'/>" type="text/javascript"></script>
 
 <script type="text/javascript" src="<c:url value='/scripts/parsley/parsley.min.js'/>"></script>
 

--- a/miso-web/src/main/webapp/pages/editExperiment.jsp
+++ b/miso-web/src/main/webapp/pages/editExperiment.jsp
@@ -30,7 +30,6 @@
 --%>
 <%@ include file="../header.jsp" %>
 
-<script type="text/javascript" src="<c:url value='/scripts/run_ajax.js?ts=${timestamp.time}'/>"></script>
 <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.breadcrumbs.popup.js'/>"></script>
 
 

--- a/miso-web/src/main/webapp/pages/editGroup.jsp
+++ b/miso-web/src/main/webapp/pages/editGroup.jsp
@@ -24,7 +24,6 @@
   ~ **********************************************************************
   --%>
 <script type="text/javascript" src="<c:url value='/scripts/parsley/parsley.min.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/scripts/group_validation.js?ts=${timestamp.time}'/>"></script>
 
 <div id="maincontent">
   <div id="contentcolumn">
@@ -74,6 +73,8 @@
 
 <script type="text/javascript">
   jQuery(document).ready(function () {
+    Validate.attachParsley('#group-form');
+    
     jQuery('#name').simplyCountable({
       counter: '#nameCounter',
       countType: 'characters',

--- a/miso-web/src/main/webapp/pages/editGroup.jsp
+++ b/miso-web/src/main/webapp/pages/editGroup.jsp
@@ -34,7 +34,7 @@
       <h1><c:choose><c:when
           test="${not empty group.groupId}">Edit</c:when><c:otherwise>Create</c:otherwise></c:choose>
         Group
-        <button onclick="return validateGroup();" class="fg-button ui-state-default ui-corner-all">Save</button>
+        <button onclick="return Group.validateGroup();" class="fg-button ui-state-default ui-corner-all">Save</button>
       </h1>
 
       <div class="bs-callout bs-callout-warning hidden">

--- a/miso-web/src/main/webapp/pages/editLibrary.jsp
+++ b/miso-web/src/main/webapp/pages/editLibrary.jsp
@@ -30,11 +30,9 @@
 --%>
 <%@ include file="../header.jsp" %>
 <script src="<c:url value='/scripts/jquery/js/jquery.breadcrumbs.popup.js'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <link href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" rel="stylesheet" type="text/css">
-
-<script src="<c:url value='/scripts/stats_ajax.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
 
 <script type="text/javascript" src="<c:url value='/scripts/parsley/parsley.min.js'/>"></script>
 

--- a/miso-web/src/main/webapp/pages/editPlate.jsp
+++ b/miso-web/src/main/webapp/pages/editPlate.jsp
@@ -22,9 +22,8 @@
   --%>
 <%@ include file="../header.jsp" %>
 <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.breadcrumbs.popup.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/scripts/plate_ajax.js?ts=${timestamp.time}'/>"></script>
 
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.mini.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.datepicker.js'/>" type="text/javascript"></script>

--- a/miso-web/src/main/webapp/pages/editPool.jsp
+++ b/miso-web/src/main/webapp/pages/editPool.jsp
@@ -33,8 +33,8 @@
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" type="text/css">
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables_themeroller.css'/>"
       type="text/css">
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/natural_sort.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/natural_sort.js'/>" type="text/javascript"></script>
 
 <script type="text/javascript" src="<c:url value='/scripts/parsley/parsley.min.js'/>"></script>
 

--- a/miso-web/src/main/webapp/pages/editProject.jsp
+++ b/miso-web/src/main/webapp/pages/editProject.jsp
@@ -22,8 +22,8 @@
   --%>
 
 <%@ include file="../header.jsp" %>
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/natural_sort.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/natural_sort.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.mini.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.datepicker.js'/>" type="text/javascript"></script>
@@ -1653,34 +1653,23 @@ jQuery(document).ready(function () {
 
 <c:if test="${not empty project.samples}">
     <script type="text/javascript">
-        var projectId_sample = ${project.id};
-        var sampleQcTypesString = {${sampleQcTypesString}};
+      projectId_sample = ${project.id};
+      sampleQcTypesString = {${sampleQcTypesString}};
     </script>
-    <script src="<c:url value='/scripts/editProject_sample.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
 </c:if>
 
 <c:if test="${not empty projectLibraries}">
     <script type="text/javascript">
-        var libraryQcTypesString = {${libraryQcTypesString}};
+      libraryQcTypesString = {${libraryQcTypesString}};
     </script>
-    <script src="<c:url value='/scripts/editProject_library.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-</c:if>
-
-<c:if test="${existsAnyEmPcrLibrary and not empty projectLibraryDilutions}">
-    <script src="<c:url value='/scripts/editProject_libraryDilution.js?ts=${timestamp.time}'/>"
-            type="text/javascript"></script>
-</c:if>
-
-<c:if test="${not empty projectEmPcrs}">
-    <script src="<c:url value='/scripts/editProject_empcr.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
 </c:if>
 
 <c:if test="${project.id != 0}">
     <script type="text/javascript">
-        var projectId_d3graph = ${project.id};
+        projectId_d3graph = ${project.id};
+        getProjectD3Json();
     </script>
-    <script src="<c:url value='/scripts/editProject_existing.js?ts=${timestamp.time}'/>"
-            type="text/javascript"></script>
+
 </c:if>
 
 <%@ include file="../footer.jsp" %>

--- a/miso-web/src/main/webapp/pages/editRun.jsp
+++ b/miso-web/src/main/webapp/pages/editRun.jsp
@@ -30,11 +30,8 @@
 --%>
 <%@ include file="../header.jsp" %>
 
-<script src="<c:url value='/scripts/statsdb.js'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/statsdbperbasecontent.js'/>" type="text/javascript"></script>
-
-<script type="text/javascript" src="<c:url value='/scripts/run_ajax.js?ts=${timestamp.time}'/>"></script>
-<script type="text/javascript" src="<c:url value='/scripts/stats_ajax.js?ts=${timestamp.time}'/>"></script>
+<script type="text/javascript" src="<c:url value='/scripts/run_ajax.js'/>"></script>
+<script type="text/javascript" src="<c:url value='/scripts/stats_ajax.js'/>"></script>
 
 
 <script type="text/javascript" src="<c:url value='/scripts/parsley/parsley.min.js'/>"></script>

--- a/miso-web/src/main/webapp/pages/editSample.jsp
+++ b/miso-web/src/main/webapp/pages/editSample.jsp
@@ -36,10 +36,8 @@
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.checkbox.js'/>" type="text/javascript"></script>
 <link href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" rel="stylesheet" type="text/css" />
 
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/natural_sort.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-
-<script src="<c:url value='/scripts/stats_ajax.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/natural_sort.js'/>" type="text/javascript"></script>
 
 <script type="text/javascript" src="<c:url value='/scripts/parsley/parsley.min.js'/>"></script>
 

--- a/miso-web/src/main/webapp/pages/editSubmission.jsp
+++ b/miso-web/src/main/webapp/pages/editSubmission.jsp
@@ -31,7 +31,6 @@
 <%@ include file="../header.jsp" %>
 
 <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.jstree.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/scripts/submission_ajax.js?ts=${timestamp.time}'/>"></script>
 
 <div id="maincontent">
 <div id="contentcolumn">

--- a/miso-web/src/main/webapp/pages/editUser.jsp
+++ b/miso-web/src/main/webapp/pages/editUser.jsp
@@ -23,7 +23,6 @@
   ~ **********************************************************************
   --%>
 <script type="text/javascript" src="<c:url value='/scripts/parsley/parsley.min.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/scripts/user_validation.js?ts=${timestamp.time}'/>"></script>
 
 <div id="maincontent">
   <div id="contentcolumn">
@@ -153,7 +152,7 @@
         <form:form action="/miso/user" method="POST" commandName="user" autocomplete="off">
           <sessionConversation:insertSessionConversationId attributeName="user"/>
           <h1>Edit Your Account
-            <button type="submit" class="fg-button ui-state-default ui-corner-all">Save</button>
+            <button onclick="return validateUser()" class="fg-button ui-state-default ui-corner-all">Save</button>
           </h1>
           <table class="in">
             <tr>
@@ -217,6 +216,8 @@
 
 <script type="text/javascript">
   jQuery(document).ready(function () {
+    Validate.attachParsley('#user-form');
+    
     jQuery('#fullName').simplyCountable({
       counter: '#fullNameCounter',
       countType: 'characters',

--- a/miso-web/src/main/webapp/pages/editUser.jsp
+++ b/miso-web/src/main/webapp/pages/editUser.jsp
@@ -33,7 +33,7 @@
           <h1><c:choose><c:when
               test="${not empty user.userId}">Edit</c:when><c:otherwise>Create</c:otherwise></c:choose>
             User
-            <button onclick="return validateUser();" class="fg-button ui-state-default ui-corner-all">Save</button>
+            <button onclick="return User.validateUser();" class="fg-button ui-state-default ui-corner-all">Save</button>
           </h1>
 
           <div class="bs-callout bs-callout-warning hidden">

--- a/miso-web/src/main/webapp/pages/exportSampleSheet.jsp
+++ b/miso-web/src/main/webapp/pages/exportSampleSheet.jsp
@@ -28,8 +28,6 @@
 --%>
 <%@ include file="../header.jsp" %>
 
-<script type="text/javascript" src="<c:url value='/scripts/import_export_ajax.js?ts=${timestamp.time}'/>"></script>
-
 <div id="maincontent">
 
 <h1>

--- a/miso-web/src/main/webapp/pages/external/externalHeader.jsp
+++ b/miso-web/src/main/webapp/pages/external/externalHeader.jsp
@@ -21,8 +21,7 @@
   ~ **********************************************************************
   --%>
 
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!DOCTYPE html>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
@@ -64,22 +63,10 @@
     <%-- timestamp to force browser to reload javascript --%>
     <jsp:useBean id="timestamp" class="java.util.Date" scope="request"/>
 
-    <link rel="stylesheet" href="<c:url value='/styles/style.css?ts=${timestamp.time}'/>" type="text/css">
     <link rel="stylesheet" href="<c:url value='/styles/simpletree.css'/>" type="text/css">
     <title>MISO LIMS <c:if test="${not empty title}">- ${title}</c:if></title>
     <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/prototype.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/fluxion-ajax/fluxion-ajax-compiled.js?ts=${timestamp.time}'/>"></script>
-
-    <!--Scriptaculous JS scripts below -->
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/scriptaculous.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/activityInput.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/effects.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/unittest.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/dragdrop.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/slider.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/builder.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/sound.js'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/scriptaculous/controls.js'/>"></script>
+    <script type="text/javascript" src="<c:url value='/scripts/fluxion-ajax/fluxion-ajax-compiled.js'/>"></script>
 
     <!-- jQuery -->
     <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery-1.4.2.min.js'/>"></script>
@@ -100,39 +87,16 @@
     <script type="text/javascript" src="<c:url value='/scripts/d3/d3.layout.min.js'/>"></script>
     <script type="text/javascript" src="<c:url value='/scripts/d3/d3.chart.min.js'/>"></script>
 
-    <!-- LIMS -->
-    <script type="text/javascript" src="<c:url value='/scripts/lims.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/search.js?ts=${timestamp.time}'/>"></script>
-
-    <script type="text/javascript" src="<c:url value='/scripts/experiment_ajax.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/library_ajax.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/pool_ajax.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/project_ajax.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/reporting_ajax.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/run_ajax.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/sample_ajax.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/sequencer_reference_ajax.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/study_ajax.js?ts=${timestamp.time}'/>"></script>
-
-    <!-- form validations -->
-    <script type="text/javascript" src="<c:url value='/scripts/experiment_validation.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/library_validation.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/pool_validation.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/project_validation.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/run_validation.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/sample_validation.js?ts=${timestamp.time}'/>"></script>
-    <script type="text/javascript" src="<c:url value='/scripts/study_validation.js?ts=${timestamp.time}'/>"></script>
-
     <!-- give $ back to prototype -->
     <script type="text/javascript">jQuery.noConflict();</script>
 
-    <script type="text/javascript" src="<c:url value='/scripts/multi_select_drag_drop.js?ts=${timestamp.time}'/>"></script>
+    <!-- minified MISO stylesheets and scripts -->
+    <link rel="stylesheet" href="<c:url value='/styles/style.min.css'/>" type="text/css">
+    <script type="text/javascript" src="<c:url value='/scripts/header_script.min.js'/>"></script>
+
 
     <link rel="shortcut icon" href="<c:url value='/styles/images/favicon.ico'/>" type="image/x-icon"/>
 
-    <!--drop down menu -->
-
-    <script src="<c:url value='/scripts/menus.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
 
     <!-- refresh page every 30mins and 1 sec -->
     <!--<meta http-equiv="refresh" content="1801"/>-->

--- a/miso-web/src/main/webapp/pages/flexreport.jsp
+++ b/miso-web/src/main/webapp/pages/flexreport.jsp
@@ -22,7 +22,6 @@
   --%>
 
 <%@ include file="../header.jsp" %>
-<script src="<c:url value='/scripts/flexreport.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/natural_sort.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
@@ -32,7 +31,7 @@
 
 <script src="<c:url value='/scripts/jquery/datatables/js/ZeroClipboard.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.datepicker.js'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/runCalendar.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/runCalendar.js'/>" type="text/javascript"></script>
 <link href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" rel="stylesheet" type="text/css">
 <link href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables_themeroller.css'/>" rel="stylesheet" type="text/css">
 

--- a/miso-web/src/main/webapp/pages/importExportIndex.jsp
+++ b/miso-web/src/main/webapp/pages/importExportIndex.jsp
@@ -8,7 +8,6 @@
 
 <%@ include file="../header.jsp" %>
 <jsp:useBean id="now" class="java.util.Date" scope="page" />
-<script type="text/javascript" src="<c:url value='/scripts/import_export_ajax.js?ts=${timestamp.time}'/>"></script>
 
 <div id="maincontent">
     <div id="contentcolumn">

--- a/miso-web/src/main/webapp/pages/importLibraryPoolSheet.jsp
+++ b/miso-web/src/main/webapp/pages/importLibraryPoolSheet.jsp
@@ -7,7 +7,6 @@
 --%>
 
 <%@ include file="../header.jsp" %>
-<script type="text/javascript" src="<c:url value='/scripts/import_export_ajax.js?ts=${timestamp.time}'/>"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" type="text/css">
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables_themeroller.css'/>"

--- a/miso-web/src/main/webapp/pages/importPlate.jsp
+++ b/miso-web/src/main/webapp/pages/importPlate.jsp
@@ -22,9 +22,8 @@
   --%>
 <%@ include file="../header.jsp" %>
 <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.breadcrumbs.popup.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/scripts/plate_ajax.js?ts=${timestamp.time}'/>"></script>
 
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.mini.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.datepicker.js'/>" type="text/javascript"></script>

--- a/miso-web/src/main/webapp/pages/importSampleSheet.jsp
+++ b/miso-web/src/main/webapp/pages/importSampleSheet.jsp
@@ -7,7 +7,6 @@
 --%>
 
 <%@ include file="../header.jsp" %>
-<script type="text/javascript" src="<c:url value='/scripts/import_export_ajax.js?ts=${timestamp.time}'/>"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" type="text/css">
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables_themeroller.css'/>"

--- a/miso-web/src/main/webapp/pages/instituteDefaults.jsp
+++ b/miso-web/src/main/webapp/pages/instituteDefaults.jsp
@@ -25,6 +25,7 @@
 
 <script src="<c:url value='/scripts/jquery/js/jquery.breadcrumbs.popup.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.mini.js'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/sortable.js'/>" type="text/javascript"></script>
 
 <div id="maincontent">
 <div id="contentcolumn">

--- a/miso-web/src/main/webapp/pages/instituteDefaults.jsp
+++ b/miso-web/src/main/webapp/pages/instituteDefaults.jsp
@@ -24,11 +24,7 @@
 <%@ include file="../header.jsp" %>
 
 <script src="<c:url value='/scripts/jquery/js/jquery.breadcrumbs.popup.js'/>" type="text/javascript"></script>
-
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.mini.js'/>" type="text/javascript"></script>
-
-<script src="<c:url value='/scripts/sortable.js'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/instituteDefaults_ajax.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
 
 <div id="maincontent">
 <div id="contentcolumn">

--- a/miso-web/src/main/webapp/pages/listAnalysisTasks.jsp
+++ b/miso-web/src/main/webapp/pages/listAnalysisTasks.jsp
@@ -23,8 +23,6 @@
   ~ **********************************************************************
   --%>
 
-<script type="text/javascript" src="<c:url value='/scripts/task_ajax.js?ts=${timestamp.time}'/>"></script>
-
 <div id="tabs">
   <ul>
     <li><a href="#tab-1"><span>Tasks</span></a></li>

--- a/miso-web/src/main/webapp/pages/listKitDescriptors.jsp
+++ b/miso-web/src/main/webapp/pages/listKitDescriptors.jsp
@@ -21,6 +21,10 @@
   ~ **********************************************************************
   --%>
 <%@ include file="../header.jsp" %>
+<script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
+<link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" type="text/css">
+<link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables_themeroller.css'/>">
+
 <div id="maincontent">
 <div id="contentcolumn">
 <script type="text/javascript">

--- a/miso-web/src/main/webapp/pages/listPlates.jsp
+++ b/miso-web/src/main/webapp/pages/listPlates.jsp
@@ -22,8 +22,11 @@
   --%>
 
 <%@ include file="../header.jsp" %>
-
 <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.popup.js'/>"></script>
+<script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
+<link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" type="text/css">
+<link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables_themeroller.css'/>">
+
 <div id="maincontent">
   <div id="contentcolumn">
     <h1>

--- a/miso-web/src/main/webapp/pages/listPools.jsp
+++ b/miso-web/src/main/webapp/pages/listPools.jsp
@@ -29,7 +29,7 @@
   Time: 14:22
 --%>
 <%@ include file="../header.jsp" %>
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" type="text/css">
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables_themeroller.css'/>">

--- a/miso-web/src/main/webapp/pages/listRuns.jsp
+++ b/miso-web/src/main/webapp/pages/listRuns.jsp
@@ -28,7 +28,7 @@
   Time: 08:51:03
 --%>
 <%@ include file="../header.jsp" %>
-<script type="text/javascript" src="<c:url value='/scripts/runCalendar.js?ts=${timestamp.time}'/>"></script>
+<script type="text/javascript" src="<c:url value='/scripts/runCalendar.js'/>"></script>
 <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.popup.js'/>"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" type="text/css">

--- a/miso-web/src/main/webapp/pages/mainMenu.jsp
+++ b/miso-web/src/main/webapp/pages/mainMenu.jsp
@@ -21,7 +21,6 @@
   ~
   ~ **********************************************************************
   --%>
-<script type="text/javascript" src="<c:url value='/scripts/dashboard.js?ts=${timestamp.time}'/>"></script>
 <div id="maincontent">
     <div id="contentcolumn">
         <h1>Dashboard</h1>

--- a/miso-web/src/main/webapp/pages/poolWizard.jsp
+++ b/miso-web/src/main/webapp/pages/poolWizard.jsp
@@ -26,8 +26,8 @@
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <link rel="stylesheet" href="<c:url value='/scripts/jquery/datatables/css/jquery.dataTables.css'/>" type="text/css">
 
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
-<script src="<c:url value='/scripts/natural_sort.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/natural_sort.js'/>" type="text/javascript"></script>
 
 <div id="maincontent">
   <div id="contentcolumn">

--- a/miso-web/src/main/webapp/pages/sampleReceipt.jsp
+++ b/miso-web/src/main/webapp/pages/sampleReceipt.jsp
@@ -30,7 +30,7 @@
 <%@ include file="../header.jsp" %>
 <script type="text/javascript" src="<c:url value='/scripts/jquery/js/jquery.breadcrumbs.popup.js'/>"></script>
 
-<script src="<c:url value='/scripts/datatables_utils.js?ts=${timestamp.time}'/>" type="text/javascript"></script>
+<script src="<c:url value='/scripts/datatables_utils.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.mini.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/jquery/editable/jquery.jeditable.datepicker.js'/>" type="text/javascript"></script>

--- a/miso-web/src/main/webapp/pages/viewPrinters.jsp
+++ b/miso-web/src/main/webapp/pages/viewPrinters.jsp
@@ -29,7 +29,6 @@
   
 --%>
 <%@ include file="../header.jsp" %>
-<script type="text/javascript" src="<c:url value='/scripts/printer_ajax.js?ts=${timestamp.time}'/>"></script>
 
 <div id="maincontent">
   <div id="contentcolumn">

--- a/miso-web/src/main/webapp/scripts/box_ajax.js
+++ b/miso-web/src/main/webapp/scripts/box_ajax.js
@@ -30,8 +30,9 @@ var Box = Box || {
       },
       data: Box.boxJSON.boxables
     });
-    if (selected)
+    if (selected) {
       Box.visual.click(selected.row, selected.col);
+    }
   },
 
   createListingTable: function() {
@@ -54,7 +55,7 @@ var Box = Box || {
     );
   },
 
-  deleteBox: function (boxId, successfunc) {
+  deleteBox: function () {
     if (confirm("Are you sure you really want to delete BOX" + Box.boxId + "? This operation is permanent!")) {
       Fluxion.doAjax(
         'boxControllerHelperService',
@@ -279,11 +280,13 @@ Box.ui = {
     jQuery('#listingBoxablesTable').empty();
     var array = [];
     for (var pos in box.boxables) {
-      var row = [];
-      row.push(pos);
-      row.push(Box.utils.hyperlinkifyBoxable(box.boxables[pos].name, box.boxables[pos].id, box.boxables[pos].name));
-      row.push(Box.utils.hyperlinkifyBoxable(box.boxables[pos].name, box.boxables[pos].id, box.boxables[pos].alias));
-      array.push(row);
+      if (box.boxables.hasOwnProperty(pos)) {
+        var row = [];
+        row.push(pos);
+        row.push(Box.utils.hyperlinkifyBoxable(box.boxables[pos].name, box.boxables[pos].id, box.boxables[pos].name));
+        row.push(Box.utils.hyperlinkifyBoxable(box.boxables[pos].name, box.boxables[pos].id, box.boxables[pos].alias));
+        array.push(row);
+      }
     }
 
     jQuery('#listingBoxablesTable').dataTable({
@@ -483,7 +486,6 @@ Box.ui = {
   },
   
   removeOneItem: function() {
-    var selectedBarcode = jQuery('#selectedBarcode').val().trim();
     var selectedPosition = Box.utils.getPositionString(Box.visual.selected.row, Box.visual.selected.col);
   
     if (confirm("Are you sure you wish to set location to unknown for " + Box.boxJSON.boxables[selectedPosition].name + "? You should re-home it as soon as possible")) {

--- a/miso-web/src/main/webapp/scripts/box_ajax.js
+++ b/miso-web/src/main/webapp/scripts/box_ajax.js
@@ -1,5 +1,3 @@
-jQuery.getScript("/scripts/box_visualization.js");
-
 var Box = Box || {
   boxJSON: null,
   originalBox: null,
@@ -157,7 +155,7 @@ var Box = Box || {
 
 Box.scan = {
   prepareScanner: function(boxRows, boxColumns) {
-    var prepScannerTimeout = setTimeout(Box.prepareScannerDialog.error, 10000); // otherwise box scanner may poll indefinitely
+    var prepareScannerTimeout = setTimeout(Box.prepareScannerDialog.error, 10000); // otherwise box scanner may poll indefinitely
     Fluxion.doAjax(
       'boxControllerHelperService',
       'prepareBoxScanner',
@@ -279,9 +277,9 @@ Box.ui = {
   //creates the table of the box contents
   createListingBoxablesTable: function(box) {
     jQuery('#listingBoxablesTable').empty();
-    array = [];
+    var array = [];
     for (var pos in box.boxables) {
-      row = [];
+      var row = [];
       row.push(pos);
       row.push(Box.utils.hyperlinkifyBoxable(box.boxables[pos].name, box.boxables[pos].id, box.boxables[pos].name));
       row.push(Box.utils.hyperlinkifyBoxable(box.boxables[pos].name, box.boxables[pos].id, box.boxables[pos].alias));
@@ -448,8 +446,8 @@ Box.ui = {
       var selectedBarcode = jQuery('#selectedBarcode').val().trim();
       var selectedPosition = Box.utils.getPositionString(Box.visual.selected.row, Box.visual.selected.col);
       // if selectedPosition is already filled, confirm before deleting that position
-      if (Box.boxJSON.boxables[selectedPosition] && Box.boxJSON.boxables[selectedPosition]["identificationBarcode"] != selectedBarcode) {
-        var sampleInfo = Box.boxJSON.boxables[selectedPosition]["name"]+"::"+ Box.boxJSON.boxables[selectedPosition]["alias"];
+      if (Box.boxJSON.boxables[selectedPosition] && Box.boxJSON.boxables[selectedPosition].identificationBarcode != selectedBarcode) {
+        var sampleInfo = Box.boxJSON.boxables[selectedPosition].name +"::"+ Box.boxJSON.boxables[selectedPosition].alias;
         if(confirm(sampleInfo + " is already located at position " + selectedPosition + ". Are you sure you wish to remove it from the box?")) {
           delete Box.boxJSON.boxables[selectedPosition];
         } else {

--- a/miso-web/src/main/webapp/scripts/box_visualization.js
+++ b/miso-web/src/main/webapp/scripts/box_visualization.js
@@ -45,7 +45,7 @@ var BoxItem = function(opts) {
   };
 
   self.normalClick = function() {
-    if (self.selInfo.item == null) {
+    if (self.selInfo.item === null) {
       self.selInfo.item = self;
       self.select();
       return;
@@ -71,7 +71,7 @@ var BoxItem = function(opts) {
 
   self.controlClick = function() {
     // Clear a selected item before ctrl-clicking begins
-    if (self.selInfo.item != null) {
+    if (self.selInfo.item !== null) {
       self.selInfo.item.unselect();
       self.selInfo.item = null;
     }
@@ -89,7 +89,7 @@ var BoxItem = function(opts) {
     self.selInfo.row = event.data.row;
     self.selInfo.col = event.data.col;
 
-    if (ctrlPressed) {
+    if (event.ctrlKey) {
       self.controlClick();
     } else {
       self.clearSelectedItems();
@@ -221,7 +221,6 @@ var BoxVisual = function() {
 
   self.getBoxPosition = function(row, col, tCell) {
     // Override this method
-    var item = self.getBoxItem(row, col);
     return new BoxPosition({
       row: row,
       col: col,
@@ -536,7 +535,6 @@ Box.ScanErrors = function() {
 
   self.getBoxItem = function(row, col) {
     var pos = Box.utils.getPositionString(row, col);
-    var boxable = self.data[pos];
     var img = '/styles/images/tube_error.png';
     if (self.scan.errors.type == 'Unknown Barcode') {
       img = '/styles/images/tube_duplicate_barcode_error.png';
@@ -636,13 +634,14 @@ Box.ScanDiff = function() {
   self.getBoxItem = function(row, col) {
     var pos = Box.utils.getPositionString(row, col);
     var boxable = self.data[pos];
+    var sel, unsel;
 
     if (typeof boxable !== 'undefined') {
-      var sel = jQuery.inArray(pos, self.changed) !== -1 ?
+      sel = jQuery.inArray(pos, self.changed) !== -1 ?
             '/styles/images/tube_full_selected_changed.png' :
             '/styles/images/tube_full_selected.png';
 
-      var unsel = jQuery.inArray(pos, self.changed) !== -1 ?
+      unsel = jQuery.inArray(pos, self.changed) !== -1 ?
             '/styles/images/tube_full_changed.png' :
             '/styles/images/tube_full.png';
       return new BoxItem({
@@ -655,11 +654,11 @@ Box.ScanDiff = function() {
         onClick: function() {}
       });
     } else {
-      var sel = jQuery.inArray(pos, self.changed) !== -1 ?
+      sel = jQuery.inArray(pos, self.changed) !== -1 ?
             '/styles/images/tube_empty_selected_changed.png' :
             '/styles/images/tube_empty_selected.png';
 
-      var unsel = jQuery.inArray(pos, self.changed) !== -1 ?
+      unsel = jQuery.inArray(pos, self.changed) !== -1 ?
             '/styles/images/tube_empty_changed.png' :
             '/styles/images/tube_empty.png';
       return new BoxItem({
@@ -790,25 +789,29 @@ Box.utils = {
 
     // Look for old items in the new
     for (var oldpos in oldBoxables) {
-      var name = oldBoxables[oldpos].name;
-      var newpos = Box.utils.findItemPos(name, newBoxables);
-      if (newpos == null) {
-        diff.push('<li style="color:red;"><b>-</b> '+name+': removed from the box</li>');
-        changed.push(oldpos);
-      }  else {
-        diff.push('<li style="color:orange;"><b>!</b> '+name+': moved ('+oldpos+'->'+newpos+')</li>');
-        changed.push(oldpos);
-        changed.push(newpos);
+      if (oldBoxables.hasOwnProperty(oldpos)) {
+        var oldname = oldBoxables[oldpos].name;
+        var newpos = Box.utils.findItemPos(oldname, newBoxables);
+        if (newpos === null) {
+          diff.push('<li style="color:red;"><b>-</b> '+oldname+': removed from the box</li>');
+          changed.push(oldpos);
+        }  else {
+          diff.push('<li style="color:orange;"><b>!</b> '+oldname+': moved ('+oldpos+'->'+newpos+')</li>');
+          changed.push(oldpos);
+          changed.push(newpos);
+        }
       }
     }
 
     // Look for new items
-    for (var newpos in newBoxables) {
-      var name = newBoxables[newpos].name;
-      var oldpos = Box.utils.findItemPos(name, oldBoxables);
-      if (oldpos == null) {
-        diff.push('<li style="color:green;"><b>+</b> '+name+': added to the box at position '+newpos+'</li>');
-        changed.push(newpos);
+    for (var pos in newBoxables) {
+      if (newBoxables.hasOwnProperty(pos)) {
+        var newname = newBoxables[pos].name;
+        oldpos = Box.utils.findItemPos(newname, oldBoxables);
+        if (oldpos === null) {
+          diff.push('<li style="color:green;"><b>+</b> '+newname+': added to the box at position '+pos+'</li>');
+          changed.push(pos);
+        }
       }
     }
     return {'html': diff, 'positions': changed};

--- a/miso-web/src/main/webapp/scripts/box_visualization.js
+++ b/miso-web/src/main/webapp/scripts/box_visualization.js
@@ -100,7 +100,7 @@ var BoxItem = function(opts) {
 
   self.click = opts.click || self.click;
   self.element.click({'row': self.row, 'col': self.col}, self.click);
-  self.selected ? self.select() : self.unselect();
+  self.selectedImg ? self.select() : self.unselect();
   return self;
 };
 
@@ -143,8 +143,9 @@ var BoxPosition = function(opts) {
   };
 
   self.cell = opts.cell;
-  if (typeof self.item !== 'undefined')
+  if (typeof self.item !== 'undefined') {
     self.addItem(self.item);
+  }
   self.row = opts.row || null;
   self.col = opts.col || null;
   self.setTitle();
@@ -227,10 +228,6 @@ var BoxVisual = function() {
       cell: tCell,
       boxItem: self.getBoxItem(row, col)
     });
-  };
-
-  self.getBoxItem = function(row, col) {
-    // Override this method
   };
 
   self.click = function(row, col) {
@@ -691,8 +688,8 @@ Box.PrepareScannerDialog = function() {
   self.show = function() {
     jQuery('#dialogInfoAbove').html('<h1>Preparing scanner</h1>');
     jQuery('#dialogVisual').html('');
-    jQuery('#dialogInfoBelow').html('<p>Please remove box from scanner until prompted.</p>' 
-                                     + '<img class="center" src="/styles/images/ajax-loader.gif"/>');   
+    jQuery('#dialogInfoBelow').html('<p>Please remove box from scanner until prompted.</p>' +
+                                     '<img class="center" src="/styles/images/ajax-loader.gif"/>');   
     jQuery('#dialogDialog').dialog({
       autoOpen: false,
       width: Box.dialogWidth,
@@ -709,8 +706,8 @@ Box.PrepareScannerDialog = function() {
   self.error = function() {
     jQuery('#dialogInfoAbove').html('<h1 class="warning">Error: could not find the scanner</h1>');
     jQuery('#dialogVisual').html('');
-    jQuery('#dialogInfoBelow').html('<p>Please ensure that the scanner software is running, ' 
-                                     + 'and remove the box before retrying.</p>');
+    jQuery('#dialogInfoBelow').html('<p>Please ensure that the scanner software is running, ' +
+                                    'and remove the box before retrying.</p>');
     jQuery('#dialogDialog').dialog({
       autoOpen: true,
       width: Box.dialogWidth,
@@ -737,7 +734,9 @@ Box.utils = {
 
   getPositionString: function(row, col) {
     var pos = Box.utils.getRowLetter(row);
-    if(col < 10) pos += 0;
+    if (col < 10) {
+      pos += 0;
+    }
     pos += col;
     return pos;
   },

--- a/miso-web/src/main/webapp/scripts/dashboard.js
+++ b/miso-web/src/main/webapp/scripts/dashboard.js
@@ -25,15 +25,16 @@ var Dashboard = Dashboard || {
   showLatestReceivedtSamples: function () {
     jQuery('#latestSamplesList').html("<img src='/styles/images/ajax-loader.gif'/>");
     Fluxion.doAjax(
-            'dashboard',
-            'showLatestReceivedSamples',
-            {
-              'url': ajaxurl
-            },
-            {'doOnSuccess': function (json) {
-              jQuery('#latestSamplesList').html(json.html);
-            }
-            });
-
+      'dashboard',
+      'showLatestReceivedSamples',
+      {
+        'url': ajaxurl
+      },
+      {
+        'doOnSuccess': function (json) {
+          jQuery('#latestSamplesList').html(json.html);
+        }
+      }
+    );
   }
 };

--- a/miso-web/src/main/webapp/scripts/datatables_utils.js
+++ b/miso-web/src/main/webapp/scripts/datatables_utils.js
@@ -60,13 +60,13 @@ DatatableUtils = {
     var sel = s.attr("sel");
     if (sel == "none") {
       tableObj.find('tbody tr').each(function () {
-        jQuery(this).addClass('row_selected')
+        jQuery(this).addClass('row_selected');
       });
       s.attr("sel", "all");
     }
     else {
       tableObj.find('tbody tr').each(function () {
-        jQuery(this).removeClass('row_selected')
+        jQuery(this).removeClass('row_selected');
       });
       s.attr("sel", "none");
     }
@@ -105,7 +105,7 @@ DatatableUtils = {
   },
 
   fnGetSelected: function (datatable) {
-    var aReturn = new Array();
+    var aReturn = [];
     var aTrs = datatable.fnGetNodes();
     for (var i = 0; i < aTrs.length; i++) {
       if (jQuery(aTrs[i]).hasClass('row_selected')) {

--- a/miso-web/src/main/webapp/scripts/editProject_empcr.js
+++ b/miso-web/src/main/webapp/scripts/editProject_empcr.js
@@ -62,30 +62,30 @@ function bulkEmPcrDilutionTable() {
     jQuery("#empcrs_table tr:gt(0)").append("<td class='defaultEditable'></td>");
 
     var datatable = jQuery('#empcrs_table').dataTable({
-                                                        "aoColumnDefs": [
-                                                          {
-                                                            "bUseRendered": false,
-                                                            "aTargets": [ 0 ]
-                                                          }
-                                                        ],
-                                                        "aoColumns": [
-                                                          {"bSortable": false},
-                                                          { "sType": 'natural' },
-                                                          null,
-                                                          null,
-                                                          null,
-                                                          null,
-                                                          {"bSortable": false},
-                                                          {"bSortable": false}
-                                                        ],
-                                                        "bPaginate": false,
-                                                        "bInfo": false,
-                                                        "bJQueryUI": true,
-                                                        "bAutoWidth": true,
-                                                        "bSort": true,
-                                                        "bFilter": false,
-                                                        "sDom": '<<"toolbar">f>r<t>ip>'
-                                                      });
+      "aoColumnDefs": [
+        {
+          "bUseRendered": false,
+          "aTargets": [ 0 ]
+        }
+      ],
+      "aoColumns": [
+        { "bSortable": false },
+        { "sType": 'natural' },
+        null,
+        null,
+        null,
+        null,
+        { "bSortable": false },
+        { "bSortable": false }
+      ],
+      "bPaginate": false,
+      "bInfo": false,
+      "bJQueryUI": true,
+      "bAutoWidth": true,
+      "bSort": true,
+      "bFilter": false,
+      "sDom": '<<"toolbar">f>r<t>ip>'
+    });
 
     jQuery('#empcrs_table').find("tr:gt(0)").each(function () {
       for (var i = 0; i < this.cells.length; i++) {
@@ -94,59 +94,64 @@ function bulkEmPcrDilutionTable() {
     });
 
     jQuery('#empcrs_table .rowSelect').click(function () {
-      if (jQuery(this).parent().hasClass('row_selected'))
+      if (jQuery(this).parent().hasClass('row_selected')) {
         jQuery(this).parent().removeClass('row_selected');
-      else if (!jQuery(this).parent().hasClass('row_saved'))
+      } else if (!jQuery(this).parent().hasClass('row_saved')) {
         jQuery(this).parent().addClass('row_selected');
+      }
     });
 
     jQuery("div.toolbar").html("<input type='button' value='Save Dilutions' id=\"bulkEmPcrDilutionButton\" onclick=\"Project.ui.saveBulkEmPcrDilutions();\" class=\"fg-button ui-state-default ui-corner-all\"/>");
     jQuery("div.toolbar").append("<input type='button' value='Cancel' onclick=\"Utils.page.pageReload();\" class=\"fg-button ui-state-default ui-corner-all\"/>");
     jQuery("div.toolbar").removeClass("toolbar");
 
-    jQuery('#empcrs_table .defaultEditable').editable(function (value, settings) {
-                                                        return value;
-                                                      },
-                                                      {
-                                                        callback: function (sValue, y) {
-                                                          var aPos = datatable.fnGetPosition(this);
-                                                          datatable.fnUpdate(sValue, aPos[0], aPos[1]);
-                                                        },
-                                                        submitdata: function (value, settings) {
-                                                          return {
-                                                            "row_id": this.parentNode.getAttribute('id'),
-                                                            "column": datatable.fnGetPosition(this)[2]
-                                                          };
-                                                        },
-                                                        onblur: 'submit',
-                                                        placeholder: '',
-                                                        height: '14px'
-                                                      });
+    jQuery('#empcrs_table .defaultEditable').editable(
+      function (value, settings) {
+        return value;
+      },
+      {
+        callback: function (sValue, y) {
+          var aPos = datatable.fnGetPosition(this);
+          datatable.fnUpdate(sValue, aPos[0], aPos[1]);
+        },
+        submitdata: function (value, settings) {
+          return {
+            "row_id": this.parentNode.getAttribute('id'),
+            "column": datatable.fnGetPosition(this)[2]
+          };
+        },
+        onblur: 'submit',
+        placeholder: '',
+        height: '14px'
+      }
+    );
 
-    jQuery("#empcrs_table .dateSelect").editable(function (value, settings) {
-                                                   return value;
-                                                 },
-                                                 {
-                                                   type: 'datepicker',
-                                                   width: '100px',
-                                                   onblur: 'submit',
-                                                   placeholder: '',
-                                                   style: 'inherit',
-                                                   datepicker: {
-                                                     dateFormat: 'dd/mm/yy',
-                                                     showButtonPanel: true,
-                                                     maxDate: 0
-                                                   },
-                                                   callback: function (sValue, y) {
-                                                     var aPos = datatable.fnGetPosition(this);
-                                                     datatable.fnUpdate(sValue, aPos[0], aPos[1]);
-                                                   },
-                                                   submitdata: function (value, settings) {
-                                                     return {
-                                                       "row_id": this.parentNode.getAttribute('id'),
-                                                       "column": datatable.fnGetPosition(this)[2]
-                                                     };
-                                                   }
-                                                 });
+    jQuery("#empcrs_table .dateSelect").editable(
+      function (value, settings) {
+        return value;
+      },
+      {
+         type: 'datepicker',
+         width: '100px',
+         onblur: 'submit',
+         placeholder: '',
+         style: 'inherit',
+         datepicker: {
+           dateFormat: 'dd/mm/yy',
+           showButtonPanel: true,
+           maxDate: 0
+         },
+         callback: function (sValue, y) {
+           var aPos = datatable.fnGetPosition(this);
+           datatable.fnUpdate(sValue, aPos[0], aPos[1]);
+         },
+         submitdata: function (value, settings) {
+           return {
+             "row_id": this.parentNode.getAttribute('id'),
+             "column": datatable.fnGetPosition(this)[2]
+           };
+         }
+       }
+    );
   }
 }

--- a/miso-web/src/main/webapp/scripts/editProject_existing.js
+++ b/miso-web/src/main/webapp/scripts/editProject_existing.js
@@ -46,11 +46,13 @@ var vis = d3.select("#chart").append("svg:svg")
         .append("svg:g")
         .attr("transform", "translate(" + r + "," + r + ")");
 
-d3.json("/miso/d3graph/project/" + projectId_d3graph, function (json) {
-  json.x0 = 800;
-  json.y0 = 0;
-  update(root = json);
-});
+function getProjectD3Json () {
+  d3.json("/miso/d3graph/project/" + projectId_d3graph, function (json) {
+    json.x0 = 800;
+    json.y0 = 0;
+    update(root = json);
+  });
+}
 
 function update(source) {
   // Compute the new tree layout.

--- a/miso-web/src/main/webapp/scripts/editProject_existing.js
+++ b/miso-web/src/main/webapp/scripts/editProject_existing.js
@@ -99,7 +99,7 @@ function update(source) {
                    return d._children ? "lightsteelblue" : "#fff";
                  })
           .style("stroke", function (d) {
-                   return d.color == 0 ? "red"
+                   return d.color === 0 ? "red"
                            : d.color == 1 ? "lightgreen"
                                   : d.color == 2 ? "gray"
                                      : "steelblue";
@@ -109,7 +109,7 @@ function update(source) {
                   return "rotate (" + (source.x0 - 90) + ")translate(" + source.y0 + ")";
                 })
           .style("stroke", function (d) {
-                   return d.color == 0 ? "red"
+                   return d.color === 0 ? "red"
                            : d.color == 1 ? "lightgreen"
                                   : d.color == 2 ? "gray"
                                      : "steelblue";
@@ -144,7 +144,7 @@ function update(source) {
                    return d._children ? "lightsteelblue" : "#fff";
                  })
           .style("stroke", function (d) {
-                   return d.color == 0 ? "red"
+                   return d.color === 0 ? "red"
                            : d.color == 1 ? "lightgreen"
                                   : d.color == 2 ? "gray"
                                      : "steelblue";

--- a/miso-web/src/main/webapp/scripts/editProject_library.js
+++ b/miso-web/src/main/webapp/scripts/editProject_library.js
@@ -57,8 +57,7 @@ function bulkLibraryQcTable(tableName) {
     lTable.find("tr").each(function () {
       if (jQuery(this).find("td:eq(8)").html() == "true") {
         jQuery(this).remove();
-      }
-      else {
+      } else {
         jQuery(this).removeAttr("onmouseover").removeAttr("onmouseout");
         jQuery(this).find("td:gt(8)").remove();
         jQuery(this).find("td:eq(6)").remove();
@@ -82,37 +81,37 @@ function bulkLibraryQcTable(tableName) {
     jQuery(tableName + " tr:gt(0)").append("<td class='defaultEditable'></td>");
 
     var datatable = lTable.dataTable({
-                                       "aoColumnDefs": [
-                                         {
-                                           "bUseRendered": false,
-                                           "aTargets": [ 0 ]
-                                         }
-                                       ],
-                                       "aaSorting": [
-                                         [2, 'asc']
-                                       ],
-                                       "aoColumns": [
-                                         {"bSortable": false},
-                                         { "sType": 'natural' },
-                                         { "sType": 'natural' },
-                                         { "sType": 'natural' },
-                                         { "sType": 'natural' },
-                                         null,
-                                         null,
-                                         null,
-                                         {"bSortable": false},
-                                         {"bSortable": false},
-                                         {"bSortable": false},
-                                         {"bSortable": false}
-                                       ],
-                                       "bPaginate": false,
-                                       "bInfo": false,
-                                       "bJQueryUI": true,
-                                       "bAutoWidth": true,
-                                       "bSort": true,
-                                       "bFilter": true,
-                                       "sDom": '<<"toolbar">f>r<t>ip>'
-                                     });
+      "aoColumnDefs": [
+        {
+          "bUseRendered": false,
+          "aTargets": [ 0 ]
+        }
+      ],
+      "aaSorting": [
+        [2, 'asc']
+      ],
+      "aoColumns": [
+        {"bSortable": false},
+        { "sType": 'natural' },
+        { "sType": 'natural' },
+        { "sType": 'natural' },
+        { "sType": 'natural' },
+        null,
+        null,
+        null,
+        {"bSortable": false},
+        {"bSortable": false},
+        {"bSortable": false},
+        {"bSortable": false}
+      ],
+      "bPaginate": false,
+      "bInfo": false,
+      "bJQueryUI": true,
+      "bAutoWidth": true,
+      "bSort": true,
+      "bFilter": true,
+      "sDom": '<<"toolbar">f>r<t>ip>'
+    });
 
     lTable.find("tr:gt(0)").each(function () {
       for (var i = 0; i < this.cells.length; i++) {
@@ -121,101 +120,110 @@ function bulkLibraryQcTable(tableName) {
     });
 
     jQuery(tableName + ' .rowSelect').click(function () {
-      if (jQuery(this).parent().hasClass('row_selected'))
+      if (jQuery(this).parent().hasClass('row_selected')) {
         jQuery(this).parent().removeClass('row_selected');
-      else if (!jQuery(this).parent().hasClass('row_saved'))
+      } else if (!jQuery(this).parent().hasClass('row_saved')) {
         jQuery(this).parent().addClass('row_selected');
+      }
     });
 
     jQuery("div.toolbar").html("<input type='button' value='Save QCs' id=\"bulkLibraryQcButton\" onclick=\"Sample.qc.saveBulkLibraryQc('" + tableName + "');\" class=\"fg-button ui-state-default ui-corner-all\"/>");
     jQuery("div.toolbar").append("<input type='button' value='Cancel'  onclick=\"Utils.page.pageReload();\" class=\"fg-button ui-state-default ui-corner-all\"/>");
     jQuery("div.toolbar").removeClass("toolbar");
 
-    jQuery(tableName + ' .defaultEditable').editable(function (value, settings) {
-                                                       return value;
-                                                     },
-                                                     {
-                                                       callback: function (sValue, y) {
-                                                         var aPos = datatable.fnGetPosition(this);
-                                                         datatable.fnUpdate(sValue, aPos[0], aPos[1]);
-                                                       },
-                                                       submitdata: function (value, settings) {
-                                                         return {
-                                                           "row_id": this.parentNode.getAttribute('id'),
-                                                           "column": datatable.fnGetPosition(this)[2]
-                                                         };
-                                                       },
-                                                       onblur: 'submit',
-                                                       placeholder: '',
-                                                       height: '14px'
-                                                     });
+    jQuery(tableName + ' .defaultEditable').editable(
+      function (value, settings) {
+        return value;
+      },
+      {
+        callback: function (sValue, y) {
+          var aPos = datatable.fnGetPosition(this);
+          datatable.fnUpdate(sValue, aPos[0], aPos[1]);
+        },
+        submitdata: function (value, settings) {
+          return {
+            "row_id": this.parentNode.getAttribute('id'),
+            "column": datatable.fnGetPosition(this)[2]
+          };
+        },
+        onblur: 'submit',
+        placeholder: '',
+        height: '14px'
+      }
+    );
 
-    jQuery(tableName + " .typeSelect").editable(function (value, settings) {
-                                                  return value;
-                                                },
-                                                {
-                                                  data: libraryQcTypesString,
-                                                  type: 'select',
-                                                  onblur: 'submit',
-                                                  placeholder: '',
-                                                  style: 'inherit',
-                                                  callback: function (sValue, y) {
-                                                    var aPos = datatable.fnGetPosition(this);
-                                                    datatable.fnUpdate(sValue, aPos[0], aPos[1]);
-                                                  },
-                                                  submitdata: function (value, settings) {
-                                                    return {
-                                                      "row_id": this.parentNode.getAttribute('id'),
-                                                      "column": datatable.fnGetPosition(this)[2]
-                                                    };
-                                                  }
-                                                });
+    jQuery(tableName + " .typeSelect").editable(
+      function (value, settings) {
+        return value;
+      },
+      {
+        data: libraryQcTypesString,
+        type: 'select',
+        onblur: 'submit',
+        placeholder: '',
+        style: 'inherit',
+        callback: function (sValue, y) {
+          var aPos = datatable.fnGetPosition(this);
+          datatable.fnUpdate(sValue, aPos[0], aPos[1]);
+        },
+        submitdata: function (value, settings) {
+          return {
+            "row_id": this.parentNode.getAttribute('id'),
+            "column": datatable.fnGetPosition(this)[2]
+          };
+        }
+      }
+    );
 
-    jQuery(tableName + " .dateSelect").editable(function (value, settings) {
-                                                  return value;
-                                                },
-                                                {
-                                                  type: 'datepicker',
-                                                  width: '100px',
-                                                  onblur: 'submit',
-                                                  placeholder: '',
-                                                  style: 'inherit',
-                                                  datepicker: {
-                                                    dateFormat: 'dd/mm/yy',
-                                                    showButtonPanel: true,
-                                                    maxDate: 0
-                                                  },
-                                                  callback: function (sValue, y) {
-                                                    var aPos = datatable.fnGetPosition(this);
-                                                    datatable.fnUpdate(sValue, aPos[0], aPos[1]);
-                                                  },
-                                                  submitdata: function (value, settings) {
-                                                    return {
-                                                      "row_id": this.parentNode.getAttribute('id'),
-                                                      "column": datatable.fnGetPosition(this)[2]
-                                                    };
-                                                  }
-                                                });
+    jQuery(tableName + " .dateSelect").editable(
+      function (value, settings) {
+        return value;
+      },
+      {
+        type: 'datepicker',
+        width: '100px',
+        onblur: 'submit',
+        placeholder: '',
+        style: 'inherit',
+        datepicker: {
+          dateFormat: 'dd/mm/yy',
+          showButtonPanel: true,
+          maxDate: 0
+        },
+        callback: function (sValue, y) {
+          var aPos = datatable.fnGetPosition(this);
+          datatable.fnUpdate(sValue, aPos[0], aPos[1]);
+        },
+        submitdata: function (value, settings) {
+          return {
+            "row_id": this.parentNode.getAttribute('id'),
+            "column": datatable.fnGetPosition(this)[2]
+          };
+        }
+      }
+    );
 
-    jQuery(tableName + " .passedCheck").editable(function (value, settings) {
-                                                   return value;
-                                                 },
-                                                 {
-                                                   type: 'qcradio',
-                                                   onblur: 'submit',
-                                                   placeholder: '',
-                                                   style: 'inherit',
-                                                   callback: function (sValue, y) {
-                                                     var aPos = datatable.fnGetPosition(this);
-                                                     datatable.fnUpdate(sValue, aPos[0], aPos[1]);
-                                                   },
-                                                   submitdata: function (value, settings) {
-                                                     return {
-                                                       "row_id": this.parentNode.getAttribute('id'),
-                                                       "column": datatable.fnGetPosition(this)[2]
-                                                     };
-                                                   }
-                                                 });
+    jQuery(tableName + " .passedCheck").editable(
+      function (value, settings) {
+        return value;
+      },
+      {
+        type: 'qcradio',
+        onblur: 'submit',
+        placeholder: '',
+        style: 'inherit',
+        callback: function (sValue, y) {
+          var aPos = datatable.fnGetPosition(this);
+          datatable.fnUpdate(sValue, aPos[0], aPos[1]);
+        },
+        submitdata: function (value, settings) {
+          return {
+            "row_id": this.parentNode.getAttribute('id'),
+            "column": datatable.fnGetPosition(this)[2]
+          };
+        }
+      }
+    );
   }
 }
 
@@ -248,8 +256,7 @@ function bulkLibraryDilutionTable(tableName) {
     lTable.find("tr").each(function () {
       if (jQuery(this).find("td:eq(8)").html() == "false") {
         jQuery(this).remove();
-      }
-      else {
+      } else {
         jQuery(this).removeAttr("onmouseover").removeAttr("onmouseout");
         jQuery(this).find("td:gt(8)").remove();
         jQuery(this).find("td:eq(6)").remove();
@@ -267,33 +274,33 @@ function bulkLibraryDilutionTable(tableName) {
     jQuery(tableName + " tr:gt(0)").append("<td class='defaultEditable'></td>");
 
     var datatable = lTable.dataTable({
-                                       "aoColumnDefs": [
-                                         {
-                                           "bUseRendered": false,
-                                           "aTargets": [ 0 ]
-                                         }
-                                       ],
-                                       "aoColumns": [
-                                         {"bSortable": false},
-                                         { "sType": 'natural' },
-                                         { "sType": 'natural' },
-                                         { "sType": 'natural' },
-                                         { "sType": 'natural' },
-                                         null,
-                                         {"bSortable": false},
-                                         {"bSortable": false},
-                                         {"bSortable": false},
-                                         {"bSortable": false},
-                                         {"bSortable": false}
-                                       ],
-                                       "bPaginate": false,
-                                       "bInfo": false,
-                                       "bJQueryUI": true,
-                                       "bAutoWidth": true,
-                                       "bSort": true,
-                                       "bFilter": false,
-                                       "sDom": '<<"toolbar">f>r<t>ip>'
-                                     });
+      "aoColumnDefs": [
+        {
+          "bUseRendered": false,
+          "aTargets": [ 0 ]
+        }
+      ],
+      "aoColumns": [
+        {"bSortable": false},
+        { "sType": 'natural' },
+        { "sType": 'natural' },
+        { "sType": 'natural' },
+        { "sType": 'natural' },
+        null,
+        {"bSortable": false},
+        {"bSortable": false},
+        {"bSortable": false},
+        {"bSortable": false},
+        {"bSortable": false}
+      ],
+      "bPaginate": false,
+      "bInfo": false,
+      "bJQueryUI": true,
+      "bAutoWidth": true,
+      "bSort": true,
+      "bFilter": false,
+      "sDom": '<<"toolbar">f>r<t>ip>'
+    });
 
     lTable.find("tr:gt(0)").each(function () {
       for (var i = 0; i < this.cells.length; i++) {
@@ -302,59 +309,64 @@ function bulkLibraryDilutionTable(tableName) {
     });
 
     jQuery(tableName + ' .rowSelect').click(function () {
-      if (jQuery(this).parent().hasClass('row_selected'))
+      if (jQuery(this).parent().hasClass('row_selected')) {
         jQuery(this).parent().removeClass('row_selected');
-      else if (!jQuery(this).parent().hasClass('row_saved'))
+      } else if (!jQuery(this).parent().hasClass('row_saved')) {
         jQuery(this).parent().addClass('row_selected');
+      }
     });
 
     jQuery("div.toolbar").html("<input type='button' value='Save Dilutions' id=\"bulkLibraryDilutionButton\" onclick=\"Sample.library.saveBulkLibraryDilutions('" + tableName + "');\" class=\"fg-button ui-state-default ui-corner-all\"/>");
     jQuery("div.toolbar").append("<input type='button' value='Cancel' onclick=\"Utils.page.pageReload();\" class=\"fg-button ui-state-default ui-corner-all\"/>");
     jQuery("div.toolbar").removeClass("toolbar");
 
-    jQuery(tableName + ' .defaultEditable').editable(function (value, settings) {
-                                                       return value;
-                                                     },
-                                                     {
-                                                       callback: function (sValue, y) {
-                                                         var aPos = datatable.fnGetPosition(this);
-                                                         datatable.fnUpdate(sValue, aPos[0], aPos[1]);
-                                                       },
-                                                       submitdata: function (value, settings) {
-                                                         return {
-                                                           "row_id": this.parentNode.getAttribute('id'),
-                                                           "column": datatable.fnGetPosition(this)[2]
-                                                         };
-                                                       },
-                                                       onblur: 'submit',
-                                                       placeholder: '',
-                                                       height: '14px'
-                                                     });
+    jQuery(tableName + ' .defaultEditable').editable(
+      function (value, settings) {
+        return value;
+      },
+      {
+        callback: function (sValue, y) {
+          var aPos = datatable.fnGetPosition(this);
+          datatable.fnUpdate(sValue, aPos[0], aPos[1]);
+        },
+        submitdata: function (value, settings) {
+          return {
+            "row_id": this.parentNode.getAttribute('id'),
+            "column": datatable.fnGetPosition(this)[2]
+          };
+        },
+        onblur: 'submit',
+        placeholder: '',
+        height: '14px'
+      }
+    );
 
-    jQuery(tableName + " .dateSelect").editable(function (value, settings) {
-                                                  return value;
-                                                },
-                                                {
-                                                  type: 'datepicker',
-                                                  width: '100px',
-                                                  onblur: 'submit',
-                                                  placeholder: '',
-                                                  style: 'inherit',
-                                                  datepicker: {
-                                                    dateFormat: 'dd/mm/yy',
-                                                    showButtonPanel: true,
-                                                    maxDate: 0
-                                                  },
-                                                  callback: function (sValue, y) {
-                                                    var aPos = datatable.fnGetPosition(this);
-                                                    datatable.fnUpdate(sValue, aPos[0], aPos[1]);
-                                                  },
-                                                  submitdata: function (value, settings) {
-                                                    return {
-                                                      "row_id": this.parentNode.getAttribute('id'),
-                                                      "column": datatable.fnGetPosition(this)[2]
-                                                    };
-                                                  }
-                                                });
+    jQuery(tableName + " .dateSelect").editable(
+      function (value, settings) {
+        return value;
+      },
+      {
+        type: 'datepicker',
+        width: '100px',
+        onblur: 'submit',
+        placeholder: '',
+        style: 'inherit',
+        datepicker: {
+          dateFormat: 'dd/mm/yy',
+          showButtonPanel: true,
+          maxDate: 0
+        },
+        callback: function (sValue, y) {
+          var aPos = datatable.fnGetPosition(this);
+          datatable.fnUpdate(sValue, aPos[0], aPos[1]);
+        },
+        submitdata: function (value, settings) {
+          return {
+            "row_id": this.parentNode.getAttribute('id'),
+            "column": datatable.fnGetPosition(this)[2]
+          };
+        }
+      }
+    );
   }
 }

--- a/miso-web/src/main/webapp/scripts/editProject_sample.js
+++ b/miso-web/src/main/webapp/scripts/editProject_sample.js
@@ -26,7 +26,6 @@
  * Created by bianx on 24/02/2014.
  */
 
-
 function bulkSampleQcTable(tableName) {
   var sTable = jQuery(tableName);
   if (!sTable.hasClass("display")) {
@@ -41,22 +40,23 @@ function bulkSampleQcTable(tableName) {
     jQuery(tableName + ' tr:first th:gt(5)').remove();
     jQuery(tableName + ' tr:first th:eq(4)').remove();
 
-    var headers = ['rowsel',
-                   'name',
-                   'alias',
-                   'description',
-                   'sampleType',
-                   'qcPassed',
-                   'qcDate',
-                   'qcType',
-                   'results'];
+    var headers = [
+      'rowsel',
+      'name',
+      'alias',
+      'description',
+      'sampleType',
+      'qcPassed',
+      'qcDate',
+      'qcType',
+      'results'
+    ];
 
     sTable.find("tr").each(function () {
       //remove rows where the sample QC has already passed
       if (jQuery(this).find("td:eq(5)").html() == "true") {
         jQuery(this).remove();
-      }
-      else {
+      } else {
         jQuery(this).removeAttr("onmouseover").removeAttr("onmouseout");
         jQuery(this).find("td:eq(4)").remove();
         jQuery(this).find("td:gt(4)").remove();
@@ -111,10 +111,11 @@ function bulkSampleQcTable(tableName) {
     });
 
     jQuery(tableName + ' .rowSelect').click(function () {
-      if (jQuery(this).parent().hasClass('row_selected'))
+      if (jQuery(this).parent().hasClass('row_selected')) {
         jQuery(this).parent().removeClass('row_selected');
-      else if (!jQuery(this).parent().hasClass('row_saved'))
+      } else if (!jQuery(this).parent().hasClass('row_saved')) {
         jQuery(this).parent().addClass('row_selected');
+      }
     });
 
     jQuery("div.toolbar").html("<input type='button' value='Save QCs' id=\"bulkSampleQcButton\" onclick=\"Project.ui.saveBulkSampleQc('"+tableName+"');\" class=\"fg-button ui-state-default ui-corner-all\"/>");
@@ -213,7 +214,7 @@ function bulkSampleQcTable(tableName) {
             "column": datatable.fnGetPosition(this)[2]
           };
         }
-            }
+      }
     );
   }
 }
@@ -230,19 +231,21 @@ function generateSampleDeliveryForm(tableName, projectId) {
     //remove edit header and column
     jQuery(tableName + ' tr:first th:gt(4)').remove();
 
-    var headers = ['rowsel',
-                   'name',
-                   'alias',
-                   'description',
-                   'sampleType',
-                   'qcPassed'];
+    var headers = [
+      'rowsel',
+      'name',
+      'alias',
+      'description',
+      'sampleType',
+      'qcPassed'
+    ];
 
     sTable.find("tr").each(function () {
       jQuery(this).removeAttr("onmouseover").removeAttr("onmouseout");
       jQuery(this).find("td:gt(4)").remove();
     });
 
-//headers
+    //headers
     jQuery(tableName + " tr:first").prepend("<th width='5%'>Select <span sel='none' header='select' class='ui-icon ui-icon-arrowstop-1-s' style='float:right' onclick='DatatableUtils.toggleSelectAll(\""+tableName+"\", this);'></span></th>");
     jQuery(tableName + " tr:gt(0)").prepend("<td width='5%' class='rowSelect'></td>");
 
@@ -276,10 +279,11 @@ function generateSampleDeliveryForm(tableName, projectId) {
     });
 
     jQuery(tableName + ' .rowSelect').click(function () {
-      if (jQuery(this).parent().hasClass('row_selected'))
+      if (jQuery(this).parent().hasClass('row_selected')) {
         jQuery(this).parent().removeClass('row_selected');
-      else if (!jQuery(this).parent().hasClass('row_saved'))
+      } else if (!jQuery(this).parent().hasClass('row_saved')){
         jQuery(this).parent().addClass('row_selected');
+      }
     });
 
     jQuery("div.toolbar").html("Plate: <input type='radio' name='plateinformationform' value='yes'/>Yes |<input type='radio' name='plateinformationform' value='no' checked='checked'/>No " + "<button type='button' onclick=\"Project.ui.processSampleDeliveryForm('"+tableName+"', " + projectId + ");\" class=\"fg-button ui-state-default ui-corner-all\">Generate Form</button>");
@@ -339,4 +343,3 @@ function getPlateInputForm(projectId) {
     }
   });
 }
-

--- a/miso-web/src/main/webapp/scripts/experiment_ajax.js
+++ b/miso-web/src/main/webapp/scripts/experiment_ajax.js
@@ -184,7 +184,7 @@ Experiment.kit = {
       'experimentControllerHelperService',
       'lookupKitByIdentificationBarcode',
       {'barcode': barcode, 'url': ajaxurl},
-      {'doOnSuccess': fillKitSelector}
+      {'doOnSuccess': fillKitSelector} // ?? fillKitSelector is not defined anywhere in the project.
     );
   },
 
@@ -193,7 +193,7 @@ Experiment.kit = {
       'experimentControllerHelperService',
       'lookupKitByLotNumber',
       {'lotNumber': lotNumber, 'url': ajaxurl},
-      {'doOnSuccess': fillKitSelector}
+      {'doOnSuccess': fillKitSelector} // ?? fillKitSelector is not defined anywhere in the project.
     );
   },
 
@@ -232,17 +232,17 @@ Experiment.kit = {
     var experimentId = json.experimentId;
     var multiplexed = json.multiplexed;
 
-    var libraryKits = new Array();
+    var libraryKits = [];
     if (json.libraryKitDescriptors) {
       for (var i = 0; i < json.libraryKitDescriptors.length; i++) {
         libraryKits.push(json.libraryKitDescriptors[i]);
       }
     }
 
-    var multiplexKits = new Array();
+    var multiplexKits = [];
     if (multiplexed == "true" && json.multiplexKitDescriptors) {
-      for (var i = 0; i < json.multiplexKitDescriptors.length; i++) {
-        multiplexKits.push(json.multiplexKitDescriptors[i]);
+      for (var j = 0; j < json.multiplexKitDescriptors.length; j++) {
+        multiplexKits.push(json.multiplexKitDescriptors[j]);
       }
     }
 
@@ -251,8 +251,8 @@ Experiment.kit = {
                      "<label for='kitDescriptor'>Library Kit</label>" +
                      "<select name='kitDescriptor' id='kitDescriptor' class='text ui-widget-content ui-corner-all' onchange='Experiment.kit.kitDescriptorChange(this)'>";
 
-    for (var i = 0; i < libraryKits.length; i++) {
-      dialogText += "<option partNumber='" + libraryKits[i].partNumber + "' value='" + libraryKits[i].id + "'>" + libraryKits[i].name + "</option>";
+    for (var k = 0; k < libraryKits.length; k++) {
+      dialogText += "<option partNumber='" + libraryKits[k].partNumber + "' value='" + libraryKits[k].id + "'>" + libraryKits[k].name + "</option>";
     }
 
     dialogText += "</select><br/>" +
@@ -263,8 +263,8 @@ Experiment.kit = {
       dialogText += "<label for='multiplexingKitType'>Multiplexing Kit</label>" +
                     "<select name='multiplexingKitType' id='multiplexingKitType' class='text ui-widget-content ui-corner-all'>";
 
-      for (var i = 0; i < multiplexKits.length; i++) {
-        dialogText += "<option partNumber='" + multiplexKits[i].partNumber + "' value='" + multiplexKits[i].id + "'>" + multiplexKits[i].name + "</option>";
+      for (var m = 0; m < multiplexKits.length; m++) {
+        dialogText += "<option partNumber='" + multiplexKits[m].partNumber + "' value='" + multiplexKits[m].id + "'>" + multiplexKits[m].name + "</option>";
       }
       dialogText += "</select><br/>" +
                     "<label for='multiplexingKitBarcode'>Multiplexing Kit Barcode</label>" +
@@ -310,13 +310,10 @@ Experiment.kit = {
         'experimentControllerHelperService',
         'addLibraryKit',
         {'experimentId': experimentId, 'kitDescriptor': kitDescriptorId, 'partNumber': partNumber, 'lotNumber': lotNumber, 'url': ajaxurl},
-        {'doOnSuccess': function (json) {
+        {'doOnSuccess': function () {
           alert("Added");
         }
       });
-    }
-    else {
-
     }
   },
 
@@ -336,7 +333,7 @@ Experiment.kit = {
 
     var experimentId = json.experimentId;
 
-    var kits = new Array();
+    var kits = [];
     if (json.emPcrKitDescriptors) {
       for (var i = 0; i < json.emPcrKitDescriptors.length; i++) {
         kits.push(json.emPcrKitDescriptors[i]);
@@ -348,8 +345,8 @@ Experiment.kit = {
                      "<label for='kitDescriptor'>EmPCR Kit</label>" +
                      "<select name='kitDescriptor' id='kitDescriptor' class='text ui-widget-content ui-corner-all' onchange='Experiment.kit.kitDescriptorChange(this)'>";
 
-    for (var i = 0; i < kits.length; i++) {
-      dialogText += "<option partNumber='" + kits[i].partNumber + "' value='" + kits[i].id + "'>" + kits[i].name + "</option>";
+    for (var j = 0; j < kits.length; j++) {
+      dialogText += "<option partNumber='" + kits[j].partNumber + "' value='" + kits[j].id + "'>" + kits[j].name + "</option>";
     }
 
     dialogText += "</select><br/>" +
@@ -388,7 +385,7 @@ Experiment.kit = {
       'experimentControllerHelperService',
       'addEmPcrKit',
       {'experimentId': experimentId, 'kitDescriptor': kitDescriptorId, 'partNumber': partNumber, 'lotNumber': lotNumber, 'url': ajaxurl},
-      {'doOnSuccess': function (json) {
+      {'doOnSuccess': function () {
         alert("Added");
       }
     });
@@ -410,7 +407,7 @@ Experiment.kit = {
 
     var experimentId = json.experimentId;
 
-    var kits = new Array();
+    var kits = [];
     if (json.clusteringKitDescriptors) {
       for (var i = 0; i < json.clusteringKitDescriptors.length; i++) {
         kits.push(json.clusteringKitDescriptors[i]);
@@ -422,8 +419,8 @@ Experiment.kit = {
                      "<label for='kitDescriptor'>Clustering Kit</label>" +
                      "<select name='kitDescriptor' id='kitDescriptor' class='text ui-widget-content ui-corner-all' onchange='Experiment.kit.kitDescriptorChange(this)'>";
 
-    for (var i = 0; i < kits.length; i++) {
-      dialogText += "<option partNumber='" + kits[i].partNumber + "' value='" + kits[i].id + "'>" + kits[i].name + "</option>";
+    for (var j = 0; j < kits.length; j++) {
+      dialogText += "<option partNumber='" + kits[j].partNumber + "' value='" + kits[j].id + "'>" + kits[j].name + "</option>";
     }
 
     dialogText += "</select><br/>" +
@@ -462,7 +459,7 @@ Experiment.kit = {
       'experimentControllerHelperService',
       'addClusteringKit',
       {'experimentId': experimentId, 'kitDescriptor': kitDescriptorId, 'partNumber': partNumber, 'lotNumber': lotNumber, 'url': ajaxurl},
-      {'doOnSuccess': function (json) {
+      {'doOnSuccess': function () {
         alert("Added");
       }
     });
@@ -484,7 +481,7 @@ Experiment.kit = {
 
     var experimentId = json.experimentId;
 
-    var kits = new Array();
+    var kits = [];
     if (json.sequencingKitDescriptors) {
       for (var i = 0; i < json.sequencingKitDescriptors.length; i++) {
         kits.push(json.sequencingKitDescriptors[i]);
@@ -496,8 +493,8 @@ Experiment.kit = {
                      "<label for='kitDescriptor'>Sequencing Kit</label>" +
                      "<select name='kitDescriptor' id='kitDescriptor' class='text ui-widget-content ui-corner-all' onchange='Experiment.kit.kitDescriptorChange(this)'>";
 
-    for (var i = 0; i < kits.length; i++) {
-      dialogText += "<option partNumber='" + kits[i].partNumber + "' value='" + kits[i].id + "'>" + kits[i].name + "</option>";
+    for (var j = 0; j < kits.length; j++) {
+      dialogText += "<option partNumber='" + kits[j].partNumber + "' value='" + kits[j].id + "'>" + kits[j].name + "</option>";
     }
 
     dialogText += "</select><br/>" +
@@ -537,7 +534,7 @@ Experiment.kit = {
       'experimentControllerHelperService',
       'addSequencingKit',
       {'experimentId': experimentId, 'kitDescriptor': kitDescriptorId, 'partNumber': partNumber, 'lotNumber': lotNumber, 'url': ajaxurl},
-      {'doOnSuccess': function (json) {
+      {'doOnSuccess': function () {
         alert("Added");
       }
     });

--- a/miso-web/src/main/webapp/scripts/flexreport.js
+++ b/miso-web/src/main/webapp/scripts/flexreport.js
@@ -182,7 +182,7 @@ Reports.ui = {
         var start = jQuery('.chkbox').index(this);
         var end = jQuery('.chkbox').index(self.lastChecked);
 
-        for (i = Math.min(start, end); i <= Math.max(start, end); i++) {
+        for (var i = Math.min(start, end); i <= Math.max(start, end); i++) {
           jQuery('.chkbox')[i].checked = self.lastChecked.checked;
         }
       }
@@ -324,7 +324,7 @@ Reports.ui = {
   toggleCheckedItems: function (className, status) {
     jQuery("." + className).each(function () {
       jQuery(this).attr("checked", status);
-    })
+    });
   },
 
   createProjectFormTable: function (array) {
@@ -719,10 +719,10 @@ Reports.ui = {
       'listSequencers',
       {'url': ajaxurl},
       {'doOnSuccess': function (json) {
-        var list = "<select id='sequencers' name='sequencers' onchange='Reports.ui.updateCalendar();'> <option value=0> All </option>;"
+        var list = "<select id='sequencers' name='sequencers' onchange='Reports.ui.updateCalendar();'> <option value=0> All </option>;";
 
         for (var i = 0; i < json.sequencers.length; i++) {
-          list += "<option value=" + json.sequencers[i].id + ">" + json.sequencers[i].name_model + " - " + json.sequencers[i].name + "</option>"
+          list += "<option value=" + json.sequencers[i].id + ">" + json.sequencers[i].name_model + " - " + json.sequencers[i].name + "</option>";
         }
 
         list += "</select>";
@@ -740,7 +740,7 @@ Reports.ui = {
   },
 
   findMaxValue: function (element) {
-    var maxValue = undefined;
+    var maxValue;
     jQuery('option', element).each(function () {
       var val = jQuery(this).attr('value');
       val = parseInt(val, 10);
@@ -754,7 +754,7 @@ Reports.ui = {
 
   updateCalendar: function () {
     var self = this;
-    if (jQuery('#sequencers').val() == 0) {
+    if (jQuery('#sequencers').val() === 0) {
       jQuery("#listtoggle").fadeIn();
     }
     else {
@@ -787,7 +787,7 @@ Reports.ui = {
       }
       var label = jQuery("#sequencers option").eq(i).text();
       color += "<td bgcolor=" + tempcolour[jQuery("#sequencers option").eq(i).val()] + "> <font color='black'> <b> " + label + "</b> </font></td>";
-      if ((i % 2) == 0) {
+      if ((i % 2) === 0) {
         color += "</tr>";
       }
     }
@@ -844,8 +844,8 @@ Reports.chart = {
   },
 
   plotHollowPieChart: function (data, div) {
-    var w = 400, h = 600, r = 150, labelr = r + 10, sum = 0 // radius for label anchor
-    color = d3.scale.category20c(), donut = d3.layout.pie(), arc = d3.svg.arc().innerRadius(r * .6).outerRadius(r);
+    var w = 400, h = 600, r = 150, labelr = r + 10, sum = 0; // radius for label anchor
+    var color = d3.scale.category20c(), donut = d3.layout.pie(), arc = d3.svg.arc().innerRadius(r * 0.6).outerRadius(r);
 
     var vis = d3.select("#" + div)
         .append("svg:svg")
@@ -856,7 +856,7 @@ Reports.chart = {
     var arcs = vis.selectAll("g.arc")
         .data(donut.value(function (d) {
           sum += parseInt(d.value);
-          return d.value
+          return d.value;
         }))
         .enter().append("svg:g")
         .attr("class", "arc")

--- a/miso-web/src/main/webapp/scripts/group_ajax.js
+++ b/miso-web/src/main/webapp/scripts/group_ajax.js
@@ -21,10 +21,6 @@
  * *********************************************************************
  */
 
-jQuery(document).ready(function () {
-  Validate.attachParsley('#group-form');
-});
-
 function validateGroup() {
   Validate.cleanFields('#group-form');
   jQuery('#group-form').parsley().destroy();

--- a/miso-web/src/main/webapp/scripts/group_ajax.js
+++ b/miso-web/src/main/webapp/scripts/group_ajax.js
@@ -21,25 +21,27 @@
  * *********************************************************************
  */
 
-function validateGroup() {
-  Validate.cleanFields('#group-form');
-  jQuery('#group-form').parsley().destroy();
-
-  // Full name input field validation
-  jQuery('#name').attr('class', 'form-control');
-  jQuery('#name').attr('data-parsley-required', 'true');
-  jQuery('#name').attr('data-parsley-maxlength', '100');
-  jQuery('#name').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
-
-  // Login name input field validation
-  jQuery('#description').attr('class', 'form-control');
-  jQuery('#description').attr('data-parsley-required', 'true');
-  jQuery('#description').attr('data-parsley-maxlength', '100');
-  jQuery('#description').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
-
-  jQuery('#group-form').parsley();
-  jQuery('#group-form').parsley().validate();
-
-  Validate.updateWarningOrSubmit('#group-form');
-  return false;
+var Group = Group || {
+  validateGroup: function () {
+    Validate.cleanFields('#group-form');
+    jQuery('#group-form').parsley().destroy();
+  
+    // Full name input field validation
+    jQuery('#name').attr('class', 'form-control');
+    jQuery('#name').attr('data-parsley-required', 'true');
+    jQuery('#name').attr('data-parsley-maxlength', '100');
+    jQuery('#name').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+  
+    // Login name input field validation
+    jQuery('#description').attr('class', 'form-control');
+    jQuery('#description').attr('data-parsley-required', 'true');
+    jQuery('#description').attr('data-parsley-maxlength', '100');
+    jQuery('#description').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+  
+    jQuery('#group-form').parsley();
+    jQuery('#group-form').parsley().validate();
+  
+    Validate.updateWarningOrSubmit('#group-form');
+    return false;
+  }
 };

--- a/miso-web/src/main/webapp/scripts/import_export_ajax.js
+++ b/miso-web/src/main/webapp/scripts/import_export_ajax.js
@@ -125,10 +125,11 @@ var ImportExport = ImportExport || {
   processSampleSheetUpload: function (frameId) {
     var iframe = document.getElementById(frameId);
     var iframedoc = iframe.document;
-    if (iframe.contentDocument)
+    if (iframe.contentDocument) {
       iframedoc = iframe.contentDocument;
-    else if (iframe.contentWindow)
+    } else if (iframe.contentWindow) {
       iframedoc = iframe.contentWindow.document;
+    }
     var response = jQuery(iframedoc).contents().find('body:first').find('#uploadresponsebody').val();
     if (!Utils.validation.isNullCheck(response)) {
       response = jQuery.parseJSON(response);
@@ -161,7 +162,7 @@ var ImportExport = ImportExport || {
     }
     else {
       setTimeout(function () {
-        ImportExport.processSampleSheetUpload(frameId)
+        ImportExport.processSampleSheetUpload(frameId);
       }, 2000);
     }
   },
@@ -180,7 +181,7 @@ var ImportExport = ImportExport || {
         'url': ajaxurl
       },
       {
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           sampleJSONArray = null;
           alert("Imported.");
           jQuery('#confirmSamplesUploadButton').html("Imported");
@@ -192,10 +193,11 @@ var ImportExport = ImportExport || {
   processLibraryPoolSheetUpload: function (frameId) {
     var iframe = document.getElementById(frameId);
     var iframedoc = iframe.document;
-    if (iframe.contentDocument)
+    if (iframe.contentDocument) {
       iframedoc = iframe.contentDocument;
-    else if (iframe.contentWindow)
+    } else if (iframe.contentWindow) {
       iframedoc = iframe.contentWindow.document;
+    }
     var response = jQuery(iframedoc).contents().find('body:first').find('#uploadresponsebody').val();
     if (!Utils.validation.isNullCheck(response)) {
       response = jQuery.parseJSON(response);
@@ -235,7 +237,7 @@ var ImportExport = ImportExport || {
     }
     else {
       setTimeout(function () {
-        ImportExport.processLibraryPoolSheetUpload(frameId)
+        ImportExport.processLibraryPoolSheetUpload(frameId);
       }, 2000);
     }
   },
@@ -259,7 +261,7 @@ var ImportExport = ImportExport || {
         'url': ajaxurl
       },
       {
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           librariesPoolsJSON = null;
           alert("Imported.");
           jQuery('#confirmLibrariesPoolsUploadButton').html("Imported");
@@ -269,7 +271,6 @@ var ImportExport = ImportExport || {
   },
 
   changePlatformName: function (input) {
-    var self = this;
     var platform = jQuery(input).val();
     Fluxion.doAjax(
       'importExportControllerHelperService',

--- a/miso-web/src/main/webapp/scripts/import_export_ajax.js
+++ b/miso-web/src/main/webapp/scripts/import_export_ajax.js
@@ -24,25 +24,27 @@
 var sampleJSONArray = null;
 var librariesPoolsJSON = null;
 var ImportExport = ImportExport || {
-
   searchSamples: function (text) {
     jQuery('#sampleList').html("<img src='/styles/images/ajax-loader.gif'/>");
     Fluxion.doAjax(
-            'importExportControllerHelperService',
-            'searchSamples',
-            {  'str': text,
-              'url': ajaxurl
-            },
-            {'doOnSuccess': function (json) {
-              jQuery('#sampleList').html(json.html);
-              jQuery('#sampleList .dashboard').each(function () {
-                var inp = jQuery(this);
-                inp.dblclick(function () {
-                  ImportExport.insertSampleNextAvailable(inp);
-                });
-              });
-            }
+      'importExportControllerHelperService',
+      'searchSamples',
+      {  
+        'str': text,
+        'url': ajaxurl
+      },
+      {
+        'doOnSuccess': function (json) {
+          jQuery('#sampleList').html(json.html);
+          jQuery('#sampleList .dashboard').each(function () {
+            var inp = jQuery(this);
+            inp.dblclick(function () {
+              ImportExport.insertSampleNextAvailable(inp);
             });
+          });
+        }
+      }
+    );
   },
 
   selectSampleElement: function (elementId, elementName) {
@@ -81,17 +83,17 @@ var ImportExport = ImportExport || {
   exportSampleForm: function () {
     Utils.ui.disableButton("exportSampleForm");
     Fluxion.doAjax(
-            'importExportControllerHelperService',
-            'exportSampleForm',
-            {
-              'form': jQuery('#sampleExportForm').serializeArray(),
-              // 'documentFormat':documentFormat,
-              'url': ajaxurl
-            },
-            {'doOnSuccess': function (json) {
-              Utils.page.pageRedirect('/miso/download/sample/forms/' + json.response);
-            }
-            }
+      'importExportControllerHelperService',
+      'exportSampleForm',
+      {
+        'form': jQuery('#sampleExportForm').serializeArray(),
+        'url': ajaxurl
+      },
+      {
+        'doOnSuccess': function (json) {
+          Utils.page.pageRedirect('/miso/download/sample/forms/' + json.response);
+        }
+      }
     );
     Utils.ui.reenableButton("exportSampleForm", "Export Sample Sheet");
   },
@@ -99,18 +101,18 @@ var ImportExport = ImportExport || {
   exportLibraryPoolForm: function () {
     Utils.ui.disableButton("exportLibraryPoolForm");
     Fluxion.doAjax(
-            'importExportControllerHelperService',
-            'exportLibraryPoolForm',
-            {
-              'barcodekit': jQuery('#barcodekit :selected').text(),
-              'form': jQuery('#sampleExportForm').serializeArray(),
-              // 'documentFormat':documentFormat,
-              'url': ajaxurl
-            },
-            {'doOnSuccess': function (json) {
-              Utils.page.pageRedirect('/miso/download/library/forms/' + json.response);
-            }
-            }
+      'importExportControllerHelperService',
+      'exportLibraryPoolForm',
+      {
+        'barcodekit': jQuery('#barcodekit :selected').text(),
+        'form': jQuery('#sampleExportForm').serializeArray(),
+        'url': ajaxurl
+      },
+      {
+        'doOnSuccess': function (json) {
+          Utils.page.pageRedirect('/miso/download/library/forms/' + json.response);
+        }
+      }
     );
     Utils.ui.reenableButton("exportLibraryPoolForm", "Export Library & Pool Sheet");
   },
@@ -119,6 +121,7 @@ var ImportExport = ImportExport || {
     jQuery('#samplesheet_statusdiv').html("Processing...");
     ImportExport.processSampleSheetUpload(json.frameId);
   },
+  
   processSampleSheetUpload: function (frameId) {
     var iframe = document.getElementById(frameId);
     var iframedoc = iframe.document;
@@ -136,25 +139,25 @@ var ImportExport = ImportExport || {
                                             "onclick=\"window.location='/miso/importexport/importsamplesheet';\">Cancel</button>" +
                                             "<table cellpadding=\"0\" cellspacing=\"0\" border=\"0\" class=\"display\" id=\"sampleSheetUploadSuccessTable\"></table>");
       jQuery('#sampleSheetUploadSuccessTable').dataTable({
-                                                           "aaData": response,
-                                                           "aoColumns": [
-                                                             { "sTitle": "Project"},
-                                                             { "sTitle": "Client"},
-                                                             { "sTitle": "Sample Name"},
-                                                             { "sTitle": "Sample Alias"},
-                                                             { "sTitle": "Well"},
-                                                             { "sTitle": "Adaptor"},
-                                                             { "sTitle": "QC value"},
-                                                             { "sTitle": "QC Passed"},
-                                                             { "sTitle": "Notes"}
-                                                           ],
-                                                           "bPaginate": false,
-                                                           "bFilter": false,
-                                                           "bSort": false,
-                                                           "bJQueryUI": true
-                                                         });
+        "aaData": response,
+        "aoColumns": [
+          { "sTitle": "Project"},
+          { "sTitle": "Client"},
+          { "sTitle": "Sample Name"},
+          { "sTitle": "Sample Alias"},
+          { "sTitle": "Well"},
+          { "sTitle": "Adaptor"},
+          { "sTitle": "QC value"},
+          { "sTitle": "QC Passed"},
+          { "sTitle": "Notes"}
+        ],
+        "bPaginate": false,
+        "bFilter": false,
+        "bSort": false,
+        "bJQueryUI": true
+      });
 
-    sampleJSONArray = response;
+      sampleJSONArray = response;
     }
     else {
       setTimeout(function () {
@@ -170,18 +173,19 @@ var ImportExport = ImportExport || {
   confirmSamplesUpload: function () {
     Utils.ui.disableButton("confirmSamplesUploadButton");
     Fluxion.doAjax(
-            'importExportControllerHelperService',
-            'confirmSamplesUpload',
-            {
-              'table': sampleJSONArray,
-              'url': ajaxurl
-            },
-            {'doOnSuccess': function (json) {
-              sampleJSONArray = null;
-              alert("Imported.");
-              jQuery('#confirmSamplesUploadButton').html("Imported");
-            }
-            }
+      'importExportControllerHelperService',
+      'confirmSamplesUpload',
+      {
+        'table': sampleJSONArray,
+        'url': ajaxurl
+      },
+      {
+        'doOnSuccess': function (json) {
+          sampleJSONArray = null;
+          alert("Imported.");
+          jQuery('#confirmSamplesUploadButton').html("Imported");
+        }
+      }
     );
   },
 
@@ -202,30 +206,30 @@ var ImportExport = ImportExport || {
                                             "onclick=\"window.location='/miso/importexport/importlibrarypoolsheet';\">Cancel</button>" +
                                             "<table cellpadding=\"0\" cellspacing=\"0\" border=\"0\" class=\"display\" id=\"librarypoolSheetUploadSuccessTable\"></table>");
       jQuery('#librarypoolSheetUploadSuccessTable').dataTable({
-                                                           "aaData": response['rows'],
-                                                           "aoColumns": [
-                                                             { "sTitle": "Sample Name"},
-                                                             { "sTitle": "Sample Alias"},
-                                                             { "sTitle": "Well"},
-                                                             { "sTitle": "Library Alias"},
-                                                             { "sTitle": "Library Description"},
-                                                             { "sTitle": "Qubit Conc"},
-                                                             { "sTitle": "Insert Size (bp)"},
-                                                             { "sTitle": "Molarity (nm)"},
-                                                             { "sTitle": "QC Passed"},
-                                                             { "sTitle": "Barcode Kit"},
-                                                             { "sTitle": "Barcode Tag"},
-                                                             { "sTitle": "LDI Conc"},
-                                                             { "sTitle": "Pool Name"},
-                                                             { "sTitle": "Pool Molarity (nm)"} ,
-                                                             { "sTitle": "Proceed Key"},
-                                                             { "sTitle": "Note"}
-                                                           ],
-                                                           "bPaginate": false,
-                                                           "bFilter": false,
-                                                           "bSort": false,
-                                                           "bJQueryUI": true
-                                                         });
+        "aaData": response['rows'],
+        "aoColumns": [
+          { "sTitle": "Sample Name"},
+          { "sTitle": "Sample Alias"},
+          { "sTitle": "Well"},
+          { "sTitle": "Library Alias"},
+          { "sTitle": "Library Description"},
+          { "sTitle": "Qubit Conc"},
+          { "sTitle": "Insert Size (bp)"},
+          { "sTitle": "Molarity (nm)"},
+          { "sTitle": "QC Passed"},
+          { "sTitle": "Barcode Kit"},
+          { "sTitle": "Barcode Tag"},
+          { "sTitle": "LDI Conc"},
+          { "sTitle": "Pool Name"},
+          { "sTitle": "Pool Molarity (nm)"} ,
+          { "sTitle": "Proceed Key"},
+          { "sTitle": "Note"}
+        ],
+        "bPaginate": false,
+        "bFilter": false,
+        "bSort": false,
+        "bJQueryUI": true
+      });
 
       librariesPoolsJSON = response;
     }
@@ -248,18 +252,19 @@ var ImportExport = ImportExport || {
   confirmLibrariesPoolsUpload: function () {
     Utils.ui.disableButton("confirmLibrariesPoolsUploadButton");
     Fluxion.doAjax(
-            'importExportControllerHelperService',
-            'confirmLibrariesPoolsUpload',
-            {
-              'sheet': librariesPoolsJSON,
-              'url': ajaxurl
-            },
-            {'doOnSuccess': function (json) {
-              librariesPoolsJSON = null;
-              alert("Imported.");
-              jQuery('#confirmLibrariesPoolsUploadButton').html("Imported");
-            }
-            }
+      'importExportControllerHelperService',
+      'confirmLibrariesPoolsUpload',
+      {
+        'sheet': librariesPoolsJSON,
+        'url': ajaxurl
+      },
+      {
+        'doOnSuccess': function (json) {
+          librariesPoolsJSON = null;
+          alert("Imported.");
+          jQuery('#confirmLibrariesPoolsUploadButton').html("Imported");
+        }
+      }
     );
   },
 
@@ -267,14 +272,18 @@ var ImportExport = ImportExport || {
     var self = this;
     var platform = jQuery(input).val();
     Fluxion.doAjax(
-            'importExportControllerHelperService',
-            'changePlatformName',
-            {'platform': platform, 'url': ajaxurl},
-            {'doOnSuccess': function (json){
-              jQuery('#type').html(json.libraryTypes);
-              jQuery('#barcodekit').html(json.tagBarcodeStrategies);
-            }
-            }
+      'importExportControllerHelperService',
+      'changePlatformName',
+      {
+        'platform': platform, 
+        'url': ajaxurl
+      },
+      {
+        'doOnSuccess': function (json){
+          jQuery('#type').html(json.libraryTypes);
+          jQuery('#barcodekit').html(json.tagBarcodeStrategies);
+        }
+      }
     );
   },
 
@@ -282,18 +291,18 @@ var ImportExport = ImportExport || {
     Utils.ui.disableButton("generateCSVBACButton");
     console.info(jQuery('#generateCSVBACForm').serializeArray());
     Fluxion.doAjax(
-            'importExportControllerHelperService',
-            'generateCSVBAC',
-            {
-              'form': jQuery('#generateCSVBACForm').serializeArray(),
-              'url': ajaxurl
-            },
-            {'doOnSuccess': function (json) {
-              Utils.page.pageRedirect('/miso/download/plate/csv/' + json.response);
-            }
-            }
+      'importExportControllerHelperService',
+      'generateCSVBAC',
+      {
+        'form': jQuery('#generateCSVBACForm').serializeArray(),
+        'url': ajaxurl
+      },
+      {
+        'doOnSuccess': function (json) {
+          Utils.page.pageRedirect('/miso/download/plate/csv/' + json.response);
+        }
+      }
     );
     Utils.ui.reenableButton("generateCSVBACButton", "Generate CSV");
-
   }
 };

--- a/miso-web/src/main/webapp/scripts/instituteDefaults_ajax.js
+++ b/miso-web/src/main/webapp/scripts/instituteDefaults_ajax.js
@@ -57,7 +57,6 @@ var Tissue = Tissue || {
     Tissue.createTable(Defaults.all.tissueOriginsDtos, 'TO', 'allOrigins', 'Origin', TOtable);
   },
 
-
   createTissueTypesTable: function (xhr) {
     var TTtable = [];
     var id, alias, description, endpoint;
@@ -477,6 +476,7 @@ var Lab = Lab || {
 
     // optional variable for if option == "Lab"
     var selectedInstituteId = null;
+    var id, alias, endpoint;
     
     // create rows if there is data; otherwise, add only the "Add New" button
     if (data) {
@@ -607,7 +607,6 @@ var Lab = Lab || {
 
 var Hierarchy = Hierarchy || {
 
-
   getSampleClasses: function () {
     Options.makeXhrRequest('GET', '/miso/rest/sampleclasses', Hierarchy.createSampleClassesTable);
   },
@@ -626,7 +625,7 @@ var Hierarchy = Hierarchy || {
     var table = [];
     var id, alias, category, endpoint;
 
-   // create rows if there is data; otherwise, add only the "Add New" button
+    // create rows if there is data; otherwise, add only the "Add New" button
     if (data) {
       data.sort(function (a, b) {
         return (a.sampleCategory > b.sampleCategory) ? 1 : ((b.sampleCategory > a.sampleCategory) ? -1 : 0);

--- a/miso-web/src/main/webapp/scripts/library_ajax.js
+++ b/miso-web/src/main/webapp/scripts/library_ajax.js
@@ -22,16 +22,18 @@
  */
 
 var Library = Library || {
-  deleteLibrary: function (libraryId, successfunc) {
+  deleteLibrary: function (libraryId) {
     if (confirm("Are you sure you really want to delete LIB" + libraryId + "? This operation is permanent!")) {
       Fluxion.doAjax(
         'libraryControllerHelperService',
         'deleteLibrary',
         {'libraryId': libraryId, 'url': ajaxurl},
-        {'doOnSuccess': function (json) {
-          successfunc();
+        {
+          'doOnSuccess': function () {
+            window.location.href = '/miso/libraries';
+          }
         }
-        });
+      );
     }
   },
   
@@ -122,24 +124,24 @@ Library.qc = {
     if (!jQuery('#libraryQcTable').attr("qcInProgress")) {
       jQuery('#libraryQcTable').attr("qcInProgress", "true");
 
-      $('libraryQcTable').insertRow(1);
+      jQuery('libraryQcTable').insertRow(1);
       //QCId  QCed By  	QC Date  	Method  	Results
 
       if (includeId) {
-        var column1 = $('libraryQcTable').rows[1].insertCell(-1);
+        var column1 = jQuery('libraryQcTable').rows[1].insertCell(-1);
         column1.innerHTML = "<input type='hidden' id='libraryId' name='libraryId' value='" + libraryId + "'/>";
       }
-      var column2 = $('libraryQcTable').rows[1].insertCell(-1);
-      column2.innerHTML = "<input id='libraryQcUser' name='libraryQcUser' type='hidden' value='" + $('currentUser').innerHTML + "'/>" + $('currentUser').innerHTML;
-      var column3 = $('libraryQcTable').rows[1].insertCell(-1);
+      var column2 = jQuery('libraryQcTable').rows[1].insertCell(-1);
+      column2.innerHTML = "<input id='libraryQcUser' name='libraryQcUser' type='hidden' value='" + jQuery('currentUser').innerHTML + "'/>" + jQuery('currentUser').innerHTML;
+      var column3 = jQuery('libraryQcTable').rows[1].insertCell(-1);
       column3.innerHTML = "<input id='libraryQcDate' name='libraryQcDate' type='text'/>";
-      var column4 = $('libraryQcTable').rows[1].insertCell(-1);
+      var column4 = jQuery('libraryQcTable').rows[1].insertCell(-1);
       column4.innerHTML = "<select id='libraryQcType' name='libraryQcType' onchange='Library.qc.changeLibraryQcUnits(this);'/>";
-      var column5 = $('libraryQcTable').rows[1].insertCell(-1);
+      var column5 = jQuery('libraryQcTable').rows[1].insertCell(-1);
       column5.innerHTML = "<input id='libraryQcResults' name='libraryQcResults' type='text'/><span id='units'/>";
-      var column6 = $('libraryQcTable').rows[1].insertCell(-1);
+      var column6 = jQuery('libraryQcTable').rows[1].insertCell(-1);
       column6.innerHTML = "<input id='libraryQcInsertSize' name='libraryQcInsertSize' type='text'/> bp";
-      var column7 = $('libraryQcTable').rows[1].insertCell(-1);
+      var column7 = jQuery('libraryQcTable').rows[1].insertCell(-1);
       column7.innerHTML = "<a href='javascript:void(0);' onclick='Library.qc.addLibraryQC();'/>Add</a>";
 
       Utils.ui.addMaxDatePicker("libraryQcDate", 0);
@@ -156,11 +158,11 @@ Library.qc = {
       );
     }
     else {
-      alert("Cannot add another QC when one is already in progress.")
+      alert("Cannot add another QC when one is already in progress.");
     }
   },
 
-  changeLibraryQcUnits: function (input) {
+  changeLibraryQcUnits: function () {
     jQuery('#units').html(jQuery('#libraryQcType').find(":selected").attr("units"));
   },
 
@@ -179,7 +181,7 @@ Library.qc = {
         'url': ajaxurl
       },
       {'updateElement': 'libraryQcTable',
-      'doOnSuccess': function (json) {
+      'doOnSuccess': function () {
         jQuery('#libraryQcTable').removeAttr("qcInProgress");
       }
     });
@@ -220,29 +222,28 @@ Library.qc = {
 };
 
 Library.dilution = {
-  insertLibraryDilutionRow: function (libraryId) {
+  insertLibraryDilutionRow: function () {
     if (!jQuery('#libraryDilutionTable').attr("dilutionInProgress")) {
       jQuery('#libraryDilutionTable').attr("dilutionInProgress", "true");
 
-      $('libraryDilutionTable').insertRow(1);
+      jQuery('libraryDilutionTable').insertRow(1);
       //dilutionId    Done By   Dilution Date Barcode Results
-      var column1 = $('libraryDilutionTable').rows[1].insertCell(-1);
+      var column1 = jQuery('libraryDilutionTable').rows[1].insertCell(-1);
       column1.innerHTML = "<input id='name' name='name' type='hidden' value='Unsaved '/>Unsaved";
-      var column2 = $('libraryDilutionTable').rows[1].insertCell(-1);
-      column2.innerHTML = "<input id='libraryDilutionCreator' name='libraryDilutionCreator' type='hidden' value='" + $('currentUser').innerHTML + "'/>" + $('currentUser').innerHTML;
-      var column3 = $('libraryDilutionTable').rows[1].insertCell(-1);
+      var column2 = jQuery('libraryDilutionTable').rows[1].insertCell(-1);
+      column2.innerHTML = "<input id='libraryDilutionCreator' name='libraryDilutionCreator' type='hidden' value='" + jQuery('currentUser').innerHTML + "'/>" + jQuery('currentUser').innerHTML;
+      var column3 = jQuery('libraryDilutionTable').rows[1].insertCell(-1);
       column3.innerHTML = "<input id='libraryDilutionDate' name='libraryDilutionDate' type='text'/>";
-      var column6 = $('libraryDilutionTable').rows[1].insertCell(-1);
+      var column6 = jQuery('libraryDilutionTable').rows[1].insertCell(-1);
       column6.innerHTML = "<input id='libraryDilutionResults' name='libraryDilutionResults' type='text'/>";
-      var column7 = $('libraryDilutionTable').rows[1].insertCell(-1);
+      var column7 = jQuery('libraryDilutionTable').rows[1].insertCell(-1);
       column7.innerHTML = "<i>Generated on save</i>";
-      var column8 = $('libraryDilutionTable').rows[1].insertCell(-1);
+      var column8 = jQuery('libraryDilutionTable').rows[1].insertCell(-1);
       column8.innerHTML = "<a href='javascript:void(0);' onclick='Library.dilution.addLibraryDilution();'/>Add</a>";
 
       Utils.ui.addMaxDatePicker("libraryDilutionDate", 0);
-    }
-    else {
-      alert("Cannot add another dilution when one is already in progress.")
+    } else {
+      alert("Cannot add another dilution when one is already in progress.");
     }
   },
 
@@ -259,7 +260,7 @@ Library.dilution = {
         'results': f.libraryDilutionResults,
         'url': ajaxurl},
       {'updateElement': 'libraryDilutionTable',
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           jQuery('#libraryDilutionTable').removeAttr("dilutionInProgress");
         }
       }
@@ -296,16 +297,15 @@ Library.dilution = {
     );
   },
 
-  deleteLibraryDilution: function (libraryDilutionId, successfunc) {
+  deleteLibraryDilution: function (libraryDilutionId) {
     if (confirm("Are you sure you really want to delete LDI" + libraryDilutionId + "? This operation is permanent!")) {
       Fluxion.doAjax(
         'libraryControllerHelperService',
         'deleteLibraryDilution',
         {'libraryDilutionId': libraryDilutionId, 'url': ajaxurl},
-        {'doOnSuccess': function (json) {
-          successfunc();
+        {'doOnSuccess': window.location.reload(true)
         }
-      });
+      );
     }
   }
 };
@@ -315,23 +315,23 @@ Library.empcr = {
     if (!jQuery('#emPcrTable').attr("pcrInProgress")) {
       jQuery('#emPcrTable').attr("pcrInProgress", "true");
 
-      $('emPcrTable').insertRow(1);
+      jQuery('emPcrTable').insertRow(1);
 
-      var column2 = $('emPcrTable').rows[1].insertCell(-1);
+      var column2 = jQuery('emPcrTable').rows[1].insertCell(-1);
       column2.innerHTML = "" + dilutionId + " <input type='hidden' id='dilutionId' name='dilutionId' value='" + dilutionId + "'/>";
-      var column3 = $('emPcrTable').rows[1].insertCell(-1);
-      column3.innerHTML = "<input id='emPcrCreator' name='emPcrCreator' type='hidden' value='" + $('currentUser').innerHTML + "'/>" + $('currentUser').innerHTML;
-      var column4 = $('emPcrTable').rows[1].insertCell(-1);
+      var column3 = jQuery('emPcrTable').rows[1].insertCell(-1);
+      column3.innerHTML = "<input id='emPcrCreator' name='emPcrCreator' type='hidden' value='" + jQuery('currentUser').innerHTML + "'/>" + jQuery('currentUser').innerHTML;
+      var column4 = jQuery('emPcrTable').rows[1].insertCell(-1);
       column4.innerHTML = "<input id='emPcrDate' name='emPcrDate' type='text'/>";
-      var column5 = $('emPcrTable').rows[1].insertCell(-1);
+      var column5 = jQuery('emPcrTable').rows[1].insertCell(-1);
       column5.innerHTML = "<input id='emPcrResults' name='emPcrResults' type='text'/>";
-      var column6 = $('emPcrTable').rows[1].insertCell(-1);
+      var column6 = jQuery('emPcrTable').rows[1].insertCell(-1);
       column6.innerHTML = "<a href='javascript:void(0);' onclick='Library.empcr.addEmPcr();'/>Add</a>";
 
       Utils.ui.addMaxDatePicker("emPcrDate", 0);
     }
     else {
-      alert("Cannot add another emPCR when one is already in progress.")
+      alert("Cannot add another emPCR when one is already in progress.");
     }
   },
 
@@ -347,7 +347,7 @@ Library.empcr = {
         'results': f.emPcrResults,
         'url': ajaxurl},
       {'updateElement': 'emPcrTable',
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           jQuery('#emPcrTable').removeAttr("pcrInProgress");
         }
       }
@@ -358,27 +358,27 @@ Library.empcr = {
     if (!jQuery('#emPcrDilutionTable').attr("dilutionInProgress")) {
       jQuery('#emPcrDilutionTable').attr("dilutionInProgress", "true");
 
-      $('emPcrDilutionTable').insertRow(1);
+      jQuery('emPcrDilutionTable').insertRow(1);
 
-      var column2 = $('emPcrDilutionTable').rows[1].insertCell(-1);
+      var column2 = jQuery('emPcrDilutionTable').rows[1].insertCell(-1);
       column2.innerHTML = "" + emPcrId + " <input type='hidden' id='emPcrId' name='emPcrId' value='" + emPcrId + "'/>";
-      var column3 = $('emPcrDilutionTable').rows[1].insertCell(-1);
-      column3.innerHTML = "<input id='emPcrDilutionCreator' name='emPcrDilutionCreator' type='hidden' value='" + $('currentUser').innerHTML + "'/>" + $('currentUser').innerHTML;
-      var column4 = $('emPcrDilutionTable').rows[1].insertCell(-1);
+      var column3 = jQuery('emPcrDilutionTable').rows[1].insertCell(-1);
+      column3.innerHTML = "<input id='emPcrDilutionCreator' name='emPcrDilutionCreator' type='hidden' value='" + jQuery('currentUser').innerHTML + "'/>" + jQuery('currentUser').innerHTML;
+      var column4 = jQuery('emPcrDilutionTable').rows[1].insertCell(-1);
       column4.innerHTML = "<input id='emPcrDilutionDate' name='emPcrDilutionDate' type='text'/>";
-      var column6 = $('emPcrDilutionTable').rows[1].insertCell(-1);
+      var column6 = jQuery('emPcrDilutionTable').rows[1].insertCell(-1);
       column6.innerHTML = "<input id='emPcrDilutionResults' name='emPcrDilutionResults' type='text'/>";
-      var column7 = $('emPcrDilutionTable').rows[1].insertCell(-1);
+      var column7 = jQuery('emPcrDilutionTable').rows[1].insertCell(-1);
       column7.innerHTML = "<a href='javascript:void(0);' onclick='Library.empcr.addEmPcrDilution();'/>Add</a>";
 
       Utils.ui.addMaxDatePicker("emPcrDilutionDate", 0);
     }
     else {
-      alert("Cannot add another dilution when one is already in progress.")
+      alert("Cannot add another dilution when one is already in progress.");
     }
   },
 
-  addEmPcrDilution: function (form) {
+  addEmPcrDilution: function () {
     var f = Utils.mappifyForm("addEmPcrDilutionForm");
     Fluxion.doAjax(
       'libraryControllerHelperService',
@@ -391,36 +391,34 @@ Library.empcr = {
         'results': f.emPcrDilutionResults,
         'url': ajaxurl},
       {'updateElement': 'emPcrDilutionTable',
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           jQuery('#emPcrDilutionTable').removeAttr("dilutionInProgress");
         }
       }
     );
   },
 
-  deleteEmPCR: function (empcrId, successfunc) {
+  deleteEmPCR: function (empcrId) {
     if (confirm("Are you sure you really want to delete EmPCR " + empcrId + "? This operation is permanent!")) {
       Fluxion.doAjax(
         'libraryControllerHelperService',
         'deleteEmPCR',
         {'empcrId': empcrId, 'url': ajaxurl},
-        {'doOnSuccess': function (json) {
-          successfunc();
+        {'doOnSuccess': window.location.reload(true)
         }
-      });
+      );
     }
   },
 
-  deleteEmPCRDilution: function (empcrDilutionId, successfunc) {
+  deleteEmPCRDilution: function (empcrDilutionId) {
     if (confirm("Are you sure you really want to delete EmPCRDilution" + empcrDilutionId + "? This operation is permanent!")) {
       Fluxion.doAjax(
         'libraryControllerHelperService',
         'deleteEmPCRDilution',
         {'empcrDilutionId': empcrDilutionId, 'url': ajaxurl},
-        {'doOnSuccess': function (json) {
-          successfunc();
+        {'doOnSuccess': window.location.reload(true)
         }
-      });
+      );
     }
   }
 };
@@ -646,7 +644,6 @@ Library.ui = {
     );
   },
   changePlatformNameWithLibraryType: function (input, librarytype) {
-    var self = this;
     var platform = jQuery(input).val();
     Fluxion.doAjax(
       'libraryControllerHelperService',
@@ -660,7 +657,6 @@ Library.ui = {
     );
   },
   changePlatformNameWithTagBarcodeStrategy: function (input, tagBarcodeStrategy) {
-    var self = this;
     var platform = jQuery(input).val();
     Fluxion.doAjax(
       'libraryControllerHelperService',
@@ -717,7 +713,7 @@ Library.ui = {
             jQuery(c).html("");
             for (var i = 0; i < json.numApplicableBarcodes; i++) {
               jQuery(c).append("<span class='tagBarcodeSelectDiv' position='" + (i + 1) + "' id='tagbarcodes" + (i + 1) + "'>- <i>Select...</i></span>");
-              if (json.numApplicableBarcodes > 1 && i == 0) {
+              if (json.numApplicableBarcodes > 1 && i === 0) {
                 jQuery(c).append("|");
               }
             }
@@ -791,7 +787,7 @@ Library.ui = {
 
         if (stratText.trim()) {
           //no select means empty or already filled
-          if (firstSelText.indexOf("Select") == 0) {
+          if (firstSelText.indexOf("Select") === 0) {
             //same strategy, just copy the cell
             if (firstSelText === stratText) {
               cell.html(tdtext);
@@ -807,7 +803,7 @@ Library.ui = {
                   cell.html("");
                   for (var i = 0; i < json.numApplicableBarcodes; i++) {
                     cell.append("<span class='tagBarcodeSelectDiv' position='" + (i + 1) + "' id='tagbarcodes" + (i + 1) + "'>- <i>Select...</i></span>");
-                    if (json.numApplicableBarcodes > 1 && i == 0) {
+                    if (json.numApplicableBarcodes > 1 && i === 0) {
                       cell.append("|");
                     }
                   }

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -110,24 +110,30 @@ Utils.ui = {
 
   checkAll: function (field) {
     var self = this;
-    for (i = 0; i < self._N(field).length; i++) self._N(field)[i].checked = true;
+    for (var i = 0; i < self._N(field).length; i++) {
+      self._N(field)[i].checked = true;
+    }
   },
 
   checkAllConfirm: function (field, message) {
     if (confirm(message)) {
       var self = this;
-      for (i = 0; i < self._N(field).length; i++) self._N(field)[i].checked = true;
+      for (var i = 0; i < self._N(field).length; i++) {
+        self._N(field)[i].checked = true;
+      }
     }
   },
 
   uncheckAll: function (field) {
     var self = this;
-    for (i = 0; i < self._N(field).length; i++) self._N(field)[i].checked = false;
+    for (var i = 0; i < self._N(field).length; i++) {
+      self._N(field)[i].checked = false;
+    }
   },
 
   uncheckOthers: function (field, item) {
     var self = this;
-    for (i = 0; i < self._N(field).length; i++) {
+    for (var i = 0; i < self._N(field).length; i++) {
       if (self._N(field)[i] != item) {
         self._N(field)[i].checked = false;
       }
@@ -135,7 +141,9 @@ Utils.ui = {
   },
 
   _N: function (element) {
-    if (typeof element == 'string') element = document.getElementsByName(element);
+    if (typeof element == 'string') {
+      element = document.getElementsByName(element);
+    }
     return Element.extend(element);
   },
 
@@ -197,8 +205,6 @@ Utils.ui = {
 
 Utils.fileUpload = {
   fileUploadProgress: function (formname, divname, successfunc) {
-    var self = this;
-
     Fluxion.doAjaxUpload(
       formname,
       'fileUploadProgressBean',
@@ -387,7 +393,7 @@ Utils.page = {
   newWindow: function (url) {
     newwindow = window.open(url, 'name', 'height=500,width=500,menubar=yes,status=yes,scrollbars=yes');
     if (window.focus) {
-      newwindow.focus()
+      newwindow.focus();
     }
     return false;
   },
@@ -475,7 +481,7 @@ Utils.alert = {
         'dashboard',
         'setAllAlertsAsRead',
         {'url': ajaxurl},
-        {'doOnSuccess': function (json) {
+        {'doOnSuccess': function () {
           jQuery('#alertList').html("<i style='color: gray'>No unread alerts</i>");
           Utils.alert.checkAlerts();
         }

--- a/miso-web/src/main/webapp/scripts/multi_select_drag_drop.js
+++ b/miso-web/src/main/webapp/scripts/multi_select_drag_drop.js
@@ -52,7 +52,6 @@
               jQuery(this).addClass('dds_selected').addClass(jQuery.fn.drag_drop_selectable.settings[jQuery.fn.drag_drop_selectable.getListId(jQuery(this).attr('dds'))].selectClass);
             }).bind('dds.deselect',function () {
               jQuery(this).removeClass('dds_selected').removeClass(jQuery.fn.drag_drop_selectable.settings[jQuery.fn.drag_drop_selectable.getListId(jQuery(this).attr('dds'))].selectClass);
-              ;
             }).css({cursor: 'pointer'});
           })
         //OK so they are selectable. now I need to make them draggable, in such a way that they pick up their friends when dragged. hmmm how do I do that?
@@ -121,8 +120,7 @@
     var jQueryothers = jQuery.fn.drag_drop_selectable.getListItems(list).clone().each(function () {
       jQuery(this).not('.dds_selected').css({visibility: 'hidden'});
       jQuery(this).filter('.dds_selected').addClass(jQuery.fn.drag_drop_selectable.settings[list].moveClass).css({opacity: jQuery.fn.drag_drop_selectable.settings[list].moveOpacity});
-      ;
-      jQuery(this).attr('dds_drag', jQuery(this).attr('dds'))
+      jQuery(this).attr('dds_drag', jQuery(this).attr('dds'));
       jQuery(this).attr('dds', '');
     });
     return jQueryothers;
@@ -132,7 +130,7 @@
     var this_offset = jQueryitem.position().top;
     var first_offset = jQuery.fn.drag_drop_selectable.getListItems(jQuery.fn.drag_drop_selectable.getListId(jQueryitem.attr('dds'))).eq(0).position().top;
     return this_offset - first_offset;
-  }
+  };
 
   jQuery.fn.drag_drop_selectable.toggle = function (id) {
     if (!jQuery.fn.drag_drop_selectable.isSelected(id)) {
@@ -212,7 +210,7 @@
     onListChange: function (list) {
       console.log(list.attr('id'));
     } //called once when the list changes
-  }
+  };
   jQuery.fn.drag_drop_selectable.settings = [];
 
 
@@ -243,33 +241,33 @@
     }
     jQuery(document).keydown(function (e) {
       if (e.keyCode == CTRL_KEY) {
-        jQuery.fn.captureKeys.stack.CTRL_KEY = true
+        jQuery.fn.captureKeys.stack.CTRL_KEY = true;
       }
       if (e.keyCode == SHIFT_KEY) {
-        jQuery.fn.captureKeys.stack.SHIFT_KEY = true
+        jQuery.fn.captureKeys.stack.SHIFT_KEY = true;
       }
       if (e.keyCode == ALT_KEY) {
-        jQuery.fn.captureKeys.stack.ALT_KEY = true
+        jQuery.fn.captureKeys.stack.ALT_KEY = true;
       }
       if (e.keyCode == META_KEY) {
-        jQuery.fn.captureKeys.stack.META_KEY = true
+        jQuery.fn.captureKeys.stack.META_KEY = true;
       }
     }).keyup(function (e) {
       if (e.keyCode == CTRL_KEY) {
-        jQuery.fn.captureKeys.stack.CTRL_KEY = false
+        jQuery.fn.captureKeys.stack.CTRL_KEY = false;
       }
       if (e.keyCode == SHIFT_KEY) {
-        jQuery.fn.captureKeys.stack.SHIFT_KEY = false
+        jQuery.fn.captureKeys.stack.SHIFT_KEY = false;
       }
       if (e.keyCode == ALT_KEY) {
-        jQuery.fn.captureKeys.stack.ALT_KEY = false
+        jQuery.fn.captureKeys.stack.ALT_KEY = false;
       }
       if (e.keyCode == META_KEY) {
-        jQuery.fn.captureKeys.stack.META_KEY = false
+        jQuery.fn.captureKeys.stack.META_KEY = false;
       }
     });
   };
-  jQuery.fn.captureKeys.stack = { CTRL_KEY: false, SHIFT_KEY: false, ALT_KEY: false, META_KEY: false }
+  jQuery.fn.captureKeys.stack = { CTRL_KEY: false, SHIFT_KEY: false, ALT_KEY: false, META_KEY: false };
   jQuery.fn.captureKeys.capturing = false;
   jQuery.fn.isPressed = function (key) {
     switch (key) {
@@ -284,14 +282,14 @@
       default:
         return false;
     }
-  }
+  };
 })(jQuery);
 
 
 jQuery(function () {
   mychange = function (jQuerylist) {
     jQuery('#' + jQuerylist.attr('id') + '_serialised').html(jQuery.dds.serialize(jQuerylist.attr('id')));
-  }
+  };
 
   jQuery('.dd').find('ul').drag_drop_selectable({onListChange: mychange});
 

--- a/miso-web/src/main/webapp/scripts/natural_sort.js
+++ b/miso-web/src/main/webapp/scripts/natural_sort.js
@@ -55,7 +55,7 @@ function naturalSort(a, b) {
     if (oFxNcL > oFyNcL) return 1;
   }
   return 0;
-};
+}
 
 jQuery(document).ready(function () {
   // Natural Sorting

--- a/miso-web/src/main/webapp/scripts/parsley_form_validations.js
+++ b/miso-web/src/main/webapp/scripts/parsley_form_validations.js
@@ -24,7 +24,9 @@
 var Validate = Validate || {
   // Attach a Parsley instance to the given form
   attachParsley: function (formSelector) {
-    if (jQuery(formSelector).length > 0) jQuery(formSelector).parsley();
+    if (jQuery(formSelector).length > 0) {
+      jQuery(formSelector).parsley();
+    }
     window.Parsley.on('parsley:field:validate', function () {
       Validate.updateWarningorSubmit(formSelector);
     });

--- a/miso-web/src/main/webapp/scripts/plate_ajax.js
+++ b/miso-web/src/main/webapp/scripts/plate_ajax.js
@@ -28,7 +28,7 @@ var Plate = Plate || {
               'plateControllerHelperService',
               'deletePlate',
               {'plateId': plateId, 'url': ajaxurl},
-              {'doOnSuccess': function (json) {
+              {'doOnSuccess': function () {
                 successfunc();
               }
               }
@@ -287,10 +287,11 @@ Plate.ui = {
   processPlateUpload: function (frameId) {
     var iframe = document.getElementById(frameId);
     var iframedoc = iframe.document;
-    if (iframe.contentDocument)
-        iframedoc = iframe.contentDocument;
-    else if (iframe.contentWindow)
+    if (iframe.contentDocument) {
+      iframedoc = iframe.contentDocument;
+    } else if (iframe.contentWindow) {
         iframedoc = iframe.contentWindow.document;
+    }
     var response = jQuery(iframedoc).contents().find('body:first').find('#uploadresponsebody').val();
     if (!Utils.validation.isNullCheck(response)) {
       var json = jQuery.parseJSON(response);
@@ -315,7 +316,7 @@ Plate.ui = {
               impb.append("<ul>");
               for (var k = 0; k < plate.elements.length; k++) {
                 var library = plate.elements[k];
-                impb.append("<li>" + library.alias + "</li>")
+                impb.append("<li>" + library.alias + "</li>");
               }
               impb.append("</ul>");
               impb.append("</div>");
@@ -326,7 +327,7 @@ Plate.ui = {
     }
     else {
       setTimeout(function () {
-        Plate.ui.processPlateUpload(frameId)
+        Plate.ui.processPlateUpload(frameId);
       }, 2000);
     }
   },
@@ -341,10 +342,11 @@ Plate.ui = {
     Utils.ui.disableButton("saveImportedElementsButton");
     var iframe = document.getElementById(frameId);
     var iframedoc = iframe.document;
-    if (iframe.contentDocument)
+    if (iframe.contentDocument) {
         iframedoc = iframe.contentDocument;
-    else if (iframe.contentWindow)
+    } else if (iframe.contentWindow) {
         iframedoc = iframe.contentWindow.document;
+    }
     var response = jQuery(iframedoc).contents().find('body:first').find('#uploadresponsebody').val();
     if (!Utils.validation.isNullCheck(response)) {
       var json = jQuery.parseJSON(response);

--- a/miso-web/src/main/webapp/scripts/pool_ajax.js
+++ b/miso-web/src/main/webapp/scripts/pool_ajax.js
@@ -28,7 +28,7 @@ var Pool = Pool || {
         'poolControllerHelperService',
         'deletePool',
         {'poolId':poolId, 'url':ajaxurl},
-        {'doOnSuccess':function(json) {
+        {'doOnSuccess':function() {
           successfunc();
         }
         }
@@ -83,22 +83,22 @@ Pool.qc = {
     if (!jQuery('#poolQcTable').attr("qcInProgress")) {
       jQuery('#poolQcTable').attr("qcInProgress", "true");
 
-      $('poolQcTable').insertRow(1);
+      jQuery('poolQcTable').insertRow(1);
       //QCId  QCed By  	QC Date  	Method  	Results
 
       if (includeId) {
-        var column1 = $('poolQcTable').rows[1].insertCell(-1);
+        var column1 = jQuery('poolQcTable').rows[1].insertCell(-1);
         column1.innerHTML = "<input type='hidden' id='poolId' name='poolId' value='" + poolId + "'/>";
       }
-      var column2 = $('poolQcTable').rows[1].insertCell(-1);
-      column2.innerHTML = "<input id='poolQcUser' name='poolQcUser' type='hidden' value='" + $('currentUser').innerHTML + "'/>" + $('currentUser').innerHTML;
-      var column3 = $('poolQcTable').rows[1].insertCell(-1);
+      var column2 = jQuery('poolQcTable').rows[1].insertCell(-1);
+      column2.innerHTML = "<input id='poolQcUser' name='poolQcUser' type='hidden' value='" + jQuery('currentUser').innerHTML + "'/>" + jQuery('currentUser').innerHTML;
+      var column3 = jQuery('poolQcTable').rows[1].insertCell(-1);
       column3.innerHTML = "<input id='poolQcDate' name='poolQcDate' type='text'/>";
-      var column4 = $('poolQcTable').rows[1].insertCell(-1);
+      var column4 = jQuery('poolQcTable').rows[1].insertCell(-1);
       column4.innerHTML = "<select id='poolQcType' name='poolQcType' onchange='Pool.qc.changePoolQcUnits(this);'/>";
-      var column5 = $('poolQcTable').rows[1].insertCell(-1);
+      var column5 = jQuery('poolQcTable').rows[1].insertCell(-1);
       column5.innerHTML = "<input id='poolQcResults' name='poolQcResults' type='text'/><span id='units'/>";
-      var column6 = $('poolQcTable').rows[1].insertCell(-1);
+      var column6 = jQuery('poolQcTable').rows[1].insertCell(-1);
       column6.innerHTML = "<a href='javascript:void(0);' onclick='Pool.qc.addPoolQC();'/>Add</a>";
 
       Utils.ui.addMaxDatePicker("poolQcDate", 0);
@@ -115,11 +115,11 @@ Pool.qc = {
       );
     }
     else {
-      alert("Cannot add another QC when one is already in progress.")
+      alert("Cannot add another QC when one is already in progress.");
     }
   },
 
-  changePoolQcUnits : function(input) {
+  changePoolQcUnits : function() {
     jQuery('#units').html(jQuery('#poolQcType').find(":selected").attr("units"));
   },
 
@@ -137,7 +137,7 @@ Pool.qc = {
         'url':ajaxurl
       },
       {'updateElement':'poolQcTable',
-        'doOnSuccess':function(json) {
+        'doOnSuccess':function() {
           jQuery('#poolQcTable').removeAttr("qcInProgress");
         }
       }
@@ -182,14 +182,14 @@ Pool.wizard = {
     if (!jQuery('#poolQcTable').attr("qcInProgress")) {
       jQuery('#poolQcTable').attr("qcInProgress", "true");
 
-      $('poolQcTable').insertRow(1);
-      var column3 = $('poolQcTable').rows[1].insertCell(-1);
+      jQuery('poolQcTable').insertRow(1);
+      var column3 = jQuery('poolQcTable').rows[1].insertCell(-1);
       column3.innerHTML = "<input id='poolQcDate' name='poolQcDate' type='text'/>";
-      var column4 = $('poolQcTable').rows[1].insertCell(-1);
+      var column4 = jQuery('poolQcTable').rows[1].insertCell(-1);
       column4.innerHTML = "<select id='poolQcType' name='poolQcType' onchange='Pool.qc.changePoolQcUnits(this);'/>";
-      var column5 = $('poolQcTable').rows[1].insertCell(-1);
+      var column5 = jQuery('poolQcTable').rows[1].insertCell(-1);
       column5.innerHTML = "<input id='poolQcResults' name='poolQcResults' type='text'/><span id='units'/>";
-      var column6 = $('poolQcTable').rows[1].insertCell(-1);
+      var column6 = jQuery('poolQcTable').rows[1].insertCell(-1);
       column6.innerHTML = "<a href='javascript:void(0);' onclick='Pool.wizard.addPoolQC(this);'/>Add</a>";
 
       jQuery("#poolQcDate").val(jQuery.datepicker.formatDate('dd/mm/yy', new Date()));
@@ -207,7 +207,7 @@ Pool.wizard = {
       );
     }
     else {
-      alert("Cannot add another QC when one is already in progress.")
+      alert("Cannot add another QC when one is already in progress.");
     }
   },
 
@@ -260,7 +260,7 @@ Pool.ui = {
     );
   },
 
-  dilutionFileUploadSuccessFunc : function(json) {
+  dilutionFileUploadSuccessFunc : function() {
     Fluxion.doAjax(
       'poolControllerHelperService',
       'selectDilutionsByBarcodeFile',
@@ -283,7 +283,7 @@ Pool.ui = {
   },
 
   /** Deprecated */
-  libraryDilutionFileUploadSuccessFunc : function(json) {
+  libraryDilutionFileUploadSuccessFunc : function() {
     Fluxion.doAjax(
       'poolControllerHelperService',
       'selectLibraryDilutionsByBarcodeFile',
@@ -306,7 +306,7 @@ Pool.ui = {
   },
 
   /** Deprecated */
-  ls454EmPcrDilutionFileUploadSuccessFunc : function(json) {
+  ls454EmPcrDilutionFileUploadSuccessFunc : function() {
     Fluxion.doAjax(
       'poolControllerHelperService',
       'select454EmPCRDilutionsByBarcodeFile',
@@ -329,7 +329,7 @@ Pool.ui = {
   },
 
   /** Deprecated */
-  solidEmPcrDilutionFileUploadSuccessFunc : function(json) {
+  solidEmPcrDilutionFileUploadSuccessFunc : function() {
     Fluxion.doAjax(
       'poolControllerHelperService',
       'selectSolidEmPCRDilutionsByBarcodeFile',
@@ -349,7 +349,7 @@ Pool.ui = {
       {
         'doOnSuccess': function(json) {
           jQuery.each(json, function(i, val) {
-            jQuery('#average' + i).html(val)
+            jQuery('#average' + i).html(val);
           });
         }
       }

--- a/miso-web/src/main/webapp/scripts/printer_ajax.js
+++ b/miso-web/src/main/webapp/scripts/printer_ajax.js
@@ -48,7 +48,7 @@ Print.ui = {
 
   editPrinterService : function(serviceName) {
     var schema='';
-    if(!jQuery('#newschema-' + serviceName).length == 0) {
+    if(jQuery('#newschema-' + serviceName).length !== 0) {
       schema =  jQuery('#newschema-' + serviceName+' option:selected').val();
     }
     Fluxion.doAjax(
@@ -88,26 +88,26 @@ Print.ui = {
 
       jQuery('#printerTable tr:first').append("<th>Printable Entity</th><th>Available</th><th></th>");
 
-      $('printerTable').insertRow(1);
+      jQuery('printerTable').insertRow(1);
 
-      var column1 = $('printerTable').rows[1].insertCell(-1);
+      var column1 = jQuery('printerTable').rows[1].insertCell(-1);
       column1.innerHTML = "<input id='serviceName' name='serviceName' type='text'/>";
-      var column2 = $('printerTable').rows[1].insertCell(-1);
+      var column2 = jQuery('printerTable').rows[1].insertCell(-1);
       column2.innerHTML = "<i>Set in context fields</i>";
-      var column3 = $('printerTable').rows[1].insertCell(-1);
+      var column3 = jQuery('printerTable').rows[1].insertCell(-1);
       column3.innerHTML = "<select id='contexts' name='context' onchange='Print.ui.getContextFieldsForContext(this)'>" +json.contexts+ "</select><br/><div id='contextFields' name='contextFields'/>";
-      var column4 = $('printerTable').rows[1].insertCell(-1);
+      var column4 = jQuery('printerTable').rows[1].insertCell(-1);
       column4.innerHTML = "<select id='barcodableSchemas' name='printSchema'>" +json.barcodableSchemas+ "</select>";
-      var column5 = $('printerTable').rows[1].insertCell(-1);
+      var column5 = jQuery('printerTable').rows[1].insertCell(-1);
       column5.innerHTML = "<select id='barcodables' name='printServiceFor'>" +json.barcodables+ "</select>";
-      var column6 = $('printerTable').rows[1].insertCell(-1);
+      var column6 = jQuery('printerTable').rows[1].insertCell(-1);
       column6.innerHTML = "<div id='available'></div>";
-      var column7 = $('printerTable').rows[1].insertCell(-1);
+      var column7 = jQuery('printerTable').rows[1].insertCell(-1);
       column7.id = "addTd";
       column7.innerHTML = "Add";
     }
     else {
-      alert("Cannot add another printer service when one is already in progress.")
+      alert("Cannot add another printer service when one is already in progress.");
     }
   },
 
@@ -130,16 +130,18 @@ Print.ui = {
         jQuery('#contextFields').append(key +": <input id='contextField-"+key+"' field='"+key+"' type='text' value='"+fields[key]+"'/><br/>");
       }
     }
-    jQuery('#contextField-host').keyup(function() { Print.service.validatePrinter(this) });
+    jQuery('#contextField-host').keyup(function() { Print.service.validatePrinter(this); });
   }
 };
 
 Print.service = {
   validatePrinter : function(t) {
-    $('available').innerHTML="<div align='center'><img src='../../styles/images/ajax-loader.gif'/></div>";
+    jQuery('available').innerHTML="<div align='center'><img src='../../styles/images/ajax-loader.gif'/></div>";
 
     if (t.value != t.lastValue) {
-      if (t.timer) clearTimeout(t.timer);
+      if (t.timer) {
+        clearTimeout(t.timer);
+      }
 
       t.timer = setTimeout(function () {
         Fluxion.doAjax(
@@ -147,13 +149,13 @@ Print.service = {
           'checkPrinterAvailability',
           {'host':t.value, 'url':ajaxurl},
           {"doOnSuccess": function(json) {
-            $('available').innerHTML = json.html;
+            jQuery('available').innerHTML = json.html;
             if (json.html == "OK") {
-              $('available').setAttribute("style", "background-color:green");
-              $('addTd').innerHTML = "<a href='javascript:void(0);' onclick='Print.service.addPrinterService();'/>Add</a>";
+              jQuery('available').setAttribute("style", "background-color:green");
+              jQuery('addTd').innerHTML = "<a href='javascript:void(0);' onclick='Print.service.addPrinterService();'/>Add</a>";
             }
             else {
-              $('available').setAttribute("style", "background-color:red");
+              jQuery('available').setAttribute("style", "background-color:red");
             }
           }
         });
@@ -167,7 +169,7 @@ Print.service = {
 
     var f = Utils.mappifyForm("addPrinterForm");
     var cf = {};
-    jQuery('input[id*="contextField-"]').each(function(e) {
+    jQuery('input[id*="contextField-"]').each(function() {
       var field = jQuery(this).attr("field");
       cf[field] = jQuery(this).val();
     });

--- a/miso-web/src/main/webapp/scripts/project_ajax.js
+++ b/miso-web/src/main/webapp/scripts/project_ajax.js
@@ -59,7 +59,9 @@ var Project = Project || {
   validate_sample_qcs: function (json) {
     var ok = true;
     for (var i = 0; i < json.length; i++) {
-      if(!json[i].results.match(/[0-9\.]+/)) ok = false;
+      if(!json[i].results.match(/[0-9\.]+/)) {
+        ok = false;
+      }
     }
     return ok;
   },
@@ -67,7 +69,9 @@ var Project = Project || {
   validate_empcrs: function (json) {
     var ok = true;
     for (var i = 0; i < json.length; i++) {
-      if(!json[i].results.match(/[0-9\.]+/)) ok = false;
+      if(!json[i].results.match(/[0-9\.]+/)) {
+        ok = false;
+      }
     }
     return ok;
   },
@@ -75,7 +79,9 @@ var Project = Project || {
   validate_empcr_dilutions: function (json) {
     var ok = true;
     for (var i = 0; i < json.length; i++) {
-      if(!json[i].results.match(/[0-9\.]+/)) ok = false;
+      if(!json[i].results.match(/[0-9\.]+/)) {
+        ok = false;
+      }
     }
     return ok;
   }
@@ -107,7 +113,7 @@ Project.ui = {
       },
       {'doOnSuccess': function (json) {
         jQuery.each(json, function (i, val) {
-          jQuery('#pro' + i + 'overview').html(val)
+          jQuery('#pro' + i + 'overview').html(val);
         });
       }
       }
@@ -290,10 +296,11 @@ Project.ui = {
   processPlateUpload: function (frameId) {
     var iframe = document.getElementById(frameId);
     var iframedoc = iframe.document;
-    if (iframe.contentDocument)
+    if (iframe.contentDocument) {
       iframedoc = iframe.contentDocument;
-    else if (iframe.contentWindow)
+    } else if (iframe.contentWindow) {
       iframedoc = iframe.contentWindow.document;
+    }
     var response = jQuery(iframedoc).contents().find('body:first').find('#uploadresponsebody').val();
     if (!Utils.validation.isNullCheck(response)) {
       var json = jQuery.parseJSON(response);
@@ -313,7 +320,7 @@ Project.ui = {
               impb.append("<ul>");
               for (var k = 0; k < plate.elements.length; k++) {
                 var library = plate.elements[k];
-                impb.append("<li>" + library.alias + "</li>")
+                impb.append("<li>" + library.alias + "</li>");
               }
               impb.append("</ul>");
             }
@@ -324,7 +331,7 @@ Project.ui = {
     }
     else {
       setTimeout(function () {
-        Project.ui.processPlateUpload(frameId)
+        Project.ui.processPlateUpload(frameId);
       }, 2000);
     }
   },
@@ -338,10 +345,11 @@ Project.ui = {
   saveImportedElements: function (frameId) {
     var iframe = document.getElementById(frameId);
     var iframedoc = iframe.document;
-    if (iframe.contentDocument)
+    if (iframe.contentDocument) {
       iframedoc = iframe.contentDocument;
-    else if (iframe.contentWindow)
+    } else if (iframe.contentWindow) {
       iframedoc = iframe.contentWindow.document;
+    }
     var response = jQuery(iframedoc).contents().find('body:first').find('#uploadresponsebody').val();
     if (!Utils.validation.isNullCheck(response)) {
       var json = jQuery.parseJSON(response);
@@ -418,8 +426,8 @@ Project.ui = {
         var at = jQuery(this).attr("name");
         obj[at] = jQuery(this).text();
       });
-      obj["qcCreator"] = jQuery('#currentUser').text();
-      obj["sampleId"] = obj["name"].substring(3);
+      obj.qcCreator = jQuery('#currentUser').text();
+      obj.sampleId = obj.name.substring(3);
       aReturn.push(obj);
     }
 
@@ -472,10 +480,10 @@ Project.ui = {
     if (json.errors) {
       var errors = json.errors;
       var errorStr = "";
-      for (var i = 0; i < errors.length; i++) {
-        errorStr += errors[i].error + "\n";
+      for (var j = 0; j < errors.length; j++) {
+        errorStr += errors[j].error + "\n";
         jQuery(tableName).find("tr:gt(0)").each(function () {
-          if (jQuery(this).attr("sampleId") === errors[i].sampleId) {
+          if (jQuery(this).attr("sampleId") === errors[j].sampleId) {
             jQuery(this).find("td").each(function () {
               jQuery(this).css('background', '#EE9966');
             });
@@ -503,8 +511,8 @@ Project.ui = {
         var at = jQuery(this).attr("name");
         obj[at] = jQuery(this).text();
       });
-      obj["pcrCreator"] = jQuery('#currentUser').text();
-      obj["dilutionId"] = obj["dilName"].substring(3);
+      obj.pcrCreator = jQuery('#currentUser').text();
+      obj.dilutionId = obj.dilName.substring(3);
       aReturn.push(obj);
     }
     if (aReturn.length > 0) {
@@ -555,10 +563,10 @@ Project.ui = {
     if (json.errors) {
       var errors = json.errors;
       var errorStr = "";
-      for (var i = 0; i < errors.length; i++) {
-        errorStr += errors[i].error + "\n";
+      for (var j = 0; j < errors.length; j++) {
+        errorStr += errors[j].error + "\n";
         jQuery('#librarydils_table').find("tr:gt(0)").each(function () {
-          if (jQuery(this).attr("dilutionId") === errors[i].dilutionId) {
+          if (jQuery(this).attr("dilutionId") === errors[j].dilutionId) {
             jQuery(this).find("td").each(function () {
               jQuery(this).css('background', '#EE9966');
             });
@@ -586,8 +594,8 @@ Project.ui = {
         var at = jQuery(this).attr("name");
         obj[at] = jQuery(this).text();
       });
-      obj["pcrDilutionCreator"] = jQuery('#currentUser').text();
-      obj["pcrId"] = obj["pcrName"].substring(3);
+      obj.pcrDilutionCreator= jQuery('#currentUser').text();
+      obj.pcrId= obj.pcrName.substring(3);
       aReturn.push(obj);
     }
 
@@ -638,10 +646,10 @@ Project.ui = {
     if (json.errors) {
       var errors = json.errors;
       var errorStr = "";
-      for (var i = 0; i < errors.length; i++) {
-        errorStr += errors[i].error + "\n";
+      for (var j = 0; j < errors.length; j++) {
+        errorStr += errors[j].error + "\n";
         jQuery('#empcrs_table').find("tr:gt(0)").each(function () {
-          if (jQuery(this).attr("pcrId") === errors[i].pcrId) {
+          if (jQuery(this).attr("pcrId") === errors[j].pcrId) {
             jQuery(this).find("td").each(function () {
               jQuery(this).css('background', '#EE9966');
             });
@@ -666,7 +674,7 @@ Project.ui = {
 
       jQuery(tableId + ' tbody').find("tr").each(function () {
           // remove received samples
-          if (jQuery(this).find("td:eq(4)").html() == "") {
+          if (jQuery(this).find("td:eq(4)").html() === "") {
             jQuery(this).removeAttr("onmouseover").removeAttr("onmouseout");
             jQuery(this).find("td:eq(4)").remove();
           }
@@ -1091,7 +1099,7 @@ Project.issues = {
 
   importIssue: function (json) {
     if (json.invalidIssues === "undefined" ||
-        json.invalidIssues.length == 0 &&
+        json.invalidIssues.length === 0 &&
         json.validIssues !== "undefined" &&
         json.validIssues.length > 0) {
       var key = json.validIssues[0].key;
@@ -1197,29 +1205,29 @@ Project.issues = {
         jQuery('#issuebox' + i).append("<b>Created:</b> " + issue.created + "<br/>");
         jQuery('#issuebox' + i).append("<b>Updated:</b> " + issue.updated + "<br/>");
 
-        if (issue["issuelinks"].length > 0) {
+        if (issue.issuelinks.length > 0) {
           jQuery('#issuebox' + i).append("<h4>Links</h4>");
-          for (var j = 0; j < issue["issuelinks"].length; j++) {
-            var link = issue["issuelinks"][j];
+          for (var j = 0; j < issue.issuelinks.length; j++) {
+            var link = issue.issuelinks[j];
             jQuery('#issuebox' + i).append(link.type.outward + " <a href='javascript:void(0);' onclick=\"Utils.page.newWindow('" + link.url + "');\">" + link.url + "</a><br/>");
           }
         }
 
         if (issue["sub-tasks"].value.length > 0) {
           jQuery('#issuebox' + i).append("<h4>Subtasks</h4>");
-          for (var j = 0; j < issue["subtasks"].length; j++) {
-            var subtask = issue["subtasks"][j];
+          for (var k = 0; k < issue.subtasks.length; k++) {
+            var subtask = issue.subtasks[k];
             jQuery('#issuebox' + i).append("<a href='javascript:void(0);' onclick=\"Utils.page.newWindow('" + subtask.url + "');\">" + subtask.url + "</a><br/>");
           }
         }
 
         jQuery('#issuebox' + i).append("<h4>Comments</h4>");
-        for (var k = 0; k < issue["comment"]["comments"].length; k++) {
-          var comment = issue["comment"]["comments"][k];
-          jQuery('#issuebox' + i).append("<div id='commentbox" + i + "_" + k + "' class='simplebox backwhite' onclick=\"Utils.page.newWindow('" + comment.url + "');\">");
-          jQuery('#commentbox' + i + "_" + k).append("<a href='javascript:void(0);' onclick=\"Utils.page.newWindow('" + comment.author.url + "');\">" + comment.author.displayName + "</a>");
-          jQuery('#commentbox' + i + "_" + k).append(" at " + comment.created + "<br/>");
-          jQuery('#commentbox' + i + "_" + k).append("<pre class='wrap'>" + comment.body + "</pre>");
+        for (var m = 0; m < issue.comment.comments.length; m++) {
+          var comment = issue.comment.comments[m];
+          jQuery('#issuebox' + i).append("<div id='commentbox" + i + "_" + m + "' class='simplebox backwhite' onclick=\"Utils.page.newWindow('" + comment.url + "');\">");
+          jQuery('#commentbox' + i + "_" + m).append("<a href='javascript:void(0);' onclick=\"Utils.page.newWindow('" + comment.author.url + "');\">" + comment.author.displayName + "</a>");
+          jQuery('#commentbox' + i + "_" + m).append(" at " + comment.created + "<br/>");
+          jQuery('#commentbox' + i + "_" + m).append("<pre class='wrap'>" + comment.body + "</pre>");
         }
 
         jQuery('#issuebox' + i).append("<input type='hidden' name='issueKeys' id='issueKeys" + i + "' value='" + key + "'" + "><hr/>");
@@ -1681,7 +1689,7 @@ Project.alert = {
         'overviewId': overviewId,
         'url': ajaxurl
       },
-      {'doOnSuccess': function (json) {
+      {'doOnSuccess': function () {
         Utils.page.pageReload();
       }
       }
@@ -1696,7 +1704,7 @@ Project.alert = {
         'overviewId': overviewId,
         'url': ajaxurl
       },
-      {'doOnSuccess': function (json) {
+      {'doOnSuccess': function () {
         Utils.page.pageReload();
       }
       }

--- a/miso-web/src/main/webapp/scripts/project_ajax.js
+++ b/miso-web/src/main/webapp/scripts/project_ajax.js
@@ -21,6 +21,9 @@
  * *********************************************************************
  */
 
+// these variables are set on the editProject page if the project has samples/libraries
+var projectId_sample, sampleQcTypesString, libraryQcTypesString, projectId_d3graph;
+
 var Project = Project || {
   validateProject: function () {
     Validate.cleanFields('#project-form');

--- a/miso-web/src/main/webapp/scripts/runCalendar.js
+++ b/miso-web/src/main/webapp/scripts/runCalendar.js
@@ -22,7 +22,7 @@
  */
 
 var width;
-var date = new Date;
+var date = new Date();
 //Default Selection
 var cellwidth;
 var tempcolour = ["#1f77b4", "#aec7e8", "#ff7f0e", "#ffbb78", "#2ca02c", "#98df8a", "#d62728", "#ff9896", "#9467bd", "#c5b0d5", "#8c564b", "#c49c94", "#e377c2", "#f7b6d2", "#7f7f7f", "#c7c7c7", "#bcbd22", "#dbdb8d", "#17becf", "#9edae5" ];
@@ -70,7 +70,7 @@ function init(selectedYear, machine, numberofmachine) {
       return d;
     });
     data = datanew;
-    drawCalendar(selectedYear, machine, numberofmachine)
+    drawCalendar(selectedYear, machine, numberofmachine);
   });
 }
 
@@ -87,11 +87,13 @@ function drawCalendar(selectedYear, machine, numberofmachine) {
   var currentTime = new Date();
   range_start = Number(currentTime.getFullYear());
   range_stop = parseInt(range_start) + 1;
+  
+  var month_filter_start, month_filter_stop, date_filter_start, date_filter_stop;
 
   if (selectedYear == "lweek") {
-    var month_filter_start = parseInt(currentTime.getMonth()) + 1;
-    var month_filter_stop = parseInt(currentTime.getMonth()) + 1;
-    var date_filter_start = currentTime.getDate() - 7;
+    month_filter_start = parseInt(currentTime.getMonth()) + 1;
+    month_filter_stop = parseInt(currentTime.getMonth()) + 1;
+    date_filter_start = currentTime.getDate() - 7;
     if (date_filter_start < 1) {
       month_filter_start -= 1;
       date_filter_start += daysInMonth(month_filter_start, currentTime.getFullYear());
@@ -99,23 +101,21 @@ function drawCalendar(selectedYear, machine, numberofmachine) {
     if (month_filter_start < 1) {
       range_start -= 1;
     }
-    var date_filter_stop = currentTime.getDate();
-  }
-  else if (selectedYear == "lmonth") {
-    var month_filter_start = parseInt(currentTime.getMonth());
-    var month_filter_stop = parseInt(currentTime.getMonth()) + 1;
-    var date_filter_start = currentTime.getDate();
+    date_filter_stop = currentTime.getDate();
+  } else if (selectedYear == "lmonth") {
+    month_filter_start = parseInt(currentTime.getMonth());
+    month_filter_stop = parseInt(currentTime.getMonth()) + 1;
+    date_filter_start = currentTime.getDate();
 
-    var date_filter_stop = currentTime.getDate();
+    date_filter_stop = currentTime.getDate();
     range_start = Number(currentTime.getFullYear());
     range_stop = parseInt(range_start) + 1;
     if (month_filter_start < 1) {
       range_start -= 1;
     }
-  }
-  else if (selectedYear == "l3month") {
-    var month_filter_start = currentTime.getMonth() - 2; // +1 -3
-    var month_filter_stop = parseInt(currentTime.getMonth()) + 1;
+  } else if (selectedYear == "l3month") {
+    month_filter_start = currentTime.getMonth() - 2; // +1 -3
+    month_filter_stop = parseInt(currentTime.getMonth()) + 1;
     range_start = Number(currentTime.getFullYear());
     range_stop = parseInt(range_start) + 1;
 
@@ -123,45 +123,41 @@ function drawCalendar(selectedYear, machine, numberofmachine) {
       range_start -= 1;
       month_filter_start = 12 + month_filter_start;
     }
-    var date_filter_start = currentTime.getDate();
-    var date_filter_stop = currentTime.getDate();
-  }
-  else if (selectedYear == "l6month") {
-    var month_filter_start = currentTime.getMonth() - 5; // +1 -3
-    var month_filter_stop = parseInt(currentTime.getMonth()) + 1;
+    date_filter_start = currentTime.getDate();
+    date_filter_stop = currentTime.getDate();
+  } else if (selectedYear == "l6month") {
+    month_filter_start = currentTime.getMonth() - 5; // +1 -3
+    month_filter_stop = parseInt(currentTime.getMonth()) + 1;
     range_start = Number(currentTime.getFullYear());
     range_stop = parseInt(range_start) + 1;
     if (month_filter_start < 1) {
       range_start -= 1;
       month_filter_start = 12 + month_filter_start;
     }
-    var date_filter_start = currentTime.getDate();
-    var date_filter_stop = currentTime.getDate();
-  }
-  else if (selectedYear == "cyear") {
-    var month_filter_start = "01";
-    var month_filter_stop = parseInt(currentTime.getMonth()) + 1;
-    var date_filter_start = "01"
-    var date_filter_stop = currentTime.getDate();
+    date_filter_start = currentTime.getDate();
+    date_filter_stop = currentTime.getDate();
+  } else if (selectedYear == "cyear") {
+    month_filter_start = "01";
+    month_filter_stop = parseInt(currentTime.getMonth()) + 1;
+    date_filter_start = "01";
+    date_filter_stop = currentTime.getDate();
     range_start = Number(currentTime.getFullYear());
     range_stop = parseInt(range_start) + 1;
-  }
-  else if (selectedYear == "lyear") {
-    var month_filter_start = "01";
-    var month_filter_stop = "12";
-    var date_filter_start = "01"
-    var date_filter_stop = "31";
+  } else if (selectedYear == "lyear") {
+    month_filter_start = "01";
+    month_filter_stop = "12";
+    date_filter_start = "01";
+    date_filter_stop = "31";
     range_start = Number(currentTime.getFullYear()) - 1;
     range_stop = parseInt(range_start) + 1;
-  }
-  else if (selectedYear == "custom") {
-    if (jQuery("#calendarfrom").val() != "" && jQuery("#calendarto").val()) {
+  } else if (selectedYear == "custom") {
+    if (jQuery("#calendarfrom").val() !== "" && jQuery("#calendarto").val()) {
       var calendarfrom = jQuery("#calendarfrom").val().split("-");
       var calendarto = jQuery("#calendarto").val().split("-");
-      var month_filter_start = calendarfrom[1];
-      var month_filter_stop = calendarto[1];
-      var date_filter_start = calendarfrom[0];
-      var date_filter_stop = calendarto[0];
+      month_filter_start = calendarfrom[1];
+      month_filter_stop = calendarto[1];
+      date_filter_start = calendarfrom[0];
+      date_filter_stop = calendarto[0];
       range_start = calendarfrom[2];
       range_stop = Number(calendarto[2]) + 1;
     }
@@ -175,7 +171,7 @@ function drawCalendar(selectedYear, machine, numberofmachine) {
   }
 
   instrument = machine;
-  if (machine == 0) {
+  if (machine === 0) {
     noofmachine = Number(numberofmachine) + 1;
   }
   else {
@@ -190,7 +186,7 @@ function drawCalendar(selectedYear, machine, numberofmachine) {
   }
 
   function eachCalendar(start, stop, data) {
-    var temp_data = data
+    var temp_data = data;
     temp_range_start = start;
     temp_range_stop = stop;
 
@@ -453,67 +449,55 @@ function drawCalendar(selectedYear, machine, numberofmachine) {
 
 //fill if months are diff
 function findWidth(g) {
+  var i, j;
 
   if (g.Stop == "null") {
     if (g.Health == "Running") {
-      var date = new Date;
+      var date = new Date();
       g.Stop = date.getFullYear() + "-" + (date.getMonth() + 1) + "-" + date.getDate();
       findWidth(g);
-    }
-    else {
+    } else {
       return (z - 1);
     }
-  }
-  else if (g.Stop == "null") {
+  } else if (g.Stop == "null") {
     return (z - 1);
-  }
-  else if (getmonth(g.Stop) == getmonth(g.Start) && getyear(g.Stop) == getyear(g.Start) && getyear(g.Start) == temp_range_start) {
-
+  } else if (getmonth(g.Stop) == getmonth(g.Start) && getyear(g.Stop) == getyear(g.Start) && getyear(g.Start) == temp_range_start) {
     return((getdate(g.Stop) - getdate(g.Start) + 1) * z - 1);
-
-  }
-  else if (getyear(g.Stop) == getyear(g.Start) && getyear(g.Stop) == temp_range_start) {
-    var i = getmonth(g.Start);
-    var j = getmonth(g.Stop);
+  } else if (getyear(g.Stop) == getyear(g.Start) && getyear(g.Stop) == temp_range_start) {
+    i = getmonth(g.Start);
+    j = getmonth(g.Stop);
 
     for (i; i < j; i++) {
       if ((j - i) >= 2) {
         fillTheRest((daysInMonth((Number(i) + 1), getyear(g.Start))), g.Instrument, g, g.Description);
-      }
-      else {
+      } else {
         fillTheRest(getdate(g.Stop), (Number(i) + 1), g.Instrument, g, g.Description);
       }
     }
-
     return ((daysInMonth(getmonth(g.Start), getyear(g.Start)) - getdate(g.Start) + 1) * z - 1);
-  }
-  else if (getyear(g.Stop) > temp_range_start) {
-    var i = getmonth(g.Start);
-    var j = 12;
+ 
+  } else if (getyear(g.Stop) > temp_range_start) {
+    i = getmonth(g.Start);
+    j = 12;
     for (i; i < j; i++) {
       if ((j - i) >= 2) {
         fillTheRest((daysInMonth((Number(i) + 1), getyear(g.Start))), g.Instrument, g, g.Description);
-      }
-      else {
+      } else {
         fillTheRest(daysInMonth(12), (Number(i) + 1), g.Instrument, g, g.Description);
       }
     }
-
     return ((daysInMonth(getmonth(g.Start), getyear(g.Start)) - getdate(g.Start) + 1) * z - 1);
-  }
-  else {
-    var i = getmonth(g.Stop) - 1;
-    var j = 1;
+  
+  } else {
+    i = getmonth(g.Stop) - 1;
+    j = 1;
     for (i; i >= j; i--) {
       if ((i - j) >= 1) {
         fillTheBegin((daysInMonth((Number(i)), getyear(g.Start))), g.Instrument, g, g.Description);
-      }
-      else {
+      } else {
         fillTheBegin(daysInMonth(1), (Number(1)), g.Instrument, g, g.Description);
       }
     }
-
-
     return (getdate(g.Stop) * z - 1);
   }
 }
@@ -537,12 +521,10 @@ function fillTheRest(date, month, Instrument, g, Description) {
 
                     if (flowcell == 2 && temp == 2) {
                       return ("yellow");
-                    }
-                    else {
+                    } else {
                       return ("green");
                     }
-                  }
-                  else {
+                  } else {
                     return tempcolour[Instrument];
                   }
                 })
@@ -567,13 +549,11 @@ function fillTheRest(date, month, Instrument, g, Description) {
                     }
                     if (flowcell == 2 && temp == 2) {
                       return(((month - 1) * z) + (z / (noofmachine * flowcell)) + 1 );
-                    }
-                    else {
+                    } else {
                       return(((month - 1) * z) + 1);
                     }
-                  }
-                  else {
-                    return((month - 1) * z + (Instrument) * z / noofmachine + 1 )
+                  } else {
+                    return((month - 1) * z + (Instrument) * z / noofmachine + 1 );
                   }
                 })
           .append("svg:title")
@@ -600,12 +580,10 @@ function fillTheBegin(date, month, Instrument, g, Description) {
 
                     if (flowcell == 2 && temp == 2) {
                       return ("yellow");
-                    }
-                    else {
+                    } else {
                       return ("green");
                     }
-                  }
-                  else {
+                  } else {
                     return tempcolour[Instrument];
                   }
                 })
@@ -630,13 +608,11 @@ function fillTheBegin(date, month, Instrument, g, Description) {
                     }
                     if (flowcell == 2 && temp == 2) {
                       return(((month - 1) * z) + (z / (noofmachine * flowcell)) + 1 );
-                    }
-                    else {
+                    } else {
                       return(((month - 1) * z) + 1);
                     }
-                  }
-                  else {
-                    return((month - 1) * z + (Instrument) * z / noofmachine + 1)
+                  } else {
+                    return((month - 1) * z + (Instrument) * z / noofmachine + 1);
                   }
 
                 })
@@ -662,9 +638,9 @@ function monthPath(t0) {
 //count days in each month
 function daysInMonth(month, year) {
   var m = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  if (month != 2)return m[month - 1];
-  if (year % 4 != 0)return m[1];
-  if (year % 100 == 0 && year % 400 != 0)return m[1];
+  if (month != 2) return m[month - 1];
+  if (year % 4 !== 0) return m[1];
+  if (year % 100 === 0 && year % 400 !== 0) return m[1];
   return m[1] + 1;
 }
 

--- a/miso-web/src/main/webapp/scripts/run_ajax.js
+++ b/miso-web/src/main/webapp/scripts/run_ajax.js
@@ -105,7 +105,7 @@ var Run = Run || {
     if (!Utils.validation.isNullCheck(statusVal)) {
       if (statusVal === "Failed" || statusVal === "Stopped") {
         alert("You are manually setting a run to Stopped or Failed. Please remember to enter a Completion Date!");
-        if (jQuery("#completionDate input").length == 0) {
+        if (jQuery("#completionDate input").length === 0) {
           jQuery("#completionDate").html("<input type='text' name='status.completionDate' id='status.completionDate' value='" + jQuery('#completionDate').html() + "'>");
           Utils.ui.addDatePicker("status\\.completionDate");
         }
@@ -137,26 +137,26 @@ Run.qc = {
     if (!jQuery('#runQcTable').attr("qcInProgress")) {
       jQuery('#runQcTable').attr("qcInProgress", "true");
 
-      $('runQcTable').insertRow(1);
+      jQuery('runQcTable').insertRow(1);
 
       if (includeId) {
-        var column1 = $('runQcTable').rows[1].insertCell(-1);
+        var column1 = jQuery('runQcTable').rows[1].insertCell(-1);
         column1.innerHTML = "<input type='hidden' id='runId' name='runId' value='" + json.runId + "'/>";
       }
 
-      var column2 = $('runQcTable').rows[1].insertCell(-1);
+      var column2 = jQuery('runQcTable').rows[1].insertCell(-1);
       column2.innerHTML = "<select id='runQcUser' name='runQcUser'>" + json.qcUserOptions + "</select>";
-      var column3 = $('runQcTable').rows[1].insertCell(-1);
+      var column3 = jQuery('runQcTable').rows[1].insertCell(-1);
       column3.innerHTML = "<input id='runQcDate' name='runQcDate' type='text'/>";
-      var column4 = $('runQcTable').rows[1].insertCell(-1);
+      var column4 = jQuery('runQcTable').rows[1].insertCell(-1);
       column4.innerHTML = "<select id='runQcType' name='runQcType'/>";
-      var column5 = $('runQcTable').rows[1].insertCell(-1);
+      var column5 = jQuery('runQcTable').rows[1].insertCell(-1);
       column5.innerHTML = "<div id='runQcProcessSelection' name='runQcProcessSelection'/>";
-      var column6 = $('runQcTable').rows[1].insertCell(-1);
+      var column6 = jQuery('runQcTable').rows[1].insertCell(-1);
       column6.innerHTML = "<input id='runQcInformation' name='runQcInformation' type='text'/>";
-      var column7 = $('runQcTable').rows[1].insertCell(-1);
+      var column7 = jQuery('runQcTable').rows[1].insertCell(-1);
       column7.innerHTML = "<input id='runQcDoNotProcess' name='runQcDoNotProcess' type='checkbox'/>";
-      var column8 = $('runQcTable').rows[1].insertCell(-1);
+      var column8 = jQuery('runQcTable').rows[1].insertCell(-1);
       column8.innerHTML = "<a href='javascript:void(0);' onclick='Run.qc.addRunQC(this);'/>Add</a>";
 
       Utils.ui.addMaxDatePicker("runQcDate", 0);
@@ -183,9 +183,8 @@ Run.qc = {
         }
         }
       );
-    }
-    else {
-      alert("Cannot add another QC when one is already in progress.")
+    } else {
+      alert("Cannot add another QC when one is already in progress.");
     }
   },
 
@@ -212,7 +211,7 @@ Run.qc = {
         'doNotProcess': donotprocess,
         'url': ajaxurl},
       {'updateElement': 'runQcTable',
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           jQuery('#runQcTable').removeAttr("qcInProgress");
           if ("SeqOps QC" === qctype && !donotprocess) {
             jQuery('#qcmenu').append("<a href='/miso/analysis/new/run/" + runid + "' class='add'>Initiate Analysis</a>");
@@ -258,7 +257,7 @@ Run.ui = {
   },
 
   populateRunOptions: function (form, runId) {
-    if (form.value != 0) {
+    if (form.value !== 0) {
       Fluxion.doAjax(
         'runControllerHelperService',
         'populateRunOptions',
@@ -409,7 +408,7 @@ Run.alert = {
         'url': ajaxurl
       },
       {
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           Utils.page.pageReload();
         }
       }
@@ -425,7 +424,7 @@ Run.alert = {
         'url': ajaxurl
       },
       {
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           Utils.page.pageReload();
         }
       }
@@ -518,7 +517,9 @@ Run.container = {
       if (json.verify) {
         var dialogStr = "Container Properties\n\n";
         for (var key in json.verify) {
-          dialogStr += "Partition " + key + ": " + json.verify[key] + "\n";
+          if (json.verify.hasOwnProperty(key)) {
+            dialogStr += "Partition " + key + ": " + json.verify[key] + "\n";
+          }
         }
 
         if (confirm("Found container '" + json.barcode + "'. Import this container?\n\n" + dialogStr)) {
@@ -538,7 +539,7 @@ Run.container = {
     });
 
     Utils.timer.typewatchFunc(jQuery("#poolBarcode" + partitionNum), function () {
-      Run.pool.getPool(jQuery("#poolBarcode" + partitionNum), containerNum)
+      Run.pool.getPool(jQuery("#poolBarcode" + partitionNum), containerNum);
     }, 300, 2);
   },
 
@@ -561,7 +562,7 @@ Run.container = {
           newpool.append(json.html);
           newpool.append("<span style='position: absolute; top: 0; right: 0;' onclick='Run.pool.confirmPoolRemove(this);' class='float-right ui-icon ui-icon-circle-close'></span>");
         },
-          'doOnError': function (json) {
+          'doOnError': function () {
             newpool.remove();
             alert("Error adding pool, no Study is present.");
           }
@@ -598,7 +599,7 @@ Run.container = {
         jQuery("#studySelectDiv" + partition + "_" + projectId).remove();
         div.append(json.html);
       },
-        'doOnError': function (json) {
+        'doOnError': function () {
           Utils.ui.reenableButton('studySelectButton-' + partition + '_' + poolId, "Select Study");
         }
       }

--- a/miso-web/src/main/webapp/scripts/sample_ajax.js
+++ b/miso-web/src/main/webapp/scripts/sample_ajax.js
@@ -170,23 +170,23 @@ Sample.qc = {
     if (!jQuery('#sampleQcTable').attr("qcInProgress")) {
       jQuery('#sampleQcTable').attr("qcInProgress", "true");
 
-      $('sampleQcTable').insertRow(1);
+      jQuery('sampleQcTable').insertRow(1);
       //QCId  QCed By  	QC Date  	Method  	Results
 
       if (includeId) {
-        var column1 = $('sampleQcTable').rows[1].insertCell(-1);
+        var column1 = jQuery('sampleQcTable').rows[1].insertCell(-1);
         column1.innerHTML = "<input type='hidden' id='sampleId' name='sampleId' value='" + json.sampleId + "'/>";
       }
 
-      var column2 = $('sampleQcTable').rows[1].insertCell(-1);
+      var column2 = jQuery('sampleQcTable').rows[1].insertCell(-1);
       column2.innerHTML = "<select id='sampleQcUser' name='sampleQcUser'>" + json.qcUserOptions + "</select>";
-      var column3 = $('sampleQcTable').rows[1].insertCell(-1);
+      var column3 = jQuery('sampleQcTable').rows[1].insertCell(-1);
       column3.innerHTML = "<input id='sampleQcDate' name='sampleQcDate' type='text'/>";
-      var column4 = $('sampleQcTable').rows[1].insertCell(-1);
+      var column4 = jQuery('sampleQcTable').rows[1].insertCell(-1);
       column4.innerHTML = "<select id='sampleQcType' name='sampleQcType' onchange='Sample.qc.changeSampleQcUnits(this);'/>";
-      var column5 = $('sampleQcTable').rows[1].insertCell(-1);
+      var column5 = jQuery('sampleQcTable').rows[1].insertCell(-1);
       column5.innerHTML = "<input id='sampleQcResults' name='sampleQcResults' type='text'/><span id='units'/>";
-      var column6 = $('sampleQcTable').rows[1].insertCell(-1);
+      var column6 = jQuery('sampleQcTable').rows[1].insertCell(-1);
       column6.innerHTML = "<a href='javascript:void(0);' onclick='Sample.qc.addSampleQC();'/>Add</a>";
 
       Utils.ui.addMaxDatePicker("sampleQcDate", 0);
@@ -202,13 +202,12 @@ Sample.qc = {
           }
         }
       );
-    }
-    else {
-      alert("Cannot add another QC when one is already in progress.")
+    } else {
+      alert("Cannot add another QC when one is already in progress.");
     }
   },
 
-  changeSampleQcUnits: function (input) {
+  changeSampleQcUnits: function () {
     jQuery('#units').html(jQuery('#sampleQcType').find(":selected").attr("units"));
   },
 
@@ -225,7 +224,7 @@ Sample.qc = {
         'results': f.sampleQcResults,
         'url': ajaxurl},
       {'updateElement': 'sampleQcTable',
-        'doOnSuccess': function (json) {
+        'doOnSuccess': function () {
           jQuery('#sampleQcTable').removeAttr("qcInProgress");
         }
       }
@@ -278,8 +277,8 @@ Sample.qc = {
         var at = jQuery(this).attr("name");
         obj[at] = jQuery(this).text();
       });
-      obj["qcCreator"] = jQuery('#currentUser').text();
-      obj["libraryId"] = obj["name"].substring(3);
+      obj.qcCreator = jQuery('#currentUser').text();
+      obj.libraryId = obj.name.substring(3);
       aReturn.push(obj);
     }
 
@@ -333,10 +332,10 @@ Sample.library = {
     if (json.errors) {
       var errors = json.errors;
       var errorStr = "";
-      for (var i = 0; i < errors.length; i++) {
-        errorStr += errors[i].error + "\n";
+      for (var j = 0; j < errors.length; j++) {
+        errorStr += errors[j].error + "\n";
         jQuery(tableName).find("tr:gt(0)").each(function () {
-          if (jQuery(this).attr("libraryId") === errors[i].libraryId) {
+          if (jQuery(this).attr("libraryId") === errors[j].libraryId) {
             jQuery(this).find("td").each(function () {
               jQuery(this).css('background', '#EE9966');
             });
@@ -365,8 +364,8 @@ Sample.library = {
           var at = jQuery(this).attr("name");
           obj[at] = jQuery(this).text();
         });
-        obj["dilutionCreator"] = jQuery('#currentUser').text();
-        obj["libraryId"] = obj["name"].substring(3);
+        obj.dilutionCreator = jQuery('#currentUser').text();
+        obj.libraryId = obj.name.substring(3);
         aReturn.push(obj);
       }
     }
@@ -419,10 +418,10 @@ Sample.library = {
     if (json.errors) {
       var errors = json.errors;
       var errorStr = "";
-      for (var i = 0; i < errors.length; i++) {
-        errorStr += errors[i].error + "\n";
+      for (var j = 0; j < errors.length; j++) {
+        errorStr += errors[j].error + "\n";
         jQuery(tableName).find("tr:gt(0)").each(function () {
-          if (jQuery(this).attr("libraryId") === errors[i].libraryId) {
+          if (jQuery(this).attr("libraryId") === errors[j].libraryId) {
             jQuery(this).find("td").each(function () {
               jQuery(this).css('background', '#EE9966');
             });
@@ -689,11 +688,10 @@ Sample.ui = {
         {'barcode': barcode, 'url': ajaxurl},
         {'doOnSuccess': function (json) {
           var sample_desc = "<div id='" + json.id + "' class='dashboard'><table width=100%><tr><td>Sample Name: " + json.name + "<br> Sample ID: " + json.id + "<br>Desc: " + json.desc + "<br>Sample Type:" + json.type + "</td><td style='position: absolute;' align='right'><span class='float-right ui-icon ui-icon-circle-close' onclick='Sample.ui.removeSample(" + json.id + ");' style='position: absolute; top: 0; right: 0;'></span></td></tr></table> </div>";
-          if (jQuery("#" + json.id).length == 0) {
+          if (jQuery("#" + json.id).length === 0) {
             jQuery("#sample_pan").append(sample_desc);
             jQuery('#msgspan').html("");
-          }
-          else {
+          } else {
             jQuery('#msgspan').html("<i>This sample has already been scanned</i>");
           }
 
@@ -708,9 +706,8 @@ Sample.ui = {
           }
         }
       );
-    }
-    else {
-      jQuery('#msgspan').html("")
+    } else {
+      jQuery('#msgspan').html("");
     }
   },
 
@@ -720,7 +717,7 @@ Sample.ui = {
 
   setSampleReceiveDate: function (sampleList) {
     var samples = [];
-    jQuery(sampleList).children('div').each(function (e) {
+    jQuery(sampleList).children('div').each(function () {
       var sdiv = jQuery(this);
       samples.push({'sampleId': sdiv.attr("id")});
     });
@@ -734,8 +731,7 @@ Sample.ui = {
           alert(json.result);
         }
       });
-    }
-    else {
+    } else {
       alert("No samples scanned");
     }
   },

--- a/miso-web/src/main/webapp/scripts/scriptaculous/activityInput.js
+++ b/miso-web/src/main/webapp/scripts/scriptaculous/activityInput.js
@@ -69,7 +69,7 @@ function removeAvailableInput(inputIds) {
 
 function getSelectedAvailableInputs() {
 	var opts = availableInput.options;
-	var results = new Array();
+	var results = [];
 	for (i = 0; i < opts.length; i++) {
 		if (opts[i].selected) {
 			results.push(opts[i].value);
@@ -101,7 +101,7 @@ function removeLockedInput(inputIds) {
 }
 
 function updateReleasedInput(inputDataXml) {
-	var inputIds = new Array();
+	var inputIds = [];
 	var data = inputDataXml.getElementsByTagName("activityData");
 	for (i = 0; i < data.length; i++) {
 		inputIds.push(data[i].attributes.getNamedItem("uniqueId").value);
@@ -112,7 +112,7 @@ function updateReleasedInput(inputDataXml) {
 
 function getSelectedLockedInputs() {
 	var opts = lockedInput.options;
-	var results = new Array();
+	var results = [];
 	for (i = 0; i < opts.length; i++) {
 		if (opts[i].selected) {
 			results.push(opts[i].value);
@@ -146,7 +146,7 @@ function ajaxAvailableInput() {
             updateAvailableInput(xmlHttpReq.responseXML.documentElement);
         }
         stopLoading();
-    }
+    };
     xmlHttpReq.send(strURL);
 }
 
@@ -169,7 +169,7 @@ function ajaxLockInput() {
             updateLockedInput(xmlHttpReq.responseXML.documentElement);
         }
         stopLoading();
-    }
+    };
     xmlHttpReq.send(strURL);
 }
 
@@ -191,6 +191,6 @@ function ajaxReleaseInput() {
             updateReleasedInput(xmlHttpReq.responseXML.documentElement);
         }
         stopLoading();
-    }
+    };
     xmlHttpReq.send(strURL);
 }

--- a/miso-web/src/main/webapp/scripts/sequencer_partition_container_ajax.js
+++ b/miso-web/src/main/webapp/scripts/sequencer_partition_container_ajax.js
@@ -45,7 +45,9 @@ var Container = Container || {
       if (json.verify) {
         var dialogStr = "Container Properties\n\n";
         for (var key in json.verify) {
-          dialogStr += "Partition " + key + ": " + json.verify[key] + "\n";
+          if (json.verify.hasOwnProperty(key)) {
+            dialogStr += "Partition " + key + ": " + json.verify[key] + "\n";
+          }
         }
 
         if (confirm("Found container '" + json.barcode + "'. Import this container?\n\n" + dialogStr)) {
@@ -128,7 +130,7 @@ var Container = Container || {
     return false;
   },
   
-  validateStudyAdded: function (form) {
+  validateStudyAdded: function () {
     var ok = true;
     if (jQuery('div[id^="studySelectDiv"]').length > 0) {
       console.log(jQuery('div[id^="studySelectDiv"]'));
@@ -153,7 +155,7 @@ Container.ui = {
            "<button onclick='Container.lookupContainer(this);' type='button' class='fg-button ui-state-default ui-corner-all'>Lookup</button>");
   },
 
-  editContainerLocationBarcode: function (span, fc) {
+  editContainerLocationBarcode: function (span) {
     var s = jQuery(span);
     s.html("<input type='text' id='locationBarcode' name='locationBarcode' value='" + s.html() + "'/>");
   },
@@ -184,7 +186,7 @@ Container.ui = {
   },
 
   populateContainerOptions: function (form) {
-    if (form.value != 0) {
+    if (form.value !== 0) {
       Fluxion.doAjax(
         'containerControllerHelperService',
         'populateContainerOptions',
@@ -336,7 +338,7 @@ Container.partition = {
           newpool.append(json.html);
           newpool.append("<span style='position: absolute; top: 0; right: 0;' onclick='Container.pool.confirmPoolRemove(this);' class='float-right ui-icon ui-icon-circle-close'></span>");
         },
-          'doOnError': function (json) {
+          'doOnError': function () {
             newpool.remove();
             alert("Error adding pool, no Study is present.");
           }
@@ -374,7 +376,7 @@ Container.partition = {
         jQuery("#studySelectDiv" + partition + "_" + projectId).remove();
         div.append(json.html);
       },
-        'doOnError': function (json) {
+        'doOnError': function () {
           Utils.ui.reenableButton('studySelectButton-' + partition + '_' + poolId, "Select Study");
         }
       }

--- a/miso-web/src/main/webapp/scripts/sequencer_reference_ajax.js
+++ b/miso-web/src/main/webapp/scripts/sequencer_reference_ajax.js
@@ -35,28 +35,30 @@ Sequencer.ui = {
   },
 
   processSequencerReferenceRow : function(json) {
-    $('sequencerReferenceTable').insertRow(1);
+    jQuery('sequencerReferenceTable').insertRow(1);
 
-    var column1 = $('sequencerReferenceTable').rows[1].insertCell(-1);
+    var column1 = jQuery('sequencerReferenceTable').rows[1].insertCell(-1);
     column1.innerHTML = "<i>Unsaved</i>";
-    var column2 = $('sequencerReferenceTable').rows[1].insertCell(-1);
+    var column2 = jQuery('sequencerReferenceTable').rows[1].insertCell(-1);
     column2.innerHTML = "<input id='sequencername' name='sequencername' type='text'/>";
-    var column3 = $('sequencerReferenceTable').rows[1].insertCell(-1);
+    var column3 = jQuery('sequencerReferenceTable').rows[1].insertCell(-1);
     column3.innerHTML = "<select id='platforms' name='platform'>" +json.platforms+ "</select>";
-    var column4 = $('sequencerReferenceTable').rows[1].insertCell(-1);
+    var column4 = jQuery('sequencerReferenceTable').rows[1].insertCell(-1);
     column4.innerHTML = "<input id='server' name='server' type='text' onkeyup='Sequencer.ui.validateServer(this)'/>";
-    var column5 = $('sequencerReferenceTable').rows[1].insertCell(-1);
+    var column5 = jQuery('sequencerReferenceTable').rows[1].insertCell(-1);
     column5.innerHTML = "<div id='available'></div>";
-    var column6 = $('sequencerReferenceTable').rows[1].insertCell(-1);
+    var column6 = jQuery('sequencerReferenceTable').rows[1].insertCell(-1);
     column6.id = "addTd";
     column6.innerHTML = "Add";
   },
 
   validateServer : function(t) {
-    $('available').innerHTML="<div align='center'><img src='../../styles/images/ajax-loader.gif'/></div>";
+    jQuery('available').innerHTML="<div align='center'><img src='../../styles/images/ajax-loader.gif'/></div>";
 
     if (t.value != t.lastValue) {
-      if (t.timer) clearTimeout(t.timer);
+      if (t.timer) {
+        clearTimeout(t.timer);
+      }
 
       t.timer = setTimeout(function () {
         Fluxion.doAjax(
@@ -64,13 +66,13 @@ Sequencer.ui = {
           'checkServerAvailability',
           {'server':t.value, 'url':ajaxurl},
           {"doOnSuccess": function(json) {
-            $('available').innerHTML = json.html;
+            jQuery('available').innerHTML = json.html;
             if (json.html == "OK") {
-              $('available').setAttribute("style", "background-color:green");
-              $('addTd').innerHTML = "<a href='javascript:void(0);' onclick='Sequencer.ui.addSequencerReference();'/>Add</a>";
+              jQuery('available').setAttribute("style", "background-color:green");
+              jQuery('addTd').innerHTML = "<a href='javascript:void(0);' onclick='Sequencer.ui.addSequencerReference();'/>Add</a>";
             }
             else {
-              $('available').setAttribute("style", "background-color:red");
+              jQuery('available').setAttribute("style", "background-color:red");
             }
           }
         });

--- a/miso-web/src/main/webapp/scripts/sortable.js
+++ b/miso-web/src/main/webapp/scripts/sortable.js
@@ -16,7 +16,7 @@
   }
 
   addEventListener = function(el, event, handler) {
-    if (el.addEventListener != null) {
+    if (el.addEventListener !== null) {
       return el.addEventListener(event, handler, false);
     } else {
       return el.attachEvent("on" + event, handler);
@@ -26,10 +26,10 @@
   sortable = {
     init: function(options) {
       var table, tables, _i, _len, _results;
-      if (options == null) {
+      if (options === null) {
         options = {};
       }
-      if (options.selector == null) {
+      if (options.selector === null) {
         options.selector = SELECTOR;
       }
       tables = document.querySelectorAll(options.selector);
@@ -42,7 +42,7 @@
     },
     initTable: function(table) {
       var i, th, ths, _i, _len, _ref;
-      if (((_ref = table.tHead) != null ? _ref.rows.length : void 0) !== 1) {
+      if (((_ref = table.tHead) !== null ? _ref.rows.length : void 0) !== 1) {
         return;
       }
       if (table.getAttribute('data-sortable-initialized') === 'true') {
@@ -86,7 +86,7 @@
         tBody = table.tBodies[0];
         rowArray = [];
         if (!sorted) {
-          if (type.compare != null) {
+          if (type.compare !== null) {
             _compare = type.compare;
           } else {
             _compare = function(a, b) {
@@ -107,7 +107,7 @@
           for (position = _j = 0, _len1 = _ref.length; _j < _len1; position = ++_j) {
             row = _ref[position];
             value = sortable.getNodeValue(row.cells[i]);
-            if (type.comparator != null) {
+            if (type.comparator !== null) {
               value = type.comparator(value);
             }
             rowArray.push([value, row, position]);
@@ -129,7 +129,7 @@
             tBody.appendChild(row);
           }
         }
-        if (typeof window['CustomEvent'] === 'function') {
+        if (typeof window.CustomEvent === 'function') {
           return typeof table.dispatchEvent === "function" ? table.dispatchEvent(new CustomEvent('Sortable.sorted', {
             bubbles: true
           })) : void 0;
@@ -144,8 +144,8 @@
     },
     getColumnType: function(table, i) {
       var row, specified, text, type, _i, _j, _len, _len1, _ref, _ref1, _ref2;
-      specified = (_ref = table.querySelectorAll('th')[i]) != null ? _ref.getAttribute('data-sortable-type') : void 0;
-      if (specified != null) {
+      specified = (_ref = table.querySelectorAll('th')[i]) !== null ? _ref.getAttribute('data-sortable-type') : void 0;
+      if (specified !== null) {
         return sortable.typesObject[specified];
       }
       _ref1 = table.tBodies[0].rows;

--- a/miso-web/src/main/webapp/scripts/stats_ajax.js
+++ b/miso-web/src/main/webapp/scripts/stats_ajax.js
@@ -127,21 +127,21 @@ var Stats = Stats || {
             jQuery.each(obj, function(key, value) {
               if (obj.lane == laneNum) {
                 if (key == "density") {
-                  if (jQuery('#qheaders th[id=density]').length == 0) {
+                  if (jQuery('#qheaders th[id=density]').length === 0) {
                     jQuery('#qheaders').append("<th id='density'>Density "+obj.units+"</th>");
                   }
                   jQuery('#metricsTable tr:last').append('<td>'+obj.density+' &plusmn; '+obj.densitySD+'</td>');
                 }
 
                 if (key == "densityPassingFilter") {
-                  if (jQuery('#qheaders th[id=densityPassingFilter]').length == 0) {
+                  if (jQuery('#qheaders th[id=densityPassingFilter]').length === 0) {
                     jQuery('#qheaders').append("<th id='densityPassingFilter'>Density PF "+obj.units+"</th>");
                   }
                   jQuery('#metricsTable tr:last').append('<td>'+obj.densityPassingFilter+' &plusmn; '+obj.densityPassingFilterSD+'</td>');
                 }
 
                 if (key == "densityPercentPassed") {
-                  if (jQuery('#qheaders th[id=densityPercentPassed]').length == 0) {
+                  if (jQuery('#qheaders th[id=densityPercentPassed]').length === 0) {
                     jQuery('#qheaders').append("<th id='densityPercentPassed'>Density Passed %</th>");
                   }
                   jQuery('#metricsTable tr:last').append('<td>'+obj.densityPercentPassed+'</td>');
@@ -156,7 +156,7 @@ var Stats = Stats || {
             jQuery.each(obj, function(key, value) {
               if (obj.lane == laneNum) {
                 if (key != "lane" && key != "raw") {
-                  if (jQuery('#qheaders th[id='+key.replace(">", "")+']').length == 0) {
+                  if (jQuery('#qheaders th[id='+key.replace(">", "")+']').length === 0) {
                     jQuery('#qheaders').append("<th id='"+key.replace(">", "")+"'>Quality "+key.replace(">", "&gt;")+"</th>");
                     jQuery('#metricsTable tr:last').append('<td>'+value+'</td>');
                   }
@@ -176,7 +176,7 @@ var Stats = Stats || {
               var output = "";
               jQuery.each(obj, function(key, value) {
                 if (key != "lane") {
-                  if (jQuery('#qheaders th[id=phasing]').length == 0) {
+                  if (jQuery('#qheaders th[id=phasing]').length === 0) {
                     jQuery('#qheaders').append("<th id='phasing'>Phasing / Prephasing</th>");
                   }
 
@@ -199,7 +199,7 @@ var Stats = Stats || {
             jQuery.each(obj, function(key, value) {
               if (obj.lane == laneNum) {
                 if (key == "meanError") {
-                  if (jQuery('#qheaders th[id='+key+']').length == 0) {
+                  if (jQuery('#qheaders th[id='+key+']').length === 0) {
                     jQuery('#qheaders').append("<th id='"+key+"'>Mean Error</th>");
                   }
                   jQuery('#metricsTable tr:last').append("<td>"+value+" &plusmn; "+obj.errorSD+"</td>");
@@ -256,21 +256,21 @@ var Stats = Stats || {
           jQuery.each(cd, function(index, obj) {
             jQuery.each(obj, function(key, value) {
               if (key == "density") {
-                if (jQuery('#qheaders th[id=density]').length == 0) {
+                if (jQuery('#qheaders th[id=density]').length === 0) {
                   jQuery('#qheaders').append("<th id='density'>Density "+obj.units+"</th>");
                 }
                 jQuery('#metricsTable tr:eq('+obj.lane+'):last').append('<td>'+obj.density+' &plusmn; '+obj.densitySD+'</td>');
               }
 
               if (key == "densityPassingFilter") {
-                if (jQuery('#qheaders th[id=densityPassingFilter]').length == 0) {
+                if (jQuery('#qheaders th[id=densityPassingFilter]').length === 0) {
                   jQuery('#qheaders').append("<th id='densityPassingFilter'>Density PF "+obj.units+"</th>");
                 }
                 jQuery('#metricsTable tr:eq('+obj.lane+'):last').append('<td>'+obj.densityPassingFilter+' &plusmn; '+obj.densityPassingFilterSD+'</td>');
               }
 
               if (key == "densityPercentPassed") {
-                if (jQuery('#qheaders th[id=densityPercentPassed]').length == 0) {
+                if (jQuery('#qheaders th[id=densityPercentPassed]').length === 0) {
                   jQuery('#qheaders').append("<th id='densityPercentPassed'>Density Passed %</th>");
                 }
                 jQuery('#metricsTable tr:eq('+obj.lane+'):last').append('<td>'+obj.densityPercentPassed+'</td>');
@@ -294,7 +294,7 @@ var Stats = Stats || {
             jQuery.each(qm, function(index, obj) {
               jQuery.each(obj, function(key, value) {
                 if (key != "lane" && key != "raw") {
-                  if (jQuery('#qheaders th[id='+key.replace(">", "")+']').length == 0) {
+                  if (jQuery('#qheaders th[id='+key.replace(">", "")+']').length === 0) {
                     jQuery('#qheaders').append("<th id='"+key.replace(">", "")+"'>Quality "+key.replace(">", "&gt;")+"</th>");
                     jQuery('#metricsTable tr:eq('+obj.lane+'):last').append('<td>'+value+'</td>');
                   }
@@ -313,7 +313,7 @@ var Stats = Stats || {
             var output = "";
             jQuery.each(obj, function(key, value) {
               if (key != "lane") {
-                if (jQuery('#qheaders th[id=phasing]').length == 0) {
+                if (jQuery('#qheaders th[id=phasing]').length === 0) {
                   jQuery('#qheaders').append("<th id='phasing'>Phasing / Prephasing</th>");
                 }
 
@@ -334,7 +334,7 @@ var Stats = Stats || {
           jQuery.each(em, function(index, obj) {
             jQuery.each(obj, function(key, value) {
               if (key == "meanError") {
-                if (jQuery('#qheaders th[id='+key+']').length == 0) {
+                if (jQuery('#qheaders th[id='+key+']').length === 0) {
                   jQuery('#qheaders').append("<th id='"+key+"'>Mean Error</th>");
                 }
                 jQuery('#metricsTable tr:eq('+obj.lane+'):last').append("<td>"+value+" &plusmn; "+obj.errorSD+"</td>");

--- a/miso-web/src/main/webapp/scripts/statsdb.js
+++ b/miso-web/src/main/webapp/scripts/statsdb.js
@@ -25,7 +25,7 @@ function readStatsdb(file) {
     position.push(d.base);
   });
 
-  w = position.length * 20 + 35
+  w = position.length * 20 + 35;
   var vis = d3.select("#statschartqualityprofile").selectAll("svg")
     .data(datas)
     .enter().append("svg")
@@ -46,7 +46,7 @@ function readStatsdb(file) {
 
   function load() {
     var scorebox = vis.selectAll("rect.day")
-      .data(scores)
+      .data(scores);
     scorebox.enter().append("svg:rect")
       .attr("x", function (g) {
         return 52.5;
@@ -76,7 +76,7 @@ function readStatsdb(file) {
       .attr("height", width);
 
       var basebox = vis.selectAll("rect.day")
-        .data(position)
+        .data(position);
       basebox.enter().append("svg:rect")
         .attr("x", function (d, i) {
             return (i + 1) * 20 + 32.5;

--- a/miso-web/src/main/webapp/scripts/statsdbperbasecontent.js
+++ b/miso-web/src/main/webapp/scripts/statsdbperbasecontent.js
@@ -38,7 +38,7 @@ function readStatsdbperbasecontent(jsonfile) {
   load();
   function load() {
     var scorebox = vis.selectAll('rect.day')
-      .data(data)
+      .data(data);
     scorebox.enter().append('svg:rect')
       .attr('x', function (d, i) {
         return (i) * space;
@@ -59,7 +59,7 @@ function readStatsdbperbasecontent(jsonfile) {
       });
 
     var basebox = vis.selectAll('rect.day')
-      .data(percentile)
+      .data(percentile);
     basebox.enter().append('svg:rect')
       .attr('x', function (g) {
         return 0;

--- a/miso-web/src/main/webapp/scripts/submission_ajax.js
+++ b/miso-web/src/main/webapp/scripts/submission_ajax.js
@@ -32,7 +32,7 @@ var Submission = Submission || {
           Utils.page.pageReload();
         }
       }
-    )
+    );
   },
 
   validateSubmissionMetadata : function(submissionId) {
@@ -46,16 +46,16 @@ var Submission = Submission || {
         }
         else {
           if (json.errors) {
-            jQuery('#submissionreport').append("<h2>Errors</h2><div id='submissionreporterror' class='flasherror'></div>")
+            jQuery('#submissionreport').append("<h2>Errors</h2><div id='submissionreporterror' class='flasherror'></div>");
             for (var i = 0; i < json.errors.length; i++) {
               jQuery('#submissionreporterror').append(json.errors[i] + "<br/>");
             }
           }
 
           if (json.infos) {
-            jQuery('#submissionreport').append("<h2>Info</h2><div id='submissionreportinfo' class='flashinfo'></div>")
-            for (var i = 0; i < json.infos.length; i++) {
-              jQuery('#submissionreportinfo').append(json.infos[i] + "<br/>");
+            jQuery('#submissionreport').append("<h2>Info</h2><div id='submissionreportinfo' class='flashinfo'></div>");
+            for (var j = 0; j < json.infos.length; j++) {
+              jQuery('#submissionreportinfo').append(json.infos[j] + "<br/>");
             }
           }
         }
@@ -74,16 +74,16 @@ var Submission = Submission || {
         }
         else {
           if (json.errors) {
-            jQuery('#submissionreport').append("<h2>Errors</h2><div id='submissionreporterror' class='flasherror'></div>")
+            jQuery('#submissionreport').append("<h2>Errors</h2><div id='submissionreporterror' class='flasherror'></div>");
             for (var i = 0; i < json.errors.length; i++) {
               jQuery('#submissionreporterror').append(json.errors[i] + "<br/>");
             }
           }
 
           if (json.infos) {
-            jQuery('#submissionreport').append("<h2>Info</h2><div id='submissionreportinfo' class='flashinfo'></div>")
-            for (var i = 0; i < json.infos.length; i++) {
-              jQuery('#submissionreportinfo').append(json.infos[i] + "<br/>");
+            jQuery('#submissionreport').append("<h2>Info</h2><div id='submissionreportinfo' class='flashinfo'></div>");
+            for (var j = 0; j < json.infos.length; j++) {
+              jQuery('#submissionreportinfo').append(json.infos[j] + "<br/>");
             }
           }
         }
@@ -99,7 +99,7 @@ var Submission = Submission || {
             'submitSequenceData',
     {'submissionId':submissionId,'url':ajaxurl},
     {'doOnSuccess':function(json) {
-        jQuery('#submissionreport').append("<h3>"+json.response+"</h3>")
+        jQuery('#submissionreport').append("<h3>"+json.response+"</h3>");
         Submission.ui.displayUploadProgress(submissionId);
       }
     });
@@ -195,8 +195,8 @@ Submission.ui = {
             "<td>"+ json.uploadJobs[i].percent+"%</td></tr>");
         }
         jQuery('#submissionreport').append("</table>");
-        for (var i = 0; i < json.uploadJobs.length; i++) {
-          jQuery("#progressbar"+i).progressbar({ value: json.uploadJobs[i].percent });
+        for (var j = 0; j < json.uploadJobs.length; j++) {
+          jQuery("#progressbar"+j).progressbar({ value: json.uploadJobs[j].percent });
         }
       }
     });

--- a/miso-web/src/main/webapp/scripts/submission_validation.js
+++ b/miso-web/src/main/webapp/scripts/submission_validation.js
@@ -25,17 +25,17 @@ function validate_submission(form) {
   var ok = true;
   var error = "Please correct the following error(s):\n\n";
 
-  if (jQuery('#title').val() == "") {
+  if (jQuery('#title').val() === "") {
     ok = false;
     error += "You have not entered a title for the Submission.\n";
   }
 
-  if (jQuery('#alias').val() == "") {
+  if (jQuery('#alias').val() === "") {
     ok = false;
     error += "You have not entered an alias for the Submission.\n";
   }
 
-  if (jQuery('#description').val() == "") {
+  if (jQuery('#description').val() === "") {
     ok = false;
     error += "You have not entered a description of the Submission.\n";
   }
@@ -46,7 +46,7 @@ function validate_submission(form) {
         ok = false;
         error += "You cannot use single or double quotes in the "+jQuery(this).attr("id")+" field and it cannot end with a space.\n";
       }
-    })
+    });
   }
 
   if (!ok) {

--- a/miso-web/src/main/webapp/scripts/task_ajax.js
+++ b/miso-web/src/main/webapp/scripts/task_ajax.js
@@ -47,8 +47,8 @@ Tasks.ui = {
         var processRuns = task.conanProcessRuns;
         var rowtext = "<td>"+task.id+"</td><td>"+task.name+"</td><td>"+task.pipeline.name+"</td><td>"+task.statusMessage+"</td><td>"+new Date(task.startDate)+"</td>";
         rowtext += "<td><table width='100%' border='0'><tr>";
-        for (var j = 0; j < task.pipeline.processes.length; j++) {
-          rowtext += "<td id='"+task.id+"-"+task.pipeline.processes[j].name+"'>"+task.pipeline.processes[j].name+"</td>";
+        for (var m = 0; m < task.pipeline.processes.length; m++) {
+          rowtext += "<td id='"+task.id+"-"+task.pipeline.processes[m].name+"'>"+task.pipeline.processes[m].name+"</td>";
         }
 
         rowtext += "</tr></table></td>";
@@ -61,7 +61,7 @@ Tasks.ui = {
           var process = task.pipeline.processes[j];
           for (var k = 0; k < processRuns.length; k++) {
             if (processRuns[k].processName === process.name) {
-              if (processRuns[k].exitValue == 0) {
+              if (processRuns[k].exitValue === 0) {
                 jQuery('#'+task.id+"-"+task.pipeline.processes[j].name).addClass("ok");
                 jQuery('#'+task.id+"-"+task.pipeline.processes[j].name).attr("title", "Finished: " + new Date(processRuns[k].endDate));
               }
@@ -229,8 +229,8 @@ Tasks.ui = {
 
           jQuery('#'+process.name+'-reqParams > tbody:last').append(jQuery('<tr>').append("<td>"+parameter.name+"</td><td>"+
                        "Required: " + !parameter.optional + "<br/>" +
-                       "Boolean: " + parameter.boolean + "<br/>" +
-                       "Transient: " + parameter.transient + "</td>"
+                       "Boolean: " + parameter["boolean"] + "<br/>" +
+                       "Transient: " + parameter["transient"] + "</td>"
           ));
         }
       }
@@ -267,31 +267,28 @@ Tasks.ui = {
 
         for (var i = 0; i < pipeline.allRequiredParameters.length; i++) {
           var parameter = pipeline.allRequiredParameters[i];
-          if (!parameter.transient) {
-            if (parameter.boolean) {
+          if (!parameter["transient"]) {
+            if (parameter["boolean"]) {
               if (parameter.optional) {
                 jQuery('#'+pipeline.name+'-reqParams > tbody:last')
                 .append(jQuery('<tr>')
                   .append("<td>"+parameter.name+"</td><td><input optional='true' type='checkbox' name='"+parameter.name+"'/>")
                 );
-              }
-              else {
+              } else {
                 jQuery('#'+pipeline.name+'-reqParams > tbody:last')
                 .append(jQuery('<tr>')
                   .append("<td>"+parameter.name+"</td><td><input required='true' type='checkbox' name='"+parameter.name+"'/>")
                 );
               }
-            }
-            else {
+            } else {
               if (parameter.optional) {
                 jQuery('#'+pipeline.name+'-reqParams > tbody:last')
-                  .append(jQuery('<tr>')
+                .append(jQuery('<tr>')
                   .append("<td>"+parameter.name+"</td><td><input optional='true' style='width:98%' type='text' id='"+parameter.name+"' name='"+parameter.name+"' value=''/>")
                 );
-              }
-              else {
+              } else {
                 jQuery('#'+pipeline.name+'-reqParams > tbody:last')
-                  .append(jQuery('<tr>')
+                .append(jQuery('<tr>')
                   .append("<td>"+parameter.name+" <span style='color: red'>*</span></td><td><input style='width:98%' required='true' type='text' id='"+parameter.name+"' name='"+parameter.name+"' value=''/>")
                 );
               }
@@ -303,7 +300,7 @@ Tasks.ui = {
       for (var j = 0; j < pipeline.processes.length; j++) {
         var process = pipeline.processes[j];
         for (var k = 0; k < process.parameters.length; k++) {
-          if (jQuery('input[name="'+process.parameters[k].name+'"]').length == 0) {
+          if (jQuery('input[name="'+process.parameters[k].name+'"]').length === 0) {
             jQuery('#'+pipeline.name+'-reqParams > tbody:last')
               .append(jQuery('<tr>')
               .append("<td>"+process.parameters[k].name+"</td><td><input style='width:98%' optional='true' type='text' id='"+process.parameters[k].name+"' name='"+process.parameters[k].name+"' value=''/>")

--- a/miso-web/src/main/webapp/scripts/user_ajax.js
+++ b/miso-web/src/main/webapp/scripts/user_ajax.js
@@ -21,52 +21,54 @@
  * *********************************************************************
  */
 
-function validateUser () {
-  Validate.cleanFields('#user-form');
-  jQuery('#user-form').parsley().destroy();
-
-  // Full name input field validation
-  jQuery('#fullName').attr('class', 'form-control');
-  jQuery('#fullName').attr('data-parsley-required', 'true');
-  jQuery('#fullName').attr('data-parsley-maxlength', '100');
-  jQuery('#fullName').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
-
-  // Login name input field validation
-  jQuery('#loginName').attr('class', 'form-control');
-  jQuery('#loginName').attr('data-parsley-required', 'true');
-  jQuery('#loginName').attr('data-parsley-maxlength', '100');
-  jQuery('#loginName').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
-
-  // Login name input field validation
-  jQuery('#email').attr('class', 'form-control');
-  jQuery('#email').attr('data-parsley-required', 'true');
-  jQuery('#email').attr('data-parsley-maxlength', '100');
-  //jQuery('#email').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
-  jQuery('#email').attr('data-parsley-type', 'email');
-
-
-  // Current Password input field validation
-  jQuery('#password').attr('class', 'form-control');
-  jQuery('#password').attr('data-parsley-required', 'true');
-  jQuery('#password').attr('data-parsley-maxlength', '100');
-  jQuery('#password').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
-
-  // New Password input field validation
-  jQuery('#newpassword').attr('class', 'form-control');
-  jQuery('#newpassword').attr('data-parsley-required', 'true');
-  jQuery('#newpassword').attr('data-parsley-maxlength', '100');
-  jQuery('#newpassword').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
-
-  // Confirm password input field validation
-  jQuery('#confirmpassword').attr('class', 'form-control');
-  jQuery('#confirmpassword').attr('data-parsley-required', 'true');
-  jQuery('#confirmpassword').attr('data-parsley-maxlength', '100');
-  jQuery('#confirmpassword').attr('data-parsley-equalto', '#newpassword');
-  jQuery('#confirmpassword').attr('data-parsley-error-message', 'Password does not match!');
-  jQuery('#confirmpassword').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
-
-  jQuery('#user-form').parsley();
-  jQuery('#user-form').parsley().validate();
-
-  Validate.updateWarningOrSubmit('#user-form');
+var User = User || {
+  validateUser: function () {
+    Validate.cleanFields('#user-form');
+    jQuery('#user-form').parsley().destroy();
+  
+    // Full name input field validation
+    jQuery('#fullName').attr('class', 'form-control');
+    jQuery('#fullName').attr('data-parsley-required', 'true');
+    jQuery('#fullName').attr('data-parsley-maxlength', '100');
+    jQuery('#fullName').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+  
+    // Login name input field validation
+    jQuery('#loginName').attr('class', 'form-control');
+    jQuery('#loginName').attr('data-parsley-required', 'true');
+    jQuery('#loginName').attr('data-parsley-maxlength', '100');
+    jQuery('#loginName').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+  
+    // Login name input field validation
+    jQuery('#email').attr('class', 'form-control');
+    jQuery('#email').attr('data-parsley-required', 'true');
+    jQuery('#email').attr('data-parsley-maxlength', '100');
+    //jQuery('#email').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+    jQuery('#email').attr('data-parsley-type', 'email');
+  
+  
+    // Current Password input field validation
+    jQuery('#password').attr('class', 'form-control');
+    jQuery('#password').attr('data-parsley-required', 'true');
+    jQuery('#password').attr('data-parsley-maxlength', '100');
+    jQuery('#password').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+  
+    // New Password input field validation
+    jQuery('#newpassword').attr('class', 'form-control');
+    jQuery('#newpassword').attr('data-parsley-required', 'true');
+    jQuery('#newpassword').attr('data-parsley-maxlength', '100');
+    jQuery('#newpassword').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+  
+    // Confirm password input field validation
+    jQuery('#confirmpassword').attr('class', 'form-control');
+    jQuery('#confirmpassword').attr('data-parsley-required', 'true');
+    jQuery('#confirmpassword').attr('data-parsley-maxlength', '100');
+    jQuery('#confirmpassword').attr('data-parsley-equalto', '#newpassword');
+    jQuery('#confirmpassword').attr('data-parsley-error-message', 'Password does not match!');
+    jQuery('#confirmpassword').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+  
+    jQuery('#user-form').parsley();
+    jQuery('#user-form').parsley().validate();
+  
+    Validate.updateWarningOrSubmit('#user-form');
+  }
 };

--- a/miso-web/src/main/webapp/scripts/user_ajax.js
+++ b/miso-web/src/main/webapp/scripts/user_ajax.js
@@ -21,10 +21,6 @@
  * *********************************************************************
  */
 
-jQuery(document).ready(function () {
-  Validate.attachParsley('#user-form');
-});
-
 function validateUser () {
   Validate.cleanFields('#user-form');
   jQuery('#user-form').parsley().destroy();

--- a/miso-web/src/main/webapp/styles/progress.css
+++ b/miso-web/src/main/webapp/styles/progress.css
@@ -80,7 +80,7 @@
 }
 
 #progress strong{
-  font-weight:normal
+  font-weight:normal;
 }
 #progress a:hover{
   text-decoration:none;


### PR DESCRIPTION
Maven Minify plugin concatenates and minifies CSS and JS files during the build cycle. 

In header.jsp: concatenated imports are **style.css** and **header_script.js** . The external header is untouched except for the removal of cache-invalidating timestamps.

These can be replaced with the minified versions which are also generated, **style.min.css** and **header_script.min.js** , but the minification makes it difficult to debug and I haven't yet found a good way of adding a "production" flag to the jsp.

There is also a cleanup commit which adds semicolons, "===" instead of "==", and fixes some whitespace issues.