### PR TITLE
Remove Volume from SampleAdditionalInfo

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAdditionalInfo.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAdditionalInfo.java
@@ -44,10 +44,6 @@ public interface SampleAdditionalInfo {
 
   void setTubeNumber(Integer tubeNumber);
 
-  Double getVolume();
-
-  void setVolume(Double volume);
-
   Double getConcentration();
 
   void setConcentration(Double concentration);

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAdditionalInfoImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAdditionalInfoImpl.java
@@ -183,16 +183,6 @@ public class SampleAdditionalInfoImpl implements SampleAdditionalInfo {
   }
 
   @Override
-  public Double getVolume() {
-    return volume;
-  }
-
-  @Override
-  public void setVolume(Double volume) {
-    this.volume = volume;
-  }
-
-  @Override
   public Double getConcentration() {
     return concentration;
   }

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -216,7 +216,6 @@ public class Dtos {
     }
     dto.setPassageNumber(from.getPassageNumber());
     dto.setTimesReceived(from.getTimesReceived());
-    dto.setVolume(from.getVolume());
     dto.setConcentration(from.getConcentration());
     dto.setCreatedById(from.getCreatedBy().getUserId());
     dto.setCreationDate(dateTimeFormatter.print(from.getCreationDate().getTime()));
@@ -239,7 +238,6 @@ public class Dtos {
     to.setPassageNumber(from.getPassageNumber());
     to.setTimesReceived(from.getTimesReceived());
     to.setTubeNumber(from.getTubeNumber());
-    to.setVolume(from.getVolume());
     to.setConcentration(from.getConcentration());
     return to;
   }

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAdditionalInfoDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAdditionalInfoDto.java
@@ -24,7 +24,6 @@ public class SampleAdditionalInfoDto {
   private Integer passageNumber;
   private Integer timesReceived;
   private Integer tubeNumber;
-  private Double volume;
   private Double concentration;
   private Long createdById;
   private String createdByUrl;
@@ -153,14 +152,6 @@ public class SampleAdditionalInfoDto {
 
   public void setTubeNumber(Integer tubeNumber) {
     this.tubeNumber = tubeNumber;
-  }
-
-  public Double getVolume() {
-    return volume;
-  }
-
-  public void setVolume(Double volume) {
-    this.volume = volume;
   }
 
   public Double getConcentration() {

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleAdditionalInfoService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleAdditionalInfoService.java
@@ -238,7 +238,6 @@ public class DefaultSampleAdditionalInfoService implements SampleAdditionalInfoS
     updatedSampleAdditionalInfo.setPassageNumber(sampleAdditionalInfo.getPassageNumber());
     updatedSampleAdditionalInfo.setTimesReceived(sampleAdditionalInfo.getTimesReceived());
     updatedSampleAdditionalInfo.setTubeNumber(sampleAdditionalInfo.getTubeNumber());
-    updatedSampleAdditionalInfo.setVolume(sampleAdditionalInfo.getVolume());
     updatedSampleAdditionalInfo.setConcentration(sampleAdditionalInfo.getConcentration());
     updatedSampleAdditionalInfo.setArchived(sampleAdditionalInfo.getArchived());
     User user = authorizationManager.getCurrentUser();

--- a/sqlstore/src/main/resources/db/migration/V0010__sample_hierarchy.sql
+++ b/sqlstore/src/main/resources/db/migration/V0010__sample_hierarchy.sql
@@ -150,7 +150,6 @@ CREATE TABLE `SampleAdditionalInfo` (
   `passageNumber` int(11) DEFAULT NULL,
   `timesReceived` int(11) DEFAULT NULL,
   `tubeNumber` int(11) DEFAULT NULL,
-  `volume` double DEFAULT NULL,
   `concentration` double DEFAULT NULL,
   `archived` bit(1) NOT NULL,
   `labId` bigint(20) DEFAULT NULL,


### PR DESCRIPTION
Volume got added to Sample directly because it interacts with Boxes. This commit removes it from SampleAdditionalInfo as well.

This commit changes V0010__sample_hierarchy.sql .