### PR TITLE
box fixes: grant all read permission to null, exclude box changelog f…

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Box.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Box.java
@@ -27,7 +27,7 @@ import uk.ac.bbsrc.tgac.miso.core.security.SecurableByProfile;
  * A Box usually has dimensions 8 by 12. (A-H, 1-12, A01 through H12)
  */
 @JsonSerialize(typing = JsonSerialize.Typing.STATIC, include = JsonSerialize.Inclusion.NON_NULL)
-@JsonIgnoreProperties({ "securityProfile", "free", "2DArray", "lastModifier" })
+@JsonIgnoreProperties({ "securityProfile", "free", "2DArray", "lastModifier", "changeLog" })
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public interface Box extends SecurableByProfile, Barcodable, Locatable, Deletable {
   public static class BoxablesSerializer extends JsonSerializer<Map<String, Boxable>> {

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/UserAuthMisoRequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/UserAuthMisoRequestManager.java
@@ -159,7 +159,7 @@ public class UserAuthMisoRequestManager implements RequestManager {
         log.error("Cannot resolve a currently logged in user", e);
       }
     } else {
-      throw new IOException("Cannot check read permissions for null object. Does this object really exist?");
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
…rom json

Permission change had been done previously, and then undone accidentally in sample hierarchy merge/revert/merge mess. Change logs aren't required in Box JSON (Used heavily on Edit Box page), and were causing serialization errors.