### PR TITLE
GLT-519 Sample hierarchy transactions working again. Sample alias and name saved correctly.

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
@@ -24,13 +24,11 @@
 package uk.ac.bbsrc.tgac.miso.core.data;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -60,7 +58,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.IdentityImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAdditionalInfoImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAnalyteImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAnalyteNode;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleIdentityNode;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleTissueImpl;
@@ -156,7 +153,8 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
   private Sample parent;
 
   @OneToMany(targetEntity = SampleImpl.class, fetch = FetchType.LAZY)
-  @JoinTable(name = "SampleHierarchy", joinColumns = @JoinColumn(name = "parentId") , inverseJoinColumns = @JoinColumn(name = "childId") )
+  @JoinTable(name = "SampleHierarchy", joinColumns = @JoinColumn(name = "parentId"), inverseJoinColumns = @JoinColumn(name = "childId"))
+  @Cascade({ CascadeType.SAVE_UPDATE })
   private Set<Sample> children = new HashSet<Sample>();
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleImpl.java
@@ -54,6 +54,7 @@ public class SampleImpl extends AbstractSample implements Serializable {
    */
   public SampleImpl() {
     setSecurityProfile(new SecurityProfile());
+    setSecurityProfileId(getSecurityProfile().getProfileId());
   }
 
   /**
@@ -64,6 +65,7 @@ public class SampleImpl extends AbstractSample implements Serializable {
    */
   public SampleImpl(User user) {
     setSecurityProfile(new SecurityProfile(user));
+    setSecurityProfileId(getSecurityProfile().getProfileId());
   }
 
   /**
@@ -79,10 +81,12 @@ public class SampleImpl extends AbstractSample implements Serializable {
     if (project.userCanRead(user)) {
       setProject(project);
       setSecurityProfile(project.getSecurityProfile());
+      setSecurityProfileId(getSecurityProfile().getProfileId());
     } else {
       log.error(String.format("User %s does not have permission to read Project %s. Unable to create Sample.", user.getFullName(),
           project.getAlias()));
       setSecurityProfile(new SecurityProfile(user));
+      setSecurityProfileId(getSecurityProfile().getProfileId());
     }
   }
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/event/manager/ProjectAlertManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/event/manager/ProjectAlertManager.java
@@ -111,6 +111,7 @@ public class ProjectAlertManager {
   public void push(Project project) {
     if (enabled) {
       if (project != null) {
+        cloner.dontClone(org.hibernate.collection.internal.PersistentSet.class);
         Project clone = cloner.deepClone(project);
         if (clone != null) {
           if (projects.containsKey(project.getId())) {

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/SampleDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/SampleDao.java
@@ -1,6 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.persistence;
 
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.List;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
@@ -12,7 +13,7 @@ public interface SampleDao {
 
   Sample getSample(Long id) throws IOException;
 
-  Long addSample(Sample sample) throws IOException, MisoNamingException;
+  Long addSample(Sample sample) throws IOException, MisoNamingException, SQLException;
 
   void deleteSample(Sample sample);
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleValidRelationshipDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleValidRelationshipDao.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.SampleValidRelationship;
@@ -30,6 +31,7 @@ public class HibernateSampleValidRelationshipDao implements SampleValidRelations
   }
 
   @Override
+  @Transactional(propagation = Propagation.REQUIRED)
   public List<SampleValidRelationship> getSampleValidRelationship() {
     Query query = currentSession().createQuery("from SampleValidRelationshipImpl");
     @SuppressWarnings("unchecked")

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSecurityProfileDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSecurityProfileDAO.java
@@ -40,6 +40,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.Group;
@@ -107,9 +108,9 @@ public class SQLSecurityProfileDAO implements Store<SecurityProfile> {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
+  @Transactional(readOnly = false, rollbackFor = IOException.class, propagation = Propagation.REQUIRED)
   @TriggersRemove(cacheName = { "securityProfileCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
-      @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
+      @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))
   public long save(SecurityProfile securityProfile) throws IOException {
     SimpleJdbcInsert insert = new SimpleJdbcInsert(template).withTableName(TABLE_NAME);
     MapSqlParameterSource params = new MapSqlParameterSource();
@@ -204,7 +205,7 @@ public class SQLSecurityProfileDAO implements Store<SecurityProfile> {
 
   @Override
   @Cacheable(cacheName = "securityProfileCache", keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
-      @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
+      @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))
   public SecurityProfile get(long id) throws IOException {
     List results = template.query(PROFILE_SELECT_BY_ID, new Object[] { id }, new SecurityProfileMapper());
     SecurityProfile sp = results.size() > 0 ? (SecurityProfile) results.get(0) : null;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/AllTestsSuite.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/AllTestsSuite.java
@@ -8,6 +8,7 @@ import org.junit.runners.Suite;
   HibernateInstituteDaoTest.class,
   HibernateLabDaoTest.class,
   HibernateIdentityDaoTest.class,
+  HibernateSampleDaoTest.class,
   HibernateSampleNumberPerProjectDaoTest.class,
   HibernateLibraryAdditionalInfoDaoTest.class
 })

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
@@ -1,0 +1,96 @@
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.bbsrc.tgac.miso.core.data.Sample;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
+import uk.ac.bbsrc.tgac.miso.core.service.naming.DefaultSampleNamingScheme;
+
+public class HibernateSampleDaoTest {
+
+  private HibernateSampleDao sut;
+
+  @Before
+  public void setUp() throws Exception {
+    sut = new HibernateSampleDao();
+    sut.setNamingScheme(new DefaultSampleNamingScheme());
+  }
+
+  @Test
+  public void parentNameNotModifiedWhenParentNullTest() throws Exception {
+    Sample sample = new SampleImpl();
+    sut.updateParentSampleNameIfRequired(sample);
+    assertNull("Null parent will remain null. No need to udate sample name.", sample.getParent());
+  }
+
+  @Test
+  public void parentNameNotModifiedWhenParentNameNotTemporaryTest() throws Exception {
+    Sample sample = new SampleImpl();
+    Sample parent = new SampleImpl();
+    sample.setParent(parent);
+    String nonTemporaryName = "RealSampleName";
+    parent.setName(nonTemporaryName);
+    sut.updateParentSampleNameIfRequired(sample);
+    assertThat("Parent has a non-temporary name. No need to udate sample name.", sample.getParent().getName(), is(nonTemporaryName));
+  }
+
+  @Test
+  public void parentNameNotModifiedWhenParentIdNotSetTest() throws Exception {
+    Sample sample = new SampleImpl();
+    Sample parent = new SampleImpl();
+    sample.setParent(parent);
+    String temporaryName = HibernateSampleDao.generateTemporaryName();
+    parent.setName(temporaryName);
+    parent.setId(Sample.UNSAVED_ID);
+    sut.updateParentSampleNameIfRequired(sample);
+    assertThat("Parent has not been assigned an id. No need to udate sample name.", sample.getParent().getName(), is(temporaryName));
+  }
+
+  @Test
+  public void parentNameModifiedTest() throws Exception {
+    Sample sample = new SampleImpl();
+    Sample parent = new SampleImpl();
+    sample.setParent(parent);
+    String temporaryName = HibernateSampleDao.generateTemporaryName();
+    parent.setName(temporaryName);
+    parent.setId(42);
+    sut.updateParentSampleNameIfRequired(sample);
+    assertThat("Parent has temporary name and an id. Update sample name.", sample.getParent().getName(), is("SAM42"));
+  }
+
+  @Test
+  public void temporarySampleNameTest() throws Exception {
+    Sample sample = new SampleImpl();
+    sample.setName(HibernateSampleDao.generateTemporaryName());
+    assertTrue("Temporary sample names must return true.", HibernateSampleDao.hasTemporaryName(sample));
+  }
+
+  @Test
+  public void notTemporarySampleNameTest() throws Exception {
+    Sample sample = new SampleImpl();
+    sample.setName("RealSampleName");
+    assertFalse("Real sample names must return false.", HibernateSampleDao.hasTemporaryName(sample));
+  }
+
+  @Test
+  public void nullSampleNameTest() throws Exception {
+    Sample sample = new SampleImpl();
+    sample.setName(null);
+    assertFalse("Non-temporary sample names must return false.", HibernateSampleDao.hasTemporaryName(sample));
+  }
+
+  @Test
+  public void nullSampleObjectNameTest() throws Exception {
+    Sample sample = null;
+    assertFalse("A null sample object does not contain a temporary name so must return false.",
+        HibernateSampleDao.hasTemporaryName(sample));
+  }
+
+}


### PR DESCRIPTION
GLT-519 Update to allow hiberate and JDBC to work together within a single transaction.

GLT-519 Cascade saving child sample information.

GLT-519 Set the securityProfileId explicitly based on the provided SecurityProfile.

GLT-519 Avoid cloning hibernate specific portion of persisted Project.

GLT-519 Use existing transaction if one exists when retrieving sample valid relationships.

GLT-519 Use existing transaction if when is present when saving SecurityProfile.

GLT-519 Move call to query.list early in the transaction to avoid unnecessary auto flush.

GLT-519 Execute JDBC statements in session.doWork calls to avoid flushing and ending transaction.

GLT-519 Catching GenericJDBCException thrown by session.doWork calls.

GLT-519 addSample can now throw SQLException.

GLT-519 Handle giving samples temporary names and then generating actual names later.

GLT-519 Set temporary name for sample created with sample ws.

GLT-519 Retrieve alias list without attempting to connect other objects with JDBC calls. This is important since during sample creation some of these object can still be null.
Moved the hibernate save to the beginning of the method to ensure it runs early to create as much of the object as possible before other methods run. This ensure that the parent sample exists, if provided.

GLT-519 Added tests for Sample name generation.

GLT-519 Removed unnecessary set of security profile. Added test to suite.