### PR TITLE
Correct wiring after LibraryDilution DAO tests

### DIFF
--- a/miso-web/src/main/resources/sql/db-config.xml
+++ b/miso-web/src/main/resources/sql/db-config.xml
@@ -185,7 +185,6 @@
       <value type="javax.persistence.CascadeType">REMOVE</value>
     </property>
     <property name="securityProfileDAO" ref="sqlSecurityProfileDAO" />
-    <property name="emPcrDAO" ref="sqlEmPCRDAO" />
     <property name="libraryDAO" ref="sqlLibraryDAO" />
     <property name="jdbcTemplate" ref="interfaceTemplate" />
   </bean>


### PR DESCRIPTION
(https://github.com/TGAC/miso-lims/pull/137) removed the need to wire
emPcrDAO in the sqlLibraryDilutionDAO.