### PR TITLE
SQLPlatformDAO tests

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/PlatformStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/PlatformStore.java
@@ -47,13 +47,15 @@ public interface PlatformStore extends Store<Platform> {
   Platform getByModel(String model) throws IOException;
 
   /**
-   * List all Platforms
+   * List all Platforms given a Platform manufacturer name
    * 
+   * @param name
+   *          of type String
    * @return List<Platform>
    * @throws IOException
    *           when
    */
-  List<Platform> listByName() throws IOException;
+  List<Platform> listByName(String name) throws IOException;
 
   /**
    * List all distinct Platform names

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlatformDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlatformDAO.java
@@ -35,11 +35,13 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
+import uk.ac.bbsrc.tgac.miso.core.data.AbstractPlatform;
 import uk.ac.bbsrc.tgac.miso.core.data.Platform;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PlatformImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.store.PlatformStore;
+import uk.ac.bbsrc.tgac.miso.core.util.CoverageIgnore;
 
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
@@ -72,14 +74,17 @@ public class SQLPlatformDAO implements PlatformStore {
   @Autowired
   private DataObjectFactory dataObjectFactory;
 
+  @CoverageIgnore
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
   }
 
+  @CoverageIgnore
   public JdbcTemplate getJdbcTemplate() {
     return template;
   }
 
+  @CoverageIgnore
   public void setJdbcTemplate(JdbcTemplate template) {
     this.template = template;
   }
@@ -93,7 +98,7 @@ public class SQLPlatformDAO implements PlatformStore {
     params.addValue("description", platform.getDescription());
     params.addValue("numContainers", platform.getNumContainers());
 
-    if (platform.getPlatformId() == null) {
+    if (platform.getPlatformId() == AbstractPlatform.UNSAVED_ID) {
       SimpleJdbcInsert insert = new SimpleJdbcInsert(template).withTableName(TABLE_NAME).usingGeneratedKeyColumns("platformId");
       Number newId = insert.executeAndReturnKey(params);
       platform.setPlatformId(newId.longValue());
@@ -122,8 +127,8 @@ public class SQLPlatformDAO implements PlatformStore {
   }
 
   @Override
-  public List<Platform> listByName() {
-    List results = template.query(PLATFORMS_SELECT_BY_NAME, new PlatformMapper());
+  public List<Platform> listByName(String name) {
+    List results = template.query(PLATFORMS_SELECT_BY_NAME, new Object[] { name }, new PlatformMapper());
     return results;
   }
 
@@ -148,6 +153,7 @@ public class SQLPlatformDAO implements PlatformStore {
 
   public class PlatformMapper implements RowMapper<Platform> {
     @Override
+    @CoverageIgnore
     public Platform mapRow(ResultSet rs, int rowNum) throws SQLException {
       Platform p = new PlatformImpl();
       p.setPlatformId(rs.getLong("platformId"));

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/AllTestsSuite.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/AllTestsSuite.java
@@ -45,6 +45,7 @@ import org.junit.runners.Suite;
   SQLSequencerReferenceDAOTest.class,
   SQLSequencerPartitionContainerDAOTest.class,
   SQLBoxDAOTest.class,
+  SQLPlatformDAOTest.class,
   SQLSequencerServiceRecordDAOTest.class,
   SQLPoolDAOTest.class
 })

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlatformDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlatformDAOTest.java
@@ -1,0 +1,230 @@
+/* Copyright (c) 2012. The Genome Analysis Centre, Norwich, UK
+ * MISO project contacts: Robert Davey, Mario Caccamo @ TGAC
+ * * *********************************************************************
+ * *
+ * * This file is part of MISO.
+ * *
+ * * MISO is free software: you can redistribute it and/or modify
+ * * it under the terms of the GNU General Public License as published by
+ * * the Free Software Foundation, either version 3 of the License, or
+ * * (at your option) any later version.
+ * *
+ * * MISO is distributed in the hope that it will be useful,
+ * * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * * GNU General Public License for more details.
+ * *
+ * * You should have received a copy of the GNU General Public License
+ * * along with MISO.  If not, see <http://www.gnu.org/licenses/>.
+ * *
+ * * *********************************************************************
+ * */
+
+  package uk.ac.bbsrc.tgac.miso.sqlstore;
+  
+  import static org.junit.Assert.assertEquals;
+  import static org.junit.Assert.assertFalse;
+  import static org.junit.Assert.assertNotNull;
+  import static org.junit.Assert.assertNotSame;
+  import static org.junit.Assert.assertNull;
+  import static org.junit.Assert.assertTrue;
+
+  import java.io.IOException;
+  import java.util.ArrayList;
+  import java.util.Collection;
+  import java.util.HashMap;
+  import java.util.List;
+  import java.util.Map;
+
+  import net.sf.ehcache.CacheManager;
+
+  import org.junit.Before;
+  import org.junit.Rule;
+  import org.junit.Test;
+  import org.junit.rules.ExpectedException;
+  import org.mockito.InjectMocks;
+  import org.mockito.Matchers;
+  import org.mockito.Mock;
+  import org.mockito.Mockito;
+  import org.mockito.MockitoAnnotations;
+  import org.mockito.Spy;
+  import org.springframework.beans.factory.annotation.Autowired;
+  import org.springframework.jdbc.core.JdbcTemplate;
+
+  import com.eaglegenomics.simlims.core.SecurityProfile;
+  import com.eaglegenomics.simlims.core.User;
+  import com.eaglegenomics.simlims.core.store.SecurityStore;
+
+  import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
+  import uk.ac.bbsrc.tgac.miso.core.data.Platform;
+  import uk.ac.bbsrc.tgac.miso.core.data.Run;
+  import uk.ac.bbsrc.tgac.miso.core.data.SequencerPartitionContainer;
+  import uk.ac.bbsrc.tgac.miso.core.data.SequencerPoolPartition;
+  import uk.ac.bbsrc.tgac.miso.core.data.impl.PlatformImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
+import uk.ac.bbsrc.tgac.miso.core.factory.TgacDataObjectFactory;
+  import uk.ac.bbsrc.tgac.miso.core.store.ChangeLogStore;
+  import uk.ac.bbsrc.tgac.miso.core.store.PartitionStore;
+  import uk.ac.bbsrc.tgac.miso.core.store.PlatformStore;
+  import uk.ac.bbsrc.tgac.miso.core.store.RunStore;
+  import uk.ac.bbsrc.tgac.miso.core.store.Store;
+
+
+  public class SQLPlatformDAOTest extends AbstractDAOTest {
+    
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Autowired
+    @Spy
+    private JdbcTemplate jdbcTemplate;
+    
+    @InjectMocks
+    private SQLPlatformDAO dao;
+
+    // Auto-increment sequence doesn't roll back with transactions, so must be tracked
+    // There are 25 Platforms created during migrations, so this is the next id.
+    // This will have to be changed if new Platforms are added during migrations.
+    private static long nextAutoIncrementId = 26L;
+    
+    @Before
+    public void setup() throws IOException {
+      MockitoAnnotations.initMocks(this);
+      dao.setJdbcTemplate(jdbcTemplate);
+      dao.setDataObjectFactory(new TgacDataObjectFactory());
+    }
+    
+    @Test
+    public void testListAll() {
+      List<Platform> platforms = dao.listAll();
+      assertEquals(3, platforms.size());
+    }
+    
+    @Test
+    public void testPlatformCount() throws IOException {
+      assertEquals(3, dao.count());
+    }
+    
+    @Test
+    public void testListDistinctPlatformNames() {
+      List<String> distinctPlatformNames = dao.listDistinctPlatformNames();
+      assertEquals(2, distinctPlatformNames.size());
+    }
+    
+    @Test
+    public void testListbyName() {
+      List<Platform> platforms = dao.listByName("Illumina");
+      assertEquals(2, platforms.size());
+    }
+    
+    @Test
+    public void testListbyNameNone() {
+      List<Platform> platforms = dao.listByName("Futurism");
+      assertEquals(0, platforms.size());
+    }
+    
+    @Test
+    public void testListByNameEmpty() {
+	  List<Platform> platforms = dao.listByName("");
+      assertEquals(0, platforms.size());
+    }
+    
+    @Test
+    public void testListByNameNull() {
+      List<Platform> platforms = dao.listByName(null);
+      assertEquals(0, platforms.size());
+    }
+    
+    @Test
+    public void testGetByModel() {
+      Platform platform = dao.getByModel("PacBio RS");
+      assertNotNull(platform);
+    }
+    
+    @Test
+    public void testGetByModelNone() {
+      Platform platform = dao.getByModel("Coco Rocha");
+      assertNull(platform);
+    }
+    
+    @Test
+    public void testGetByModelEmpty() {
+      Platform platform = dao.getByModel("");
+      assertNull(platform);
+    }
+    
+    @Test
+    public void testGetByModelNull() {
+      Platform platform = dao.getByModel(null);
+      assertNull(platform);
+    }
+    
+    @Test
+    public void testGet() throws IOException {
+      Platform platform = dao.get(16L);
+      assertNotNull(platform);
+    }
+    
+    @Test
+    public void testGetNone() throws IOException {
+      Platform platform = dao.get(-9999L);
+      assertNull(platform);
+    }
+    
+    @Test
+    public void testLazyGet() throws IOException {
+      Platform platform = dao.lazyGet(16L);
+      assertNotNull(platform);
+    }
+
+    @Test
+    public void testSaveEdit() throws IOException {
+      Platform platform = dao.get(16L);
+      
+      platform.setPlatformType(platform.getPlatformType());
+      platform.setInstrumentModel("Illumina HiSeq 2500");
+      platform.setDescription("4-channel flow cell");
+      platform.setNumContainers(1);
+      
+      assertEquals(16L, dao.save(platform));
+      Platform savedPlatform = dao.get(16L);
+      assertNotSame(platform, savedPlatform);
+      assertEquals(platform.getPlatformId(), savedPlatform.getPlatformId());
+      assertEquals("Illumina HiSeq 2500", savedPlatform.getInstrumentModel());
+      assertEquals("4-channel flow cell", savedPlatform.getDescription());
+      assertEquals("Illumina", savedPlatform.getPlatformType().getKey());
+    }
+    
+    @Test
+    public void testSaveNew() throws IOException {
+      long autoIncrementId = nextAutoIncrementId;
+      Platform newPlatform = makePlatform("PacBio","Mystery container", 1);
+      mockAutoIncrement(autoIncrementId);
+      assertEquals(autoIncrementId, dao.save(newPlatform));
+      
+      Platform savedPlatform = dao.get(autoIncrementId);
+      assertEquals(newPlatform.getDescription(), savedPlatform.getDescription());
+      nextAutoIncrementId += 1;
+    }
+    
+    @Test
+    public void testSaveNull() throws IOException {
+       exception.expect(NullPointerException.class);
+       dao.save(null);
+    }
+    
+    Platform makePlatform(String instrumentModel, String description, Integer numContainers) {
+      Platform platform = new PlatformImpl();
+      platform.setDescription(description);
+      platform.setNumContainers(numContainers);
+      platform.setInstrumentModel(instrumentModel);
+      platform.setPlatformType((PlatformType) PlatformType.get("PacBio"));
+      return platform;
+    }
+    
+    private void mockAutoIncrement(long value) {
+       Map<String, Object> rs = new HashMap<>();
+       rs.put("auto_increment",  value);
+       Mockito.doReturn(rs).when(jdbcTemplate).queryForMap(Matchers.anyString());
+    }
+  }


### PR DESCRIPTION
Note: Since Platforms get added as part of the migration scripts (before the test data is migrated), nextAutoIncrementId needs to be the ID after the last of the added Platforms since neither MySQL nor H2 roll IDs back.