### PR TITLE
MISO-201 fix Illumina KD NPE

### DIFF
--- a/miso-web/src/main/webapp/pages/editKitDescriptor.jsp
+++ b/miso-web/src/main/webapp/pages/editKitDescriptor.jsp
@@ -91,7 +91,9 @@
             <c:when test="${kitDescriptor.kitDescriptorId == 0 or empty kitDescriptor.platformType}">
               <td>Platform Type:</td>
               <td>
-                <form:select id="platformTypes" path="platformType" items="${platformTypes}"/>
+                <form:select id="platformTypes" path="platformType">
+                  <form:options items="${platformTypes}" itemValue="key" itemLabel="key"/>
+                </form:select>
               </td>
             </c:when>
             <c:otherwise>


### PR DESCRIPTION
Platform type was sending Enum back to server, so it was breaking when the Stringified Enum (all uppercase) did not match the String Enum key (regular case).