### PR TITLE
Reduce autowiring in tests

### DIFF
--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIdentityDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIdentityDao.java
@@ -26,7 +26,7 @@ public class HibernateIdentityDao implements IdentityDao {
   private SessionFactory sessionFactory;
 
   private Session currentSession() {
-    return sessionFactory.getCurrentSession();
+    return getSessionFactory().getCurrentSession();
   }
 
   @Override
@@ -68,6 +68,14 @@ public class HibernateIdentityDao implements IdentityDao {
     Date now = new Date();
     identity.setLastUpdated(now);
     currentSession().update(identity);
+  }
+
+  public SessionFactory getSessionFactory() {
+    return sessionFactory;
+  }
+
+  public void setSessionFactory(SessionFactory sessionFactory) {
+    this.sessionFactory = sessionFactory;
   }
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstituteDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstituteDao.java
@@ -26,7 +26,7 @@ public class HibernateInstituteDao implements InstituteDao {
   private SessionFactory sessionFactory;
 
   private Session currentSession() {
-    return sessionFactory.getCurrentSession();
+    return getSessionFactory().getCurrentSession();
   }
 
   @Override
@@ -60,6 +60,14 @@ public class HibernateInstituteDao implements InstituteDao {
     Date now = new Date();
     institute.setLastUpdated(now);
     currentSession().update(institute);
+  }
+
+  public SessionFactory getSessionFactory() {
+    return sessionFactory;
+  }
+
+  public void setSessionFactory(SessionFactory sessionFactory) {
+    this.sessionFactory = sessionFactory;
   }
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLabDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLabDao.java
@@ -26,7 +26,7 @@ public class HibernateLabDao implements LabDao {
   private SessionFactory sessionFactory;
 
   private Session currentSession() {
-    return sessionFactory.getCurrentSession();
+    return getSessionFactory().getCurrentSession();
   }
 
   @Override
@@ -60,6 +60,14 @@ public class HibernateLabDao implements LabDao {
     Date now = new Date();
     lab.setLastUpdated(now);
     currentSession().update(lab);
+  }
+
+  public SessionFactory getSessionFactory() {
+    return sessionFactory;
+  }
+
+  public void setSessionFactory(SessionFactory sessionFactory) {
+    this.sessionFactory = sessionFactory;
   }
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleNumberPerProjectDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleNumberPerProjectDao.java
@@ -30,7 +30,7 @@ public class HibernateSampleNumberPerProjectDao implements SampleNumberPerProjec
   private SessionFactory sessionFactory;
 
   private Session currentSession() {
-    return sessionFactory.getCurrentSession();
+    return getSessionFactory().getCurrentSession();
   }
 
   @Override
@@ -103,6 +103,14 @@ public class HibernateSampleNumberPerProjectDao implements SampleNumberPerProjec
       stringBuffer.append("0");
     }
     return stringBuffer.toString() + highestSampleNumber;
+  }
+
+  public SessionFactory getSessionFactory() {
+    return sessionFactory;
+  }
+
+  public void setSessionFactory(SessionFactory sessionFactory) {
+    this.sessionFactory = sessionFactory;
   }
 
 }

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/AllTestsSuite.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/AllTestsSuite.java
@@ -4,9 +4,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({
-  HibernateInstituteDaoTest.class,
-  HibernateLabDaoTest.class
-})
+@Suite.SuiteClasses({ HibernateInstituteDaoTest.class, HibernateLabDaoTest.class, HibernateIdentityDaoTest.class,
+    HibernateSampleNumberPerProjectDaoTest.class })
 public class AllTestsSuite {
 }

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIdentityDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIdentityDaoTest.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.Date;
 import java.util.List;
 
+import org.hibernate.SessionFactory;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -24,10 +26,18 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 
 public class HibernateIdentityDaoTest extends AbstractDAOTest {
-  
+
   @Autowired
+  private SessionFactory sessionFactory;
+
   private HibernateIdentityDao dao;
-  
+
+  @Before
+  public void setup() {
+    dao = new HibernateIdentityDao();
+    dao.setSessionFactory(sessionFactory);
+  }
+
   @Test
   public void testGetIdentity() {
     Identity identity = dao.getIdentity(1L);
@@ -95,7 +105,5 @@ public class HibernateIdentityDaoTest extends AbstractDAOTest {
     assertEquals(new Long(1), dao.getIdentity().get(0).getIdentityId());
 
   }
-
-
 
 }

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstituteDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstituteDaoTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertNull;
 import java.util.Date;
 import java.util.List;
 
+import org.hibernate.SessionFactory;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -19,10 +21,18 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import com.eaglegenomics.simlims.core.User;
 
 public class HibernateInstituteDaoTest extends AbstractDAOTest {
-  
-  @Autowired
+
   private HibernateInstituteDao dao;
-  
+
+  @Autowired
+  private SessionFactory sessionFactory;
+
+  @Before
+  public void setup() {
+    dao = new HibernateInstituteDao();
+    dao.setSessionFactory(sessionFactory);
+  }
+
   @Test
   public void testGetInstituteList() {
     List<Institute> list = dao.getInstitute();
@@ -37,7 +47,7 @@ public class HibernateInstituteDaoTest extends AbstractDAOTest {
     assertEquals(Long.valueOf(1L), i.getId());
     assertEquals("Institute A", i.getAlias());
   }
-  
+
   @Test
   public void testGetSingleInstituteNull() {
     Institute i = dao.getInstitute(100L);
@@ -70,13 +80,13 @@ public class HibernateInstituteDaoTest extends AbstractDAOTest {
     final Date oldDate = i.getLastUpdated();
     final String newAlias = "Changed Alias";
     i.setAlias(newAlias);
-    
+
     dao.update(i);
     Institute updated = dao.getInstitute(1L);
     assertEquals(newAlias, updated.getAlias());
     assertFalse(oldDate.equals(updated.getLastUpdated()));
   }
-  
+
   private Institute makeInstitute(String alias) {
     Institute i = new InstituteImpl();
     i.setAlias(alias);

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLabDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLabDaoTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertNull;
 import java.util.Date;
 import java.util.List;
 
+import org.hibernate.SessionFactory;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -21,17 +23,25 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.LabImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 
 public class HibernateLabDaoTest extends AbstractDAOTest {
-  
+
   @Autowired
+  private SessionFactory sessionFactory;
+
   private HibernateLabDao dao;
-  
+
+  @Before
+  public void setup() {
+    dao = new HibernateLabDao();
+    dao.setSessionFactory(sessionFactory);
+  }
+
   @Test
   public void testGetLabList() {
     List<Lab> list = dao.getLabs();
     assertNotNull(list);
     assertEquals(4, list.size());
   }
-  
+
   @Test
   public void testGetSingleLab() {
     Lab l = dao.getLab(1L);
@@ -40,13 +50,13 @@ public class HibernateLabDaoTest extends AbstractDAOTest {
     assertEquals("Lab A1", l.getAlias());
     assertEquals(Long.valueOf(1L), l.getInstitute().getId());
   }
-  
+
   @Test
   public void testGetSingleLabNull() {
     Lab l = dao.getLab(100L);
     assertNull(l);
   }
-  
+
   @Test
   public void testAddLab() {
     Lab l = new LabImpl();
@@ -60,27 +70,27 @@ public class HibernateLabDaoTest extends AbstractDAOTest {
     l.setUpdatedBy(user);
     Date now = new Date();
     l.setCreationDate(now);
-    
+
     final Long newId = dao.addLab(l);
     Lab saved = dao.getLab(newId);
     assertNotNull(saved);
     assertEquals(l.getAlias(), saved.getAlias());
     assertEquals(l.getInstitute().getId(), saved.getInstitute().getId());
   }
-  
+
   @Test
   public void testUpdateLab() {
     Lab l = dao.getLab(1L);
     final Date oldDate = l.getLastUpdated();
     final String newAlias = "Changed Alias";
     l.setAlias(newAlias);
-    
+
     dao.update(l);
     Lab updated = dao.getLab(1L);
     assertEquals(newAlias, updated.getAlias());
     assertFalse(oldDate.equals(updated.getLastUpdated()));
   }
-  
+
   @Test
   public void testDeleteLab() {
     Lab l = dao.getLab(1L);

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleNumberPerProjectDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleNumberPerProjectDaoTest.java
@@ -2,6 +2,8 @@ package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
+import org.hibernate.SessionFactory;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -15,7 +17,15 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 public class HibernateSampleNumberPerProjectDaoTest extends AbstractDAOTest {
 
   @Autowired
+  private SessionFactory sessionFactory;
+
   private HibernateSampleNumberPerProjectDao sampleNumberPerProjectDao;
+
+  @Before
+  public void setup() {
+    sampleNumberPerProjectDao = new HibernateSampleNumberPerProjectDao();
+    sampleNumberPerProjectDao.setSessionFactory(sessionFactory);
+  }
 
   @Test
   public void testNextNumber() throws Exception {

--- a/sqlstore/src/test/resources/db-test-context.xml
+++ b/sqlstore/src/test/resources/db-test-context.xml
@@ -87,13 +87,6 @@
     <property name="includeParameterTypes" value="false" />
   </bean>
   
-  <context:component-scan base-package="uk.ac.bbsrc.tgac.miso.persistence" /> 
-
-  <bean id="hibernateSampleDao" class="uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSampleDao">
-    <property name="jdbcTemplate" ref="interfaceTemplate" />
-    <property name="sessionFactory" ref="sessionFactory" />
-  </bean>
-  
   <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
     <property name="driverClass" value="org.h2.Driver"/>
     <property name="url" value="jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:db/scripts/init_tests.sql';"/>


### PR DESCRIPTION
Avoid attempting to autowire all of the Hibernate objects when performing
tests. They usually aren't required and autowiring them can create problems.