### PR TITLE
remove redundant DB relationships, edit sample elements via sample webservice

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
@@ -37,7 +37,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
@@ -128,23 +127,19 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
   @JoinColumn(name = "lastModifier", nullable = false)
   private User lastModifier;
 
-  @OneToOne(targetEntity = SampleAnalyteImpl.class)
-  @JoinColumn(name = "sampleAnalyteId")
+  @OneToOne(targetEntity = SampleAnalyteImpl.class, mappedBy = "sample")
   @Cascade({ CascadeType.SAVE_UPDATE })
   private SampleAnalyte sampleAnalyte;
 
-  @OneToOne(targetEntity = SampleTissueImpl.class)
-  @JoinColumn(name = "sampleTissueId")
+  @OneToOne(targetEntity = SampleTissueImpl.class, mappedBy = "sample")
   @Cascade({ CascadeType.SAVE_UPDATE })
   private SampleTissue sampleTissue;
 
-  @OneToOne(targetEntity = IdentityImpl.class)
-  @JoinColumn(name = "identityId")
+  @OneToOne(targetEntity = IdentityImpl.class, mappedBy = "sample")
   @Cascade({ CascadeType.SAVE_UPDATE })
   private Identity identity;
 
-  @OneToOne(targetEntity = SampleAdditionalInfoImpl.class)
-  @JoinColumn(name = "sampleAdditionalInfoId")
+  @OneToOne(targetEntity = SampleAdditionalInfoImpl.class, mappedBy = "sample")
   @Cascade({ CascadeType.SAVE_UPDATE })
   private SampleAdditionalInfo sampleAdditionalInfo;
 
@@ -153,8 +148,7 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
   @Cascade({ CascadeType.SAVE_UPDATE })
   private Sample parent;
 
-  @OneToMany(targetEntity = SampleImpl.class, fetch = FetchType.EAGER)
-  @JoinTable(name = "SampleHierarchy", joinColumns = @JoinColumn(name = "parentId"), inverseJoinColumns = @JoinColumn(name = "childId"))
+  @OneToMany(targetEntity = SampleImpl.class, fetch = FetchType.LAZY, mappedBy = "parent")
   @Cascade({ CascadeType.SAVE_UPDATE })
   private Set<Sample> children = new HashSet<Sample>();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Identity.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Identity.java
@@ -9,9 +9,9 @@ import com.eaglegenomics.simlims.core.User;
 @JsonIgnoreProperties({ "sample" })
 public interface Identity {
 
-  Long getIdentityId();
+  Long getSampleId();
 
-  void setIdentityId(Long identityId);
+  void setSampleId(Long sampleId);
 
   Sample getSample();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAdditionalInfo.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAdditionalInfo.java
@@ -15,9 +15,9 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
 @JsonIgnoreProperties({ "sample" })
 public interface SampleAdditionalInfo {
 
-  Long getSampleAdditionalInfoId();
+  Long getSampleId();
 
-  void setSampleAdditionalInfoId(Long sampleAdditionalInfoId);
+  void setSampleId(Long sampleAdditionalInfoId);
 
   Sample getSample();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAnalyte.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAnalyte.java
@@ -9,9 +9,9 @@ import com.eaglegenomics.simlims.core.User;
 @JsonIgnoreProperties({ "sample" })
 public interface SampleAnalyte {
 
-  Long getSampleAnalyteId();
+  Long getSampleId();
 
-  void setSampleAnalyteId(Long sampleAnalyteId);
+  void setSampleId(Long sampleId);
 
   Sample getSample();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleTissue.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleTissue.java
@@ -9,9 +9,9 @@ import com.eaglegenomics.simlims.core.User;
 @JsonIgnoreProperties({ "sample" })
 public interface SampleTissue {
 
-  Long getSampleTissueId();
+  Long getSampleId();
 
-  void setSampleTissueId(Long sampleTissueId);
+  void setSampleId(Long sampleId);
 
   Sample getSample();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/IdentityImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/IdentityImpl.java
@@ -4,10 +4,9 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
@@ -21,11 +20,11 @@ import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 public class IdentityImpl implements Identity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long identityId;
+  private Long sampleId;
 
   @OneToOne(targetEntity = SampleImpl.class)
   @JoinColumn(name = "sampleId", nullable = false)
+  @MapsId
   private Sample sample;
 
   @Column(unique = true, nullable = false)
@@ -49,13 +48,13 @@ public class IdentityImpl implements Identity {
   private Date lastUpdated;
 
   @Override
-  public Long getIdentityId() {
-    return identityId;
+  public Long getSampleId() {
+    return sampleId;
   }
 
   @Override
-  public void setIdentityId(Long identityId) {
-    this.identityId = identityId;
+  public void setSampleId(Long sampleId) {
+    this.sampleId = sampleId;
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAdditionalInfoImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAdditionalInfoImpl.java
@@ -6,10 +6,9 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -31,11 +30,11 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
 public class SampleAdditionalInfoImpl implements SampleAdditionalInfo {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  private Long sampleAdditionalInfoId;
+  private Long sampleId;
 
   @OneToOne(targetEntity = SampleImpl.class)
   @JoinColumn(name = "sampleId", nullable = false)
+  @MapsId
   private Sample sample;
 
   @OneToOne(targetEntity = SampleClassImpl.class)
@@ -96,13 +95,13 @@ public class SampleAdditionalInfoImpl implements SampleAdditionalInfo {
   private Date lastUpdated;
 
   @Override
-  public Long getSampleAdditionalInfoId() {
-    return sampleAdditionalInfoId;
+  public Long getSampleId() {
+    return sampleId;
   }
 
   @Override
-  public void setSampleAdditionalInfoId(Long sampleAdditionalInfoId) {
-    this.sampleAdditionalInfoId = sampleAdditionalInfoId;
+  public void setSampleId(Long sampleAdditionalInfoId) {
+    this.sampleId = sampleAdditionalInfoId;
   }
 
   @Override
@@ -304,7 +303,7 @@ public class SampleAdditionalInfoImpl implements SampleAdditionalInfo {
 
   @Override
   public String toString() {
-    return "SampleAdditionalInfoImpl [sampleAdditionalInfoId=" + sampleAdditionalInfoId + ", sample=" + sample + ", sampleClass="
+    return "SampleAdditionalInfoImpl [sampleId=" + sampleId + ", sample=" + sample + ", sampleClass="
         + sampleClass + ", tissueOrigin=" + tissueOrigin + ", tissueType=" + tissueType + ", qcPassedDetail=" + qcPassedDetail
         + ", subproject=" + subproject + ", lab=" + lab + ", kitDescriptorId=" + kitDescriptorId + ", prepKit=" + prepKit
         + ", passageNumber=" + passageNumber + ", timesReceived=" + timesReceived + ", tubeNumber=" + tubeNumber + ", concentration="

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAnalyteImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAnalyteImpl.java
@@ -4,10 +4,9 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
@@ -24,11 +23,11 @@ import uk.ac.bbsrc.tgac.miso.core.data.TissueMaterial;
 public class SampleAnalyteImpl implements SampleAnalyte {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long sampleAnalyteId;
+  private Long sampleId;
 
   @OneToOne(targetEntity = SampleImpl.class)
   @JoinColumn(name = "sampleId", nullable = false)
+  @MapsId
   private Sample sample;
 
   @OneToOne(targetEntity = SamplePurposeImpl.class)
@@ -63,13 +62,13 @@ public class SampleAnalyteImpl implements SampleAnalyte {
   private Date lastUpdated;
 
   @Override
-  public Long getSampleAnalyteId() {
-    return sampleAnalyteId;
+  public Long getSampleId() {
+    return sampleId;
   }
 
   @Override
-  public void setSampleAnalyteId(Long sampleAnalyteId) {
-    this.sampleAnalyteId = sampleAnalyteId;
+  public void setSampleId(Long sampleId) {
+    this.sampleId = sampleId;
   }
 
   @Override
@@ -194,7 +193,7 @@ public class SampleAnalyteImpl implements SampleAnalyte {
 
   @Override
   public String toString() {
-    return "SampleAnalyteImpl [sampleAnalyteId=" + sampleAnalyteId + ", sample=" + sample + ", samplePurpose=" + samplePurpose
+    return "SampleAnalyteImpl [sampleAnalyteId=" + sampleId + ", sample=" + sample + ", samplePurpose=" + samplePurpose
         + ", sampleGroup=" + sampleGroup + ", tissueMaterial=" + tissueMaterial + ", region=" + region + ", tubeId=" + tubeId
         + ", stockNumber=" + stockNumber + ", aliquotNumber=" + aliquotNumber + ", createdBy=" + createdBy + ", creationDate="
         + creationDate + ", updatedBy=" + updatedBy + ", lastUpdated=" + lastUpdated + "]";

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleTissueImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleTissueImpl.java
@@ -4,10 +4,9 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
@@ -21,11 +20,11 @@ import uk.ac.bbsrc.tgac.miso.core.data.SampleTissue;
 public class SampleTissueImpl implements SampleTissue {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long sampleTissueId;
+  private Long sampleId;
 
   @OneToOne(targetEntity = SampleImpl.class)
   @JoinColumn(name = "sampleId", nullable = false)
+  @MapsId
   private Sample sample;
 
   private String instituteTissueName;
@@ -116,18 +115,18 @@ public class SampleTissueImpl implements SampleTissue {
   }
 
   @Override
-  public Long getSampleTissueId() {
-    return sampleTissueId;
+  public Long getSampleId() {
+    return sampleId;
   }
 
   @Override
-  public void setSampleTissueId(Long sampleTissueId) {
-    this.sampleTissueId = sampleTissueId;
+  public void setSampleId(Long sampleId) {
+    this.sampleId = sampleId;
   }
 
   @Override
   public String toString() {
-    return "SampleTissueImpl [id=" + sampleTissueId + ", sample=" + sample + ", instituteTissueName=" + instituteTissueName
+    return "SampleTissueImpl [sampleId=" + sampleId + ", sample=" + sample + ", instituteTissueName=" + instituteTissueName
         + ", cellularity=" + cellularity + ", createdBy=" + createdBy + ", creationDate=" + creationDate + ", updatedBy=" + updatedBy
         + ", lastUpdated=" + lastUpdated + "]";
   }

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -199,8 +199,7 @@ public class Dtos {
 
   public static SampleAdditionalInfoDto asDto(SampleAdditionalInfo from) {
     SampleAdditionalInfoDto dto = new SampleAdditionalInfoDto();
-    dto.setId(from.getSampleAdditionalInfoId());
-    dto.setSampleId(from.getSample().getId());
+    dto.setSampleId(from.getSampleId());
     dto.setSampleClassId(from.getSampleClass().getSampleClassId());
     if (from.getLab() != null) {
       dto.setLabId(from.getLab().getId());
@@ -242,12 +241,43 @@ public class Dtos {
 
   public static SampleAdditionalInfo to(SampleAdditionalInfoDto from) {
     SampleAdditionalInfo to = new SampleAdditionalInfoImpl();
+    to.setSampleId(from.getSampleId());
     to.setPassageNumber(from.getPassageNumber());
     to.setTimesReceived(from.getTimesReceived());
     to.setTubeNumber(from.getTubeNumber());
     to.setConcentration(from.getConcentration());
     if (from.getStrStatus() != null) {
       to.setStrStatus(from.getStrStatus());
+    }
+    if (from.getTissueOriginId() != null) {
+      TissueOrigin tissueOrigin = new TissueOriginImpl();
+      tissueOrigin.setTissueOriginId(from.getTissueOriginId());
+      to.setTissueOrigin(tissueOrigin);
+    }
+    if (from.getTissueTypeId() != null) {
+      TissueType tissueType = new TissueTypeImpl();
+      tissueType.setTissueTypeId(from.getTissueTypeId());
+      to.setTissueType(tissueType);
+    }
+    if (from.getQcPassedDetailId() != null) {
+      QcPassedDetail qcpassedDetail = new QcPassedDetailImpl();
+      qcpassedDetail.setQcPassedDetailId(from.getQcPassedDetailId());
+      to.setQcPassedDetail(qcpassedDetail);
+    }
+    if (from.getSubprojectId() != null) {
+      Subproject subproject = new SubprojectImpl();
+      subproject.setSubprojectId(from.getSubprojectId());
+      to.setSubproject(subproject);
+    }
+    if (from.getPrepKitId() != null) {
+      KitDescriptor prepKit = new KitDescriptor();
+      prepKit.setKitDescriptorId(from.getPrepKitId());
+      to.setPrepKit(prepKit);
+    }
+    if (from.getSampleClassId() != null) {
+      SampleClass sampleClass = new SampleClassImpl();
+      sampleClass.setSampleClassId(from.getSampleClassId());
+      to.setSampleClass(sampleClass);
     }
     return to;
   }
@@ -338,7 +368,7 @@ public class Dtos {
 
   public static SampleAnalyteDto asDto(SampleAnalyte from) {
     SampleAnalyteDto dto = new SampleAnalyteDto();
-    dto.setId(from.getSampleAnalyteId());
+    dto.setSampleId(from.getSampleId());
     dto.setSampleId(from.getSample().getId());
     if (from.getSamplePurpose() != null) {
       dto.setSamplePurposeId(from.getSamplePurpose().getSamplePurposeId());
@@ -378,17 +408,22 @@ public class Dtos {
 
   public static SampleAnalyte to(SampleAnalyteDto from) {
     SampleAnalyte to = new SampleAnalyteImpl();
-    if (from.getRegion() != null) {
-      to.setRegion(from.getRegion());
+    to.setSampleId(from.getSampleId());
+    to.setRegion(from.getRegion());
+    to.setTubeId(from.getTubeId());
+    to.setStockNumber(from.getStockNumber());
+    to.setAliquotNumber(from.getAliquotNumber());
+    if (from.getSampleGroupId() != null) {
+      to.setSampleGroup(new SampleGroupImpl());
+      to.getSampleGroup().setSampleGroupId(from.getSampleGroupId());
     }
-    if (from.getTubeId() != null) {
-      to.setTubeId(from.getTubeId());
+    if (from.getSamplePurposeId() != null) {
+      to.setSamplePurpose(new SamplePurposeImpl());
+      to.getSamplePurpose().setSamplePurposeId(from.getSamplePurposeId());
     }
-    if (from.getStockNumber() != null) {
-      to.setStockNumber(from.getStockNumber());
-    }
-    if (from.getAliquotNumber() != null) {
-      to.setAliquotNumber(from.getAliquotNumber());
+    if (from.getTissueMaterialId() != null) {
+      to.setTissueMaterial(new TissueMaterialImpl());
+      to.getTissueMaterial().setTissueMaterialId(from.getTissueMaterialId());
     }
     return to;
   }
@@ -483,13 +518,24 @@ public class Dtos {
     if (from.getVolume() != null) {
       to.setVolume(from.getVolume());
     }
+    if (from.getSampleAdditionalInfo() != null) {
+      to.setSampleAdditionalInfo(to(from.getSampleAdditionalInfo()));
+    }
+    if (from.getSampleIdentity() != null) {
+      to.setIdentity(to(from.getSampleIdentity()));
+    }
+    if (from.getSampleTissue() != null) {
+      to.setSampleTissue(to(from.getSampleTissue()));
+    }
+    if (from.getSampleAnalyte() != null) {
+      to.setSampleAnalyte(to(from.getSampleAnalyte()));
+    }
     return to;
   }
 
   public static SampleIdentityDto asDto(Identity from) {
     SampleIdentityDto dto = new SampleIdentityDto();
-    dto.setId(from.getIdentityId());
-    dto.setSampleId(from.getSample().getId());
+    dto.setSampleId(from.getSampleId());
     dto.setInternalName(from.getInternalName());
     dto.setExternalName(from.getExternalName());
     dto.setCreatedById(from.getCreatedBy().getUserId());
@@ -620,7 +666,7 @@ public class Dtos {
 
   public static SampleTissueDto asDto(SampleTissue from) {
     SampleTissueDto dto = new SampleTissueDto();
-    dto.setId(from.getSampleTissueId());
+    dto.setSampleId(from.getSampleId());
     dto.setCellularity(from.getCellularity());
     dto.setInstituteTissueName(from.getInstituteTissueName());
     dto.setCreatedById(from.getCreatedBy().getUserId());

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAdditionalInfoDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAdditionalInfoDto.java
@@ -5,9 +5,8 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 public class SampleAdditionalInfoDto {
 
-  private Long id;
-  private String url;
   private Long sampleId;
+  private String url;
   private String sampleUrl;
   private Long sampleClassId;
   private String sampleClassUrl;
@@ -35,12 +34,12 @@ public class SampleAdditionalInfoDto {
   private String labUrl;
   private String strStatus;
 
-  public Long getId() {
-    return id;
+  public Long getSampleId() {
+    return sampleId;
   }
 
-  public void setId(Long id) {
-    this.id = id;
+  public void setSampleId(Long id) {
+    this.sampleId = id;
   }
 
   public String getUrl() {
@@ -49,14 +48,6 @@ public class SampleAdditionalInfoDto {
 
   public void setUrl(String url) {
     this.url = url;
-  }
-
-  public Long getSampleId() {
-    return sampleId;
-  }
-
-  public void setSampleId(Long sampleId) {
-    this.sampleId = sampleId;
   }
 
   public String getSampleUrl() {

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAnalyteDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAnalyteDto.java
@@ -5,9 +5,8 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 public class SampleAnalyteDto {
 
-  private Long id;
-  private String url;
   private Long sampleId;
+  private String url;
   private String sampleUrl;
   private Long samplePurposeId;
   private String samplePurposeUrl;
@@ -28,12 +27,12 @@ public class SampleAnalyteDto {
   private String updatedByUrl;
   private String lastUpdated;
 
-  public Long getId() {
-    return id;
+  public Long getSampleId() {
+    return sampleId;
   }
 
-  public void setId(Long id) {
-    this.id = id;
+  public void setSampleId(Long sampleId) {
+    this.sampleId = sampleId;
   }
 
   public String getUrl() {
@@ -90,14 +89,6 @@ public class SampleAnalyteDto {
 
   public void setUpdatedById(Long updatedById) {
     this.updatedById = updatedById;
-  }
-
-  public Long getSampleId() {
-    return sampleId;
-  }
-
-  public void setSampleId(Long sampleId) {
-    this.sampleId = sampleId;
   }
 
   public String getSampleUrl() {

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleIdentityDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleIdentityDto.java
@@ -5,9 +5,8 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 public class SampleIdentityDto {
 
-  private Long id;
-  private String url;
   private Long sampleId;
+  private String url;
   private String sampleUrl;
   private String internalName;
   private String externalName;
@@ -18,12 +17,12 @@ public class SampleIdentityDto {
   private String updatedByUrl;
   private String lastUpdated;
 
-  public Long getId() {
-    return id;
+  public Long getSampleId() {
+    return sampleId;
   }
 
-  public void setId(Long id) {
-    this.id = id;
+  public void setSampleId(Long id) {
+    this.sampleId = id;
   }
 
   public String getUrl() {
@@ -96,14 +95,6 @@ public class SampleIdentityDto {
 
   public void setLastUpdated(String lastUpdated) {
     this.lastUpdated = lastUpdated;
-  }
-
-  public Long getSampleId() {
-    return sampleId;
-  }
-
-  public void setSampleId(Long sampleId) {
-    this.sampleId = sampleId;
   }
 
   public String getSampleUrl() {

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleTissueDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleTissueDto.java
@@ -10,12 +10,13 @@ public class SampleTissueDto {
   private Long createdById;
   private String createdByUrl;
   private String creationDate;
-  private Long id;
+  private Long sampleId;
   private String instituteTissueName;
   private String lastUpdated;
   private Long updatedById;
   private String updatedByUrl;
   private String url;
+  private String sampleUrl;
 
   public String getBioBankId() {
     return bioBankId;
@@ -37,8 +38,8 @@ public class SampleTissueDto {
     return creationDate;
   }
 
-  public Long getId() {
-    return id;
+  public Long getSampleId() {
+    return sampleId;
   }
 
   public String getInstituteTissueName() {
@@ -81,8 +82,8 @@ public class SampleTissueDto {
     this.creationDate = creationDate;
   }
 
-  public void setId(Long id) {
-    this.id = id;
+  public void setSampleId(Long sampleId) {
+    this.sampleId = sampleId;
   }
 
   public void setInstituteTissueName(String instituteTissueName) {
@@ -105,11 +106,23 @@ public class SampleTissueDto {
     this.url = url;
   }
 
+  public String getSampleUrl() {
+    return sampleUrl;
+  }
+
+  public void setSampleUrl(String sampleUrl) {
+    this.sampleUrl = sampleUrl;
+  }
+
   @Override
   public String toString() {
-    return "SampleTissueDto [bioBankId=" + bioBankId + ", cellularity=" + cellularity + ", createdById=" + createdById + ", createdByUrl="
-        + createdByUrl + ", creationDate=" + creationDate + ", id=" + id + ", instituteTissueName=" + instituteTissueName + ", lastUpdated="
-        + lastUpdated + ", updatedById=" + updatedById + ", updatedByUrl=" + updatedByUrl + ", url=" + url + "]";
+    return "SampleTissueDto [bioBankId=" + bioBankId + ", cellularity="
+        + cellularity + ", createdById=" + createdById + ", createdByUrl="
+        + createdByUrl + ", creationDate=" + creationDate + ", sampleId="
+        + sampleId + ", instituteTissueName=" + instituteTissueName
+        + ", lastUpdated=" + lastUpdated + ", updatedById=" + updatedById
+        + ", updatedByUrl=" + updatedByUrl + ", url=" + url + ", sampleUrl="
+        + sampleUrl + "]";
   }
 
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/IdentityService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/IdentityService.java
@@ -1,12 +1,10 @@
 package uk.ac.bbsrc.tgac.miso.service;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.dto.SampleIdentityDto;
-import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 
 public interface IdentityService {
 
@@ -23,5 +21,13 @@ public interface IdentityService {
   void delete(Long identityId) throws IOException;
 
   Identity to(SampleIdentityDto sampleIdentityDto) throws IOException;
+  
+  /**
+   * copies all the editable properties from one Identity instance to another
+   * 
+   * @param target the persisted Identity to copy changes into
+   * @param source the modified Identity to copy changes from
+   */
+  public void applyChanges(Identity target, Identity source);
 
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleAdditionalInfoService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleAdditionalInfoService.java
@@ -9,19 +9,42 @@ import uk.ac.bbsrc.tgac.miso.dto.SampleAdditionalInfoDto;
 public interface SampleAdditionalInfoService {
 
   SampleAdditionalInfo get(Long sampleAdditionalInfoId) throws IOException;
+  
+  Long create(SampleAdditionalInfo sampleAdditionalInfo) throws IOException;
 
-  Long create(SampleAdditionalInfo sampleAdditionalInfo, Long sampleId, Long tissueOriginId, Long tissueTypeId, Long qcPassedDetailId,
-      Long subprojectId, Long prepKitId, Long sampleClassId) throws IOException;
-
-  void update(SampleAdditionalInfo sampleAdditionalInfo, Long tissueOriginId, Long tissueTypeId, Long qcPassedDetailId, Long prepKitId,
-      Long sampleClassId) throws IOException;
+  void update(SampleAdditionalInfo sampleAdditionalInfo) throws IOException;
 
   Set<SampleAdditionalInfo> getAll() throws IOException;
 
   void delete(Long sampleAdditionalInfoId) throws IOException;
 
-  Long create(SampleAdditionalInfoDto sampleAdditionalInfoDto) throws IOException;
-
   SampleAdditionalInfo to(SampleAdditionalInfoDto sampleAdditionalInfoDto) throws IOException;
+
+  /**
+   * copies all editable properties from one SampleAdditionalInfo instance to another
+   * 
+   * @param target the persisted SampleAdditionalInfo to copy changes into
+   * @param source the modified SampleAdditionalInfo to copy changes from
+   * @throws IOException
+   */
+  void applyChanges(SampleAdditionalInfo target, SampleAdditionalInfo source) throws IOException;
+  
+  /**
+   * loads the contained objects into the target object from the database using IDs that are already present in the target
+   * 
+   * @param target the SampleAdditionalInfo whose attributes are to be populated from the database. Must already contain the IDs to 
+   * be used for lookup
+   * @throws IOException
+   */
+  void loadMembers(SampleAdditionalInfo target) throws IOException;
+  
+  /**
+   * loads the contained objects into the target object from the database using IDs found in the source object
+   * 
+   * @param target the SampleAdditionalInfo whose attributes are to be populated from the database
+   * @param source the SampleAdditionalInfo containing IDs to be used for lookup
+   * @throws IOException 
+   */
+  void loadMembers(SampleAdditionalInfo target, SampleAdditionalInfo source) throws IOException;
 
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleAnalyteService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleAnalyteService.java
@@ -10,12 +10,9 @@ public interface SampleAnalyteService {
 
   SampleAnalyte get(Long sampleAnalyteId) throws IOException;
 
-  Long create(SampleAnalyte sampleAnalyte, Long sampleId, Long samplePurposeId, Long sampleGroupId, Long tissueMaterialId)
-      throws IOException;
-
   Long create(SampleAnalyte sampleAnalyte) throws IOException;
 
-  void update(SampleAnalyte sampleAnalyte, Long samplePurposeId, Long sampleGroupId, Long tissueMaterialId) throws IOException;
+  void update(SampleAnalyte sampleAnalyte) throws IOException;
 
   Set<SampleAnalyte> getAll() throws IOException;
 
@@ -24,5 +21,31 @@ public interface SampleAnalyteService {
   Long create(SampleAnalyteDto sampleAnalyteDto) throws IOException;
 
   SampleAnalyte to(SampleAnalyteDto sampleAnalyteDto) throws IOException;
+  
+  /**
+   * copies all the editable properties from one SampleAnalyte instance to another
+   * 
+   * @param target the persisted SampleAnalyte to copy changes into
+   * @param source the modified SampleAnalyte to copy changes from
+   */
+  public void applyChanges(SampleAnalyte target, SampleAnalyte source) throws IOException;
+  
+  /**
+   * loads the contained objects into the target object from the database using IDs that are already present in the target
+   * 
+   * @param target the SampleAnalyte whose attributes are to be populated from the database. Must already contain the IDs to 
+   * be used for lookup
+   * @throws IOException
+   */
+  void loadMembers(SampleAnalyte target) throws IOException;
+  
+  /**
+   * loads the contained objects into the target object from the database using IDs found in the source object
+   * 
+   * @param target the SampleAnalyte whose attributes are to be populated from the database
+   * @param source the SampleAnalyte containing IDs to be used for lookup
+   * @throws IOException 
+   */
+  void loadMembers(SampleAnalyte target, SampleAnalyte source) throws IOException;
 
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleTissueService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleTissueService.java
@@ -19,5 +19,13 @@ public interface SampleTissueService {
   void delete(Long sampleTissueId);
 
   SampleTissue to(SampleTissueDto sampleTissueDto) throws IOException;
+  
+  /**
+   * copies all the editable properties from one SampleTissue instance to another
+   * 
+   * @param target the persisted SampleTissue to copy changes into
+   * @param source the modified SampleTissue to copy changes from
+   */
+  public void applyChanges(SampleTissue target, SampleTissue source);
 
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultIdentityService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultIdentityService.java
@@ -57,12 +57,16 @@ public class DefaultIdentityService implements IdentityService {
   @Override
   public void update(Identity identity) throws IOException {
     authorizationManager.throwIfNonAdmin();
-    Identity updatedIdentity = get(identity.getIdentityId());
-    updatedIdentity.setInternalName(identity.getInternalName());
-    updatedIdentity.setExternalName(identity.getExternalName());
-    User user = authorizationManager.getCurrentUser();
-    updatedIdentity.setUpdatedBy(user);
+    Identity updatedIdentity = get(identity.getSampleId());
+    applyChanges(updatedIdentity, identity);
+    updatedIdentity.setUpdatedBy(authorizationManager.getCurrentUser());
     identityDao.update(updatedIdentity);
+  }
+  
+  @Override
+  public void applyChanges(Identity target, Identity source) {
+    target.setInternalName(source.getInternalName());
+    target.setExternalName(source.getExternalName());
   }
 
   @Override

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleTissueService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleTissueService.java
@@ -76,12 +76,17 @@ public class DefaultSampleTissueService implements SampleTissueService {
 
   @Override
   public void update(SampleTissue sampleTissue) throws IOException {
-    SampleTissue updatedSampleTissue = get(sampleTissue.getSampleTissueId());
-    updatedSampleTissue.setInstituteTissueName(sampleTissue.getInstituteTissueName());
-    updatedSampleTissue.setCellularity(sampleTissue.getCellularity());
+    SampleTissue updatedSampleTissue = get(sampleTissue.getSampleId());
+    applyChanges(updatedSampleTissue, sampleTissue);
     User user = securityManager.getUserByLoginName(SecurityContextHolder.getContext().getAuthentication().getName());
     updatedSampleTissue.setUpdatedBy(user);
     sampleTissueDao.update(updatedSampleTissue);
+  }
+
+  @Override
+  public void applyChanges(SampleTissue target, SampleTissue source) {
+    target.setInstituteTissueName(source.getInstituteTissueName());
+    target.setCellularity(source.getCellularity());
   }
 
   @Override

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleAdditionalInfoController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleAdditionalInfoController.java
@@ -75,11 +75,11 @@ public class SampleAdditionalInfoController extends RestController {
     }
   }
 
-  private static SampleAdditionalInfoDto writeUrls(SampleAdditionalInfoDto sampleAdditionalInfoDto, UriComponentsBuilder uriBuilder) {
+  public static SampleAdditionalInfoDto writeUrls(SampleAdditionalInfoDto sampleAdditionalInfoDto, UriComponentsBuilder uriBuilder) {
 
     URI baseUri = uriBuilder.build().toUri();
     sampleAdditionalInfoDto.setUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/sampleadditionalinfo/{id}")
-        .buildAndExpand(sampleAdditionalInfoDto.getId()).toUriString());
+        .buildAndExpand(sampleAdditionalInfoDto.getSampleId()).toUriString());
     sampleAdditionalInfoDto.setCreatedByUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/user/{id}")
         .buildAndExpand(sampleAdditionalInfoDto.getCreatedById()).toUriString());
     sampleAdditionalInfoDto.setUpdatedByUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/user/{id}")
@@ -130,10 +130,7 @@ public class SampleAdditionalInfoController extends RestController {
   public ResponseEntity<?> createSampleAdditionalInfo(@RequestBody SampleAdditionalInfoDto sampleAdditionalInfoDto, UriComponentsBuilder b,
       HttpServletResponse response) throws IOException {
     SampleAdditionalInfo sampleAdditionalInfo = to(sampleAdditionalInfoDto);
-    Long id = sampleAdditionalInfoService.create(sampleAdditionalInfo, sampleAdditionalInfoDto.getSampleId(),
-        sampleAdditionalInfoDto.getTissueOriginId(), sampleAdditionalInfoDto.getTissueTypeId(),
-        sampleAdditionalInfoDto.getQcPassedDetailId(), sampleAdditionalInfoDto.getSubprojectId(), sampleAdditionalInfoDto.getPrepKitId(),
-        sampleAdditionalInfoDto.getSampleClassId());
+    Long id = sampleAdditionalInfoService.create(sampleAdditionalInfo);
     UriComponents uriComponents = b.path("/sampleadditionalinfo/{id}").buildAndExpand(id);
     HttpHeaders headers = new HttpHeaders();
     headers.setLocation(uriComponents.toUri());
@@ -145,10 +142,8 @@ public class SampleAdditionalInfoController extends RestController {
   public ResponseEntity<?> updateSampleAdditionalInfo(@PathVariable("id") Long id,
       @RequestBody SampleAdditionalInfoDto sampleAdditionalInfoDto, HttpServletResponse response) throws IOException {
     SampleAdditionalInfo sampleAdditionalInfo = to(sampleAdditionalInfoDto);
-    sampleAdditionalInfo.setSampleAdditionalInfoId(id);
-    sampleAdditionalInfoService.update(sampleAdditionalInfo, sampleAdditionalInfoDto.getTissueOriginId(),
-        sampleAdditionalInfoDto.getTissueTypeId(), sampleAdditionalInfoDto.getQcPassedDetailId(), sampleAdditionalInfoDto.getPrepKitId(),
-        sampleAdditionalInfoDto.getSampleClassId());
+    sampleAdditionalInfo.setSampleId(id);
+    sampleAdditionalInfoService.update(sampleAdditionalInfo);
     return new ResponseEntity<>(HttpStatus.OK);
   }
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleAnalyteController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleAnalyteController.java
@@ -75,10 +75,10 @@ public class SampleAnalyteController extends RestController {
     }
   }
 
-  private static SampleAnalyteDto writeUrls(SampleAnalyteDto sampleAnalyteDto, UriComponentsBuilder uriBuilder) {
+  public static SampleAnalyteDto writeUrls(SampleAnalyteDto sampleAnalyteDto, UriComponentsBuilder uriBuilder) {
     URI baseUri = uriBuilder.build().toUri();
     sampleAnalyteDto.setUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/sample/analyte/{id}")
-        .buildAndExpand(sampleAnalyteDto.getId()).toUriString());
+        .buildAndExpand(sampleAnalyteDto.getSampleId()).toUriString());
     sampleAnalyteDto.setCreatedByUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/user/{id}")
         .buildAndExpand(sampleAnalyteDto.getCreatedById()).toUriString());
     sampleAnalyteDto.setUpdatedByUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/user/{id}")
@@ -116,8 +116,7 @@ public class SampleAnalyteController extends RestController {
   public ResponseEntity<?> createSampleAnalyte(@RequestBody SampleAnalyteDto sampleAnalyteDto, UriComponentsBuilder b,
       HttpServletResponse response) throws IOException {
     SampleAnalyte sampleAnalyte = Dtos.to(sampleAnalyteDto);
-    Long id = sampleAnalyteService.create(sampleAnalyte, sampleAnalyteDto.getSampleId(), sampleAnalyteDto.getSamplePurposeId(),
-        sampleAnalyteDto.getSampleGroupId(), sampleAnalyteDto.getTissueMaterialId());
+    Long id = sampleAnalyteService.create(sampleAnalyte);
     UriComponents uriComponents = b.path("/sampleanalyte/{id}").buildAndExpand(id);
     HttpHeaders headers = new HttpHeaders();
     headers.setLocation(uriComponents.toUri());
@@ -129,9 +128,8 @@ public class SampleAnalyteController extends RestController {
   public ResponseEntity<?> updateSampleAnalyte(@PathVariable("id") Long id, @RequestBody SampleAnalyteDto sampleAnalyteDto,
       HttpServletResponse response) throws IOException {
     SampleAnalyte sampleAnalyte = Dtos.to(sampleAnalyteDto);
-    sampleAnalyte.setSampleAnalyteId(id);
-    sampleAnalyteService.update(sampleAnalyte, sampleAnalyteDto.getSamplePurposeId(), sampleAnalyteDto.getSampleGroupId(),
-        sampleAnalyteDto.getTissueMaterialId());
+    sampleAnalyte.setSampleId(id);
+    sampleAnalyteService.update(sampleAnalyte);
     return new ResponseEntity<>(HttpStatus.OK);
   }
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleCategoryController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleCategoryController.java
@@ -24,8 +24,8 @@ import uk.ac.bbsrc.tgac.miso.dto.SampleCategoryDto;
 @RequestMapping("/rest")
 @Controller
 @SessionAttributes("sampleidentity")
-public class SampleIdentityController {
-  protected static final Logger log = LoggerFactory.getLogger(SampleIdentityController.class);
+public class SampleCategoryController {
+  protected static final Logger log = LoggerFactory.getLogger(SampleCategoryController.class);
 
   @RequestMapping(value = "/samplecategories", method = RequestMethod.GET, produces = { "application/json" })
   @ResponseBody

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleController.java
@@ -50,6 +50,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.dto.Dtos;
 import uk.ac.bbsrc.tgac.miso.dto.SampleDto;
+import uk.ac.bbsrc.tgac.miso.dto.SampleIdentityDto;
 import uk.ac.bbsrc.tgac.miso.service.SampleService;
 
 @Controller
@@ -87,6 +88,29 @@ public class SampleController extends RestController {
       sampleDto.setRootSampleClassUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/sampleclass/{id}")
           .buildAndExpand(sampleDto.getRootSampleClassId()).toUriString());
     }
+    if (sampleDto.getSampleAdditionalInfo() != null) {
+      SampleAdditionalInfoController.writeUrls(sampleDto.getSampleAdditionalInfo(), uriBuilder);
+    }
+    if (sampleDto.getSampleIdentity() != null) {
+      SampleIdentityDto sid = sampleDto.getSampleIdentity();
+      sid.setSampleUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/tree/sample/{id}")
+          .buildAndExpand(sampleDto.getId()).toUriString());
+      if (sid.getCreatedById() != null) {
+        sid.setCreatedByUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/user/{id}")
+            .buildAndExpand(sid.getCreatedById()).toUriString());
+      }
+      if (sid.getUpdatedById() != null) {
+        sid.setUpdatedByUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/user/{id}")
+            .buildAndExpand(sid.getUpdatedById()).toUriString());
+      }
+    }
+    if (sampleDto.getSampleTissue() != null) {
+      SampleTissueController.writeUrls(sampleDto.getSampleTissue(), uriBuilder);
+    }
+    if (sampleDto.getSampleAnalyte() != null) {
+      SampleAnalyteController.writeUrls(sampleDto.getSampleAnalyte(), uriBuilder);
+    }
+    
     return sampleDto;
   }
 
@@ -129,7 +153,7 @@ public class SampleController extends RestController {
   @ResponseBody
   public ResponseEntity<?> updateSample(@PathVariable("id") Long id, @RequestBody SampleDto sampleDto) throws IOException {
     Sample sample = Dtos.to(sampleDto);
-    sample.setSampleId(id);
+    sample.setId(id);
     sampleService.update(sample);
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleTissueController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleTissueController.java
@@ -38,10 +38,12 @@ public class SampleTissueController extends RestController {
   @Autowired
   private SampleTissueService sampleTissueService;
 
-  private static SampleTissueDto writeUrls(SampleTissueDto sampleTissueDto, UriComponentsBuilder uriBuilder) {
+  public static SampleTissueDto writeUrls(SampleTissueDto sampleTissueDto, UriComponentsBuilder uriBuilder) {
     URI baseUri = uriBuilder.build().toUri();
     sampleTissueDto.setUrl(
-        UriComponentsBuilder.fromUri(baseUri).path("/rest/sample/tissue/{id}").buildAndExpand(sampleTissueDto.getId()).toUriString());
+        UriComponentsBuilder.fromUri(baseUri).path("/rest/sample/tissue/{id}").buildAndExpand(sampleTissueDto.getSampleId()).toUriString());
+    sampleTissueDto.setSampleUrl(
+        UriComponentsBuilder.fromUri(baseUri).path("/rest/sample/{id}").buildAndExpand(sampleTissueDto.getSampleId()).toUriString());
     sampleTissueDto.setCreatedByUrl(
         UriComponentsBuilder.fromUri(baseUri).path("/rest/user/{id}").buildAndExpand(sampleTissueDto.getCreatedById()).toUriString());
     sampleTissueDto.setUpdatedByUrl(
@@ -94,7 +96,7 @@ public class SampleTissueController extends RestController {
   public ResponseEntity<?> updateSampleTissue(@PathVariable("id") Long id, @RequestBody SampleTissueDto sampleTissueDto,
       UriComponentsBuilder uriBuilder) throws IOException {
     SampleTissue sampleTissue = Dtos.to(sampleTissueDto);
-    sampleTissue.setSampleTissueId(id);
+    sampleTissue.setSampleId(id);
     getSampleTissueService().update(sampleTissue);
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
@@ -4,12 +4,14 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import javax.persistence.CascadeType;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
 
 import org.hibernate.Query;
 import org.hibernate.Session;
@@ -29,13 +31,9 @@ import com.eaglegenomics.simlims.core.SecurityProfile;
 import com.eaglegenomics.simlims.core.store.SecurityStore;
 import com.google.common.annotations.VisibleForTesting;
 
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectOverview;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.MisoNamingScheme;
@@ -90,9 +88,6 @@ public class HibernateSampleDao implements SampleDao, SampleStore {
   @Transactional(propagation = Propagation.MANDATORY)
   @Override
   public Long addSample(final Sample sample) throws IOException, MisoNamingException {
-    Date now = new Date();
-    sample.setLastUpdated(now);
-
     // We can't generate the name until we have the ID and we don't have an ID until we start the persistence. So, we assign a temporary
     // name.
     sample.setName(generateTemporaryName());
@@ -483,8 +478,6 @@ public class HibernateSampleDao implements SampleDao, SampleStore {
 
   @Override
   public void update(Sample sample) throws IOException {
-    Date now = new Date();
-    sample.setLastUpdated(now);
     if (sample.getSecurityProfile() != null) {
       sample.setSecurityProfileId(sample.getSecurityProfile().getProfileId());
     }

--- a/sqlstore/src/main/resources/db/migration/V0010__sample_hierarchy.sql
+++ b/sqlstore/src/main/resources/db/migration/V0010__sample_hierarchy.sql
@@ -41,15 +41,13 @@ CREATE TABLE `TissueType` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `Identity` (
-  `identityId` bigint(20) NOT NULL AUTO_INCREMENT,
-  `sampleId` bigint(20) NOT NULL,
+  `sampleId` bigint(20) PRIMARY KEY,
   `internalName` varchar(255) NOT NULL,
   `externalName` varchar(255) NOT NULL,
   `createdBy` bigint(20) NOT NULL,
   `creationDate` datetime NOT NULL,
   `updatedBy` bigint(20) NOT NULL,
   `lastUpdated` datetime NOT NULL,
-  PRIMARY KEY (`identityId`),
   UNIQUE KEY `UK_ew7ogw2mxhcs9d6ncgelgyh9t` (`internalName`),
   KEY `FKauqylg2sle5eudy0tqabtlmsb` (`createdBy`),
   KEY `FKa11fikh6ktu2cn1qbgudb2st6` (`sampleId`),
@@ -58,9 +56,6 @@ CREATE TABLE `Identity` (
   CONSTRAINT `FKa8c6e56hg9iucguhr0dcse62h` FOREIGN KEY (`updatedBy`) REFERENCES `User` (`userId`),
   CONSTRAINT `FKauqylg2sle5eudy0tqabtlmsb` FOREIGN KEY (`createdBy`) REFERENCES `User` (`userId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-ALTER TABLE Sample ADD COLUMN `identityId` BIGINT (20) DEFAULT NULL after taxonIdentifier;
-ALTER TABLE Sample ADD FOREIGN KEY (identityId) REFERENCES Identity (identityId);
 
 CREATE TABLE `Subproject` (
   `subprojectId` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -141,8 +136,7 @@ CREATE TABLE `Lab` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `SampleAdditionalInfo` (
-  `sampleAdditionalInfoId` bigint(20) NOT NULL AUTO_INCREMENT,
-  `sampleId` bigint(20) NOT NULL,
+  `sampleId` bigint(20) PRIMARY KEY,
   `sampleClassId` bigint(20) NOT NULL,
   `tissueOriginId` bigint(20) DEFAULT NULL,
   `tissueTypeId` bigint(20) DEFAULT NULL,
@@ -159,7 +153,6 @@ CREATE TABLE `SampleAdditionalInfo` (
   `creationDate` datetime NOT NULL,
   `updatedBy` bigint(20) NOT NULL,
   `lastUpdated` datetime NOT NULL,
-  PRIMARY KEY (`sampleAdditionalInfoId`),
   KEY `FKeutn2473w3yr16khgalspuviw` (`createdBy`),
   KEY `FKa2t38wms0eer896xo4fw76tw0` (`qcPassedDetailId`),
   KEY `FKd4g1h1n50bflt9a2v2pgr0jn` (`sampleId`),
@@ -236,8 +229,7 @@ CREATE TABLE `SampleGroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `SampleAnalyte` (
-  `sampleAnalyteId` bigint(20) NOT NULL AUTO_INCREMENT,
-  `sampleId` bigint(20) NOT NULL,
+  `sampleId` bigint(20) PRIMARY KEY,
   `samplePurposeId` bigint(20) DEFAULT NULL,
   `sampleGroupId` bigint(20) DEFAULT NULL,
   `tissueMaterialId` bigint(20) DEFAULT NULL,
@@ -249,7 +241,6 @@ CREATE TABLE `SampleAnalyte` (
   `creationDate` datetime NOT NULL,
   `updatedBy` bigint(20) NOT NULL,
   `lastUpdated` datetime NOT NULL,
-  PRIMARY KEY (`sampleAnalyteId`),
   KEY `FKpras819b6p7vh12xbeovne8o0` (`createdBy`),
   KEY `FKe6n6a5x04km19m5376iaah9gy` (`sampleId`),
   KEY `FKmirq92ew3h3732cexgqdeyehk` (`sampleGroupId`),
@@ -264,23 +255,7 @@ CREATE TABLE `SampleAnalyte` (
   CONSTRAINT `FKprqyhv40bntjrf5l64mjdgl1j` FOREIGN KEY (`updatedBy`) REFERENCES `User` (`userId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-
-ALTER TABLE Sample ADD COLUMN `sampleAnalyteId` BIGINT (20) DEFAULT NULL after identityId;
-ALTER TABLE Sample ADD FOREIGN KEY (sampleAnalyteId) REFERENCES SampleAnalyte (sampleAnalyteId);
-
-ALTER TABLE Sample ADD COLUMN `sampleAdditionalInfoId` BIGINT (20) DEFAULT NULL after sampleAnalyteId;
-ALTER TABLE Sample ADD FOREIGN KEY (sampleAdditionalInfoId) REFERENCES SampleAdditionalInfo (sampleAdditionalInfoId);
-
-CREATE TABLE `SampleHierarchy` (
-  `parentId` bigint(20) NOT NULL,
-  `childId` bigint(20) NOT NULL,
-  PRIMARY KEY (`parentId`,`childId`),
-  UNIQUE KEY `UK_a5jwa184bxpj7fm7bf7yqpmhh` (`childId`),
-  CONSTRAINT `FKdw2ithwf37a42xbbr98fqx91h` FOREIGN KEY (`childId`) REFERENCES `Sample` (`sampleId`),
-  CONSTRAINT `FKrw8dmp9ac7ikylmqup276vmf8` FOREIGN KEY (`parentId`) REFERENCES `Sample` (`sampleId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-ALTER TABLE Sample ADD COLUMN `parentId` BIGINT (20) DEFAULT NULL after sampleAdditionalInfoId;
+ALTER TABLE Sample ADD COLUMN `parentId` BIGINT (20) DEFAULT NULL;
 ALTER TABLE Sample ADD FOREIGN KEY (parentId) REFERENCES Sample (sampleId);
 
 CREATE TABLE `SampleNumberPerProject` (
@@ -321,8 +296,7 @@ CREATE TABLE `SampleValidRelationship` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `SampleTissue` (
-  `sampleTissueId` bigint(20) PRIMARY KEY AUTO_INCREMENT,
-  `sampleId` bigint(20) NOT NULL,
+  `sampleId` bigint(20) PRIMARY KEY,
   `instituteTissueName` varchar(255),
   `cellularity` int,
   `createdBy` bigint(20) NOT NULL,
@@ -333,9 +307,6 @@ CREATE TABLE `SampleTissue` (
   CONSTRAINT `sampleTissue_createUser_fkey` FOREIGN KEY (`createdBy`) REFERENCES `User` (`userId`),
   CONSTRAINT `sampleTissue_updateUser_fkey` FOREIGN KEY (`updatedBy`) REFERENCES `User` (`userId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-ALTER TABLE Sample ADD COLUMN `sampleTissueId` BIGINT (20) DEFAULT NULL after sampleAnalyteId;
-ALTER TABLE Sample ADD FOREIGN KEY (sampleTissueId) REFERENCES SampleTissue (sampleTissueId);
 
 CREATE TABLE `LibraryAdditionalInfo` (
   `libraryAdditionalInfoId` bigint(20) PRIMARY KEY AUTO_INCREMENT,

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIdentityDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIdentityDaoTest.java
@@ -1,9 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
@@ -18,10 +16,8 @@ import com.eaglegenomics.simlims.core.User;
 
 import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
-import uk.ac.bbsrc.tgac.miso.core.data.Institute;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.IdentityImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.InstituteImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 
@@ -85,10 +81,10 @@ public class HibernateIdentityDaoTest extends AbstractDAOTest {
 
   @Test
   public void testDeleteIdentity() {
-    Identity identity = dao.getIdentity(2L);
+    Identity identity = dao.getIdentity(4L);
     dao.deleteIdentity(identity);
 
-    Identity deleted = dao.getIdentity(2L);
+    Identity deleted = dao.getIdentity(4L);
     assertTrue(deleted == null);
 
   }
@@ -102,7 +98,7 @@ public class HibernateIdentityDaoTest extends AbstractDAOTest {
     dao.update(identity);
 
     Identity updated = dao.getIdentity("updatedExternal");
-    assertEquals(new Long(1), dao.getIdentity().get(0).getIdentityId());
+    assertEquals(new Long(1), dao.getIdentity().get(0).getSampleId());
 
   }
 

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
@@ -1,26 +1,63 @@
 package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
 
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.store.SecurityStore;
+
+import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.DefaultSampleNamingScheme;
+import uk.ac.bbsrc.tgac.miso.core.store.ChangeLogStore;
+import uk.ac.bbsrc.tgac.miso.core.store.LibraryStore;
+import uk.ac.bbsrc.tgac.miso.core.store.NoteStore;
+import uk.ac.bbsrc.tgac.miso.core.store.ProjectStore;
+import uk.ac.bbsrc.tgac.miso.core.store.SampleQcStore;
+import uk.ac.bbsrc.tgac.miso.core.store.Store;
 
-public class HibernateSampleDaoTest {
+public class HibernateSampleDaoTest extends AbstractDAOTest {
 
+  @Autowired
+  private SessionFactory sessionFactory;
+  
+  @Mock
+  private SecurityStore securityDAO;
+  @Mock
+  private Store<SecurityProfile> securityProfileDAO;
+  @Mock
+  private ChangeLogStore changeLogDAO;
+  @Mock
+  private ProjectStore projectStore;
+  @Mock
+  private LibraryStore libraryStore;
+  @Mock
+  private SampleQcStore sampleQCStore;
+  @Mock
+  private NoteStore noteStore;
+
+  @InjectMocks
   private HibernateSampleDao sut;
 
   @Before
   public void setUp() throws Exception {
-    sut = new HibernateSampleDao();
+    MockitoAnnotations.initMocks(this);
     sut.setNamingScheme(new DefaultSampleNamingScheme());
+    sut.setSessionFactory(sessionFactory);
   }
 
   @Test
@@ -91,6 +128,13 @@ public class HibernateSampleDaoTest {
     Sample sample = null;
     assertFalse("A null sample object does not contain a temporary name so must return false.",
         HibernateSampleDao.hasTemporaryName(sample));
+  }
+  
+  @Test
+  public void getSampleWithChildrenTest() throws Exception {
+    Sample sample = sut.get(15L);
+    assertNotNull(sample.getChildren());
+    assertEquals(2,sample.getChildren().size());
   }
 
 }

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleDAOTest.java
@@ -99,7 +99,7 @@ public class SQLSampleDAOTest extends AbstractDAOTest {
   public void testListAll() throws IOException {
     Collection<Sample> samples = dao.listAll();
     samples.iterator().next().getScientificName().equals("Homo sapiens");
-    assertEquals(14, samples.size());
+    assertEquals(17, samples.size());
   }
 
   @Test
@@ -182,7 +182,7 @@ public class SQLSampleDAOTest extends AbstractDAOTest {
   @Test
   public void testCount() throws Exception {
     int total = dao.count();
-    assertEquals(14, total);
+    assertEquals(17, total);
   }
 
   @Test

--- a/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
+++ b/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
@@ -198,6 +198,27 @@ VALUES (1,NULL,'SAM1','Inherited from TEST_0001',1,'SAM1::TEST_0001_Bn_P_nn_1-1_
 (13,NULL,'SAM13','Inherited from TEST_0007',1,'SAM13::TEST_0007_Bn_P_nn_1-1_D_1','Freezer1_13','GENOMIC','2015-01-27','true','TEST_0007_Bn_P_nn_1-1_D_1',1,'Homo sapiens',NULL,1),
 (14,NULL,'SAM14','Inherited from TEST_0007',1,'SAM14::TEST_0007_Bn_R_nn_1-1_D_1','Freezer1_14','GENOMIC','2015-01-27','true','TEST_0007_Bn_R_nn_1-1_D_1',1,'Homo sapiens',NULL,1);
 
+INSERT INTO `Sample`(`sampleId`, `accession`, `name`, `description`, `securityProfile_profileId`, `identificationBarcode`, `locationBarcode`, `sampleType`, `receivedDate`, `qcPassed`, `alias`, `project_projectId`, `scientificName`, `taxonIdentifier`, `lastModifier`,`parentId`) 
+VALUES (15,NULL,'SAM15','identity1',1,'SAM15::TEST_0001_IDENTITY_1','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_IDENTITY_1',1,'Homo sapiens',NULL,1,NULL),
+(16,NULL,'SAM16','tissue1',1,'SAM16::TEST_0001_TISSUE_1','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_TISSUE_1',1,'Homo sapiens',NULL,1,15),
+(17,NULL,'SAM17','tissue2',1,'SAM17::TEST_0001_TISSUE_2','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_TISSUE_2',1,'Homo sapiens',NULL,1,15);
+
+INSERT INTO `SampleClass`(`sampleClassId`, `alias`, `sampleCategory`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
+VALUES (1,'Identity','Identity',1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00'),
+(2,'Primary Tumor Tissue','Tissue',1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00');
+
+INSERT INTO `SampleAdditionalInfo`(`sampleId`, `sampleClassId`, `archived`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
+VALUES (15,1,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00'),
+(16,2,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00'),
+(17,2,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00');
+
+INSERT INTO `Identity`(`sampleId`, `internalName`, `externalName`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
+VALUES (15,'INT1','EXT1',1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00');
+
+INSERT INTO `SampleTissue`(`sampleId`,`createdBy`,`creationDate`,`updatedBy`,`lastUpdated`)
+VALUES (16,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00'),
+(17,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00');
+
 DELETE FROM `SampleQC`;
 INSERT INTO `SampleQC`(`qcId`, `sample_sampleId`, `qcUserName`, `qcDate`, `qcMethod`, `results`) 
 VALUES (1,1,'admin','2015-08-27',1,5),(2,2,'admin','2015-08-27',1,5),(3,3,'admin','2015-08-27',1,5),(4,4,'admin','2015-08-27',1,5),
@@ -261,10 +282,9 @@ VALUES (1,1,'Lab A1',1,'2016-02-10 15:35:00',1,'2016-02-10 15:35:00'),(2,1,'Lab 
 (3,1,'Lab B1',1,'2016-02-10 15:35:00',1,'2016-02-10 15:35:00'),(4,1,'Lab B2',1,'2016-02-10 15:35:00',1,'2016-02-10 15:35:00');
 
 DELETE FROM `Identity`;
-INSERT INTO `Identity` (`identityId`, `sampleId`, `internalName`, `externalName`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
-VALUES ('1', '1', 'internalName1', 'externalName1', '1', '2016-02-17 09:32:00', '1', '2016-02-17 09:32:00');
-INSERT INTO `Identity` (`identityId`, `sampleId`, `internalName`, `externalName`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
-VALUES ('2', '4', 'internalName2', 'externalName2', '1', '2016-02-17 09:32:00', '1', '2016-02-17 09:32:00');
+INSERT INTO `Identity` (`sampleId`, `internalName`, `externalName`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
+VALUES ('1', 'internalName1', 'externalName1', '1', '2016-02-17 09:32:00', '1', '2016-02-17 09:32:00'),
+('4', 'internalName2', 'externalName2', '1', '2016-02-17 09:32:00', '1', '2016-02-17 09:32:00');
 
 INSERT INTO `SampleNumberPerProject`
 (`sampleNumberPerProjectId`, `projectId`, `highestSampleNumber`, `padding`, `createdBy`, `updatedBy`, `creationDate`, `lastUpdated`)


### PR DESCRIPTION
Removed foreign keys from Sample table pointing to SampleAdditionalInfo, Identity, SampleTissue, and SampleAnalyte. These tables now all share sampleId as their primary keys.

Removed the SampleHierarchy table, which mapped parents to children. This is already handled by the parentId field in Sample.

Fixed SampleCategoryController name as well - it was called SampleIdentityController before.