### PR TITLE
allow users to delete their own notes

### DIFF
--- a/miso-web/src/main/webapp/pages/editLibrary.jsp
+++ b/miso-web/src/main/webapp/pages/editLibrary.jsp
@@ -473,7 +473,7 @@
           <div class="exppreview" id="library-notes-${n.count}">
             <b>${note.creationDate}</b>: ${note.text}
               <span class="float-right" style="font-weight:bold; color:#C0C0C0;">${note.owner.loginName}
-                <c:if test="${(project.securityProfile.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
+                <c:if test="${(note.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
                                 or fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')}">
                 <span style="color:#000000"><a href='#' onclick="Library.ui.deleteLibraryNote('${library.id}', '${note.noteId}');">
                   <span class="ui-icon ui-icon-trash" style="clear: both; position: relative; float: right; margin-top: -15px;"/></a></span>

--- a/miso-web/src/main/webapp/pages/editPool.jsp
+++ b/miso-web/src/main/webapp/pages/editPool.jsp
@@ -220,11 +220,13 @@
           <c:forEach items="${pool.notes}" var="note" varStatus="n">
             <div class="exppreview" id="pool-notes-${n.count}">
               <b>${note.creationDate}</b>: ${note.text}
-              <span class="float-right" style="font-weight:bold; color:#C0C0C0;">${note.owner.loginName}
-                <c:if test="${(project.securityProfile.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
+              <span class="float-right" style="font-weight:bold; color:#C0C0C0;">${note.owner.loginName}</span>
+                <c:if test="${(note.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
                                 or fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')}">
-                  <span style="color:#000000"><a href='#' onclick="Pool.ui.deletePoolNote('${pool.id}', '${note.noteId}');">
-                    <span class="ui-icon ui-icon-trash" style="clear: both; position: relative; float: right; margin-top: -15px;"/></a></span>
+                  <span style="color:#000000">
+                    <a href='#' onclick="Pool.ui.deletePoolNote('${pool.id}', '${note.noteId}');">
+                      <span class="ui-icon ui-icon-trash" style="clear: both; position: relative; float: right; margin-top: -15px;"></span>
+                    </a>
                   </span>
                 </c:if>
             </div>

--- a/miso-web/src/main/webapp/pages/editProject.jsp
+++ b/miso-web/src/main/webapp/pages/editProject.jsp
@@ -290,10 +290,13 @@
         <div class="exppreview" id="overview-notes-${n.count}">
           <b>${note.creationDate}</b>: ${note.text}
           <span class="float-right" style="font-weight:bold; color:#C0C0C0;">${note.owner.loginName}
-            <c:if test="${(project.securityProfile.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
+            <c:if test="${(note.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
                             or fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')}">
-            <span style="color:#000000"><a href='#' onclick="Project.overview.deleteProjectOverviewNote('${overview.overviewId}', '${note.noteId}');">
-              <span class="ui-icon ui-icon-trash" style="clear: both; position: relative; float: right; margin-top: -15px;"/></a></span>
+              <span style="color:#000000">
+                <a href='#' onclick="Project.overview.deleteProjectOverviewNote('${overview.overviewId}', '${note.noteId}');">
+                  <span class="ui-icon ui-icon-trash" style="clear: both; position: relative; float: right; margin-top: -15px;"></span>
+                </a>
+              </span>
             </c:if>
           </span>
         </div>

--- a/miso-web/src/main/webapp/pages/editRun.jsp
+++ b/miso-web/src/main/webapp/pages/editRun.jsp
@@ -317,10 +317,13 @@
             <b>${note.creationDate}</b>: ${note.text}
           <span class="float-right"
                 style="font-weight:bold; color:#C0C0C0;">${note.owner.loginName}
-            <c:if test="${(project.securityProfile.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
+            <c:if test="${(note.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
                             or fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')}">
-            <span style="color:#000000"><a href='#' onclick="Run.ui.deleteRunNote('${run.runId}', '${note.noteId}');">
-              <span class="ui-icon ui-icon-trash" style="clear: both; position: relative; float: right; margin-top: -15px;"/></a></span>
+              <span style="color:#000000">
+                <a href='#' onclick="Run.ui.deleteRunNote('${run.runId}', '${note.noteId}');">
+                  <span class="ui-icon ui-icon-trash" style="clear: both; position: relative; float: right; margin-top: -15px;"></span>
+                </a>
+              </span>
             </c:if>
           </span>
           </div>

--- a/miso-web/src/main/webapp/pages/editSample.jsp
+++ b/miso-web/src/main/webapp/pages/editSample.jsp
@@ -313,7 +313,7 @@
             <div class="exppreview" id="sample-notes-${n.count}">
               <b>${note.creationDate}</b>: ${note.text}
               <span class="float-right" style="font-weight:bold; color:#C0C0C0;">${note.owner.loginName}
-                <c:if test="${(project.securityProfile.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
+                <c:if test="${(note.owner.loginName eq SPRING_SECURITY_CONTEXT.authentication.principal.username)
                                 or fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')}">
                 <span style="color:#000000"><a href='#' onclick="Sample.ui.deleteSampleNote('${sample.sampleId}', '${note.noteId}');">
                   <span class="ui-icon ui-icon-trash" style="clear: both; position: relative; float: right; margin-top: -15px;"/></a></span>


### PR DESCRIPTION
Allows non-admin users to delete their own notes on Sample, Library, Pool, Run, and ProjectOverview. This seems to have been the original intended behaviour, but was thwarted by copy pasta.