### PR TITLE
GLT-529 add Platforms and update Groovy script to ignore site-specific migrations

### DIFF
--- a/sqlstore/src/main/resources/db/migration/V0019__more_platforms.sql
+++ b/sqlstore/src/main/resources/db/migration/V0019__more_platforms.sql
@@ -1,0 +1,8 @@
+INSERT INTO `Platform` (name, instrumentModel, description, numContainers) VALUES
+  ('Illumina', 'Illumina HiSeq 2500', '4-channel flowgram', 1),
+  ('Illumina', 'Illumina NextSeq 500', '4-channel flowgram', 1),
+  ('Illumina', 'Illumina HiSeq X Ten', '4-channel flowgram', 1),
+  ('OxfordNanopore', 'MinION', 'Nanopore', 1),
+  ('OxfordNanopore', 'GridION', 'Nanopore', 1),
+  ('IonTorrent', 'Ion Torrent PGM', 'Ion Torrent', 1),
+  ('IonTorrent', 'Ion Torrent Proton', 'Ion Torrent', 1);

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlatformDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlatformDAOTest.java
@@ -83,9 +83,9 @@ import uk.ac.bbsrc.tgac.miso.core.factory.TgacDataObjectFactory;
     private SQLPlatformDAO dao;
 
     // Auto-increment sequence doesn't roll back with transactions, so must be tracked
-    // There are 25 Platforms created during migrations, so this is the next id.
+    // There are 32 Platforms created during migrations, so this is the next id.
     // This will have to be changed if new Platforms are added during migrations.
-    private static long nextAutoIncrementId = 26L;
+    private static long nextAutoIncrementId = 33L;
     
     @Before
     public void setup() throws IOException {

--- a/sqlstore/src/test/resources/db/scripts/schema_translator.groovy
+++ b/sqlstore/src/test/resources/db/scripts/schema_translator.groovy
@@ -14,7 +14,9 @@ import java.nio.file.attribute.PosixFilePermissions;
 final String basedir = "${project.basedir}"
 final File productionSchemaDir = new File(basedir + '/src/main/resources/db/migration/')
 println('Translating schema files from ' + productionSchemaDir.getAbsolutePath() + '...')
-final String productionScriptPattern = '^V\\d{4}_.*\\.sql$'
+
+// ignore V8000-series site-specific migrations as they will cause tests to fail
+final String productionScriptPattern = '^V[0-79]\\d{3}_.*\\.sql$'
 final String testSchemaDir = basedir + '/target/test-classes/db/test_migration/'
 
 Files.createDirectories(Paths.get(testSchemaDir))

--- a/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
+++ b/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
@@ -352,11 +352,11 @@ VALUES (33, 2);
 
 
 DELETE FROM `Kit_Note`;
-INSERT INTO `Kit_note`(`kit_kitId`, `notes_noteId`)
+INSERT INTO `Kit_Note`(`kit_kitId`, `notes_noteId`)
 VALUES (33, 1);
 
 DELETE FROM `Sample_Note`;
-INSERT INTO `Sample_note`(`sample_sampleId`, `notes_noteId`)
+INSERT INTO `Sample_Note`(`sample_sampleId`, `notes_noteId`)
 VALUES (33, 2);
 
 DELETE FROM `Library_Note`;
@@ -364,12 +364,6 @@ INSERT INTO `Library_Note`(`library_libraryId`, `notes_noteId`)
 VALUES (33, 3);
 
 DELETE FROM `Run_Note`;
-INSERT INTO `Run_Note`(`run_runId`, `notes_noteId`)
-VALUES (33, 1);
-
-DELETE FROM `Pool_Note`;
-INSERT INTO `Pool_Note`(`pool_poolId`, `notes_noteId`)
-VALUES (33, 2);DELETE FROM `Run_Note`;
 INSERT INTO `Run_Note`(`run_runId`, `notes_noteId`)
 VALUES (33, 1);
 


### PR DESCRIPTION
- adds additional Platforms and updates PlatformDAOTests
- minor syntax fixes in V9000 test data
- updates Groovy script to ignore site-specific V8000-series migrations