### PR TITLE
Glt 545 relocate parent

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
@@ -32,18 +32,15 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
-import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Transient;
 
-import org.codehaus.jackson.annotate.JsonBackReference;
 import org.codehaus.jackson.annotate.JsonManagedReference;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
@@ -142,17 +139,6 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
   @OneToOne(targetEntity = SampleAdditionalInfoImpl.class, mappedBy = "sample")
   @Cascade({ CascadeType.SAVE_UPDATE })
   private SampleAdditionalInfo sampleAdditionalInfo;
-
-  @ManyToOne(targetEntity = SampleImpl.class)
-  @JoinColumn(name = "parentId")
-  @Cascade({ CascadeType.SAVE_UPDATE })
-  @JsonBackReference
-  private Sample parent;
-
-  @OneToMany(targetEntity = SampleImpl.class, fetch = FetchType.LAZY, mappedBy = "parent")
-  @Cascade({ CascadeType.SAVE_UPDATE })
-  @JsonManagedReference
-  private Set<Sample> children = new HashSet<Sample>();
 
   @Override
   public User getLastModifier() {
@@ -508,22 +494,12 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
 
   @Override
   public Sample getParent() {
-    return parent;
-  }
-
-  @Override
-  public void setParent(Sample parent) {
-    this.parent = parent;
+    return sampleAdditionalInfo == null ? null : sampleAdditionalInfo.getParent();
   }
 
   @Override
   public Set<Sample> getChildren() {
-    return children;
-  }
-
-  @Override
-  public void setChildren(Set<Sample> children) {
-    this.children = children;
+    return sampleAdditionalInfo == null ? null : sampleAdditionalInfo.getChildren();
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
@@ -123,9 +123,6 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
   private String alias;
   private Long securityProfile_profileId;
 
-  @Transient
-  private Date lastUpdated;
-
   @OneToOne(targetEntity = UserImpl.class)
   @JoinColumn(name = "lastModifier", nullable = false)
   private User lastModifier;
@@ -368,16 +365,6 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
   @Override
   public Collection<ChangeLog> getChangeLog() {
     return changeLog;
-  }
-
-  @Override
-  public Date getLastUpdated() {
-    return lastUpdated;
-  }
-
-  @Override
-  public void setLastUpdated(Date lastUpdated) {
-    this.lastUpdated = lastUpdated;
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Sample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Sample.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.Set;
 
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonManagedReference;
 import org.codehaus.jackson.annotate.JsonTypeName;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.w3c.dom.Document;
@@ -53,7 +54,7 @@ import uk.ac.bbsrc.tgac.miso.core.security.SecurableByProfile;
  */
 @JsonSerialize(typing = JsonSerialize.Typing.STATIC, include = JsonSerialize.Inclusion.NON_NULL)
 @JsonTypeName("sample")
-@JsonIgnoreProperties({ "securityProfile", "submissionDocument", "parent" })
+@JsonIgnoreProperties({ "securityProfile", "submissionDocument", "children", "parent" })
 @PrintableBarcode
 public interface Sample
     extends SecurableByProfile, Submittable<Document>, Locatable, Reportable, Comparable, Deletable, Plateable, Boxable {
@@ -298,17 +299,14 @@ public interface Sample
 
   public void setIdentity(Identity identity);
 
+  @JsonManagedReference
   public SampleAdditionalInfo getSampleAdditionalInfo();
 
   public void setSampleAdditionalInfo(SampleAdditionalInfo sampleAdditionalInfo);
 
   public Sample getParent();
 
-  public void setParent(Sample parent);
-
   public Set<Sample> getChildren();
-
-  public void setChildren(Set<Sample> children);
 
   public void setSampleTissue(SampleTissue sampleTissue);
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Sample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Sample.java
@@ -286,10 +286,6 @@ public interface Sample
    */
   void setQCs(Collection<SampleQC> qcs);
 
-  Date getLastUpdated();
-
-  void setLastUpdated(Date lastUpdated);
-
   public User getLastModifier();
 
   public void setLastModifier(User user);

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAdditionalInfo.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAdditionalInfo.java
@@ -1,23 +1,34 @@
 package uk.ac.bbsrc.tgac.miso.core.data;
 
 import java.util.Date;
+import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonBackReference;
+import org.codehaus.jackson.annotate.JsonIgnore;
 
 import com.eaglegenomics.simlims.core.User;
 
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
 
-@JsonIgnoreProperties({ "sample" })
 public interface SampleAdditionalInfo {
 
   Long getSampleId();
 
   void setSampleId(Long sampleAdditionalInfoId);
 
+  @JsonBackReference
   Sample getSample();
 
   void setSample(Sample sample);
+  
+  public Sample getParent();
+  
+  public void setParent(Sample parent);
+  
+  public Set<Sample> getChildren();
+  
+  @JsonIgnore
+  public void setChildren(Set<Sample> children);
 
   SampleClass getSampleClass();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAdditionalInfoImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAdditionalInfoImpl.java
@@ -1,11 +1,15 @@
 package uk.ac.bbsrc.tgac.miso.core.data.impl;
 
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
@@ -34,6 +38,13 @@ public class SampleAdditionalInfoImpl implements SampleAdditionalInfo {
   @JoinColumn(name = "sampleId", nullable = false)
   @MapsId
   private Sample sample;
+  
+  @ManyToOne(optional = true, targetEntity = SampleImpl.class, cascade = CascadeType.ALL)
+  @JoinColumn(name = "parentId", nullable = true)
+  private Sample parent;
+
+  @Transient
+  private Set<Sample> children = new HashSet<>();
 
   @OneToOne(targetEntity = SampleClassImpl.class)
   @JoinColumn(name = "sampleClassId", nullable = false)
@@ -109,6 +120,26 @@ public class SampleAdditionalInfoImpl implements SampleAdditionalInfo {
   @Override
   public void setSample(Sample sample) {
     this.sample = sample;
+  }
+
+  @Override
+  public Sample getParent() {
+    return parent;
+  }
+
+  @Override
+  public void setParent(Sample parent) {
+    this.parent = parent;
+  }
+  
+  @Override
+  public Set<Sample> getChildren() {
+    return children;
+  }
+  
+  @Override
+  public void setChildren(Set<Sample> children) {
+    this.children = children;
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleImpl.java
@@ -128,9 +128,9 @@ public class SampleImpl extends AbstractSample implements Serializable {
 
   public static SampleImpl sampleAnalyte(SampleFactoryBuilder builder) {
     SampleImpl sampleImpl = new SampleImpl(builder);
-    sampleImpl.setParent(builder.getParent());
-    sampleImpl.getParent().getChildren().add(sampleImpl);
     sampleImpl.setSampleAdditionalInfo(builder.getSampleAdditionalInfo());
+    sampleImpl.getSampleAdditionalInfo().setParent(builder.getParent());
+    sampleImpl.getSampleAdditionalInfo().getParent().getSampleAdditionalInfo().getChildren().add(sampleImpl);
     sampleImpl.getSampleAdditionalInfo().setSample(sampleImpl);
     sampleImpl.setSampleAnalyte(builder.getSampleAnalyte());
     sampleImpl.getSampleAnalyte().setSample(sampleImpl);
@@ -139,9 +139,9 @@ public class SampleImpl extends AbstractSample implements Serializable {
 
   public static SampleImpl sampleTissue(SampleFactoryBuilder builder) {
     SampleImpl sampleImpl = new SampleImpl(builder);
-    sampleImpl.setParent(builder.getParent());
-    sampleImpl.getParent().getChildren().add(sampleImpl);
     sampleImpl.setSampleAdditionalInfo(builder.getSampleAdditionalInfo());
+    sampleImpl.getSampleAdditionalInfo().setParent(builder.getParent());
+    sampleImpl.getSampleAdditionalInfo().getParent().getSampleAdditionalInfo().getChildren().add(sampleImpl);
     sampleImpl.getSampleAdditionalInfo().setSample(sampleImpl);
     sampleImpl.setSampleTissue(builder.getSampleTissue());
     sampleImpl.getSampleTissue().setSample(sampleImpl);

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleTissueNode.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleTissueNode.java
@@ -9,10 +9,10 @@ public class SampleTissueNode extends SampleImpl {
 
   public SampleTissueNode(SampleFactoryBuilder builder) {
     super(builder);
-    setParent(builder.getParent());
-    getParent().getChildren().add(this);
     setSampleAdditionalInfo(builder.getSampleAdditionalInfo());
     getSampleAdditionalInfo().setSample(this);
+    getSampleAdditionalInfo().setParent(builder.getParent());
+    getSampleAdditionalInfo().getParent().getSampleAdditionalInfo().getChildren().add(this);
     setSampleTissue(builder.getSampleTissue());
     getSampleTissue().setSample(this);
   }

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -219,6 +219,9 @@ public class Dtos {
     if (from.getPrepKit() != null) {
       dto.setPrepKitId(from.getPrepKit().getKitDescriptorId());
     }
+    if (from.getParent() != null) {
+      dto.setParentId(from.getParent().getId());
+    }
     dto.setPassageNumber(from.getPassageNumber());
     dto.setTimesReceived(from.getTimesReceived());
     dto.setConcentration(from.getConcentration());
@@ -470,9 +473,6 @@ public class Dtos {
     }
     if (from.getSampleTissue() != null) {
       dto.setSampleTissue(asDto(from.getSampleTissue()));
-    }
-    if (from.getParent() != null) {
-      dto.setParentId(from.getParent().getId());
     }
     dto.setVolume(from.getVolume());
 

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAdditionalInfoDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAdditionalInfoDto.java
@@ -8,6 +8,8 @@ public class SampleAdditionalInfoDto {
   private Long sampleId;
   private String url;
   private String sampleUrl;
+  private Long parentId;
+  private String parentUrl;
   private Long sampleClassId;
   private String sampleClassUrl;
   private Long tissueOriginId;
@@ -56,6 +58,22 @@ public class SampleAdditionalInfoDto {
 
   public void setSampleUrl(String sampleUrl) {
     this.sampleUrl = sampleUrl;
+  }
+
+  public Long getParentId() {
+    return parentId;
+  }
+  
+  public void setParentId(Long parentId) {
+    this.parentId = parentId;
+  }
+
+  public String getParentUrl() {
+    return parentUrl;
+  }
+
+  public void setParentUrl(String parentUrl) {
+    this.parentUrl = parentUrl;
   }
 
   public Long getTissueOriginId() {

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleDto.java
@@ -25,8 +25,6 @@ public class SampleDto {
   private SampleAnalyteDto sampleAnalyte;
   private SampleTissueDto sampleTissue;
   private SampleAdditionalInfoDto sampleAdditionalInfo;
-  private Long parentId;
-  private String parentUrl;
   private Long rootSampleClassId;
   private String rootSampleClassUrl;
   private Double volume;
@@ -159,28 +157,12 @@ public class SampleDto {
     this.sampleAdditionalInfo = sampleAdditionalInfo;
   }
 
-  public Long getParentId() {
-    return parentId;
-  }
-
-  public void setParentId(Long parentId) {
-    this.parentId = parentId;
-  }
-
   public Long getRootSampleClassId() {
     return rootSampleClassId;
   }
 
   public void setRootSampleClassId(Long rootSampleClassId) {
     this.rootSampleClassId = rootSampleClassId;
-  }
-
-  public String getParentUrl() {
-    return parentUrl;
-  }
-
-  public void setParentUrl(String parentUrl) {
-    this.parentUrl = parentUrl;
   }
 
   public String getRootSampleClassUrl() {

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
@@ -104,7 +104,7 @@ public class DefaultSampleService implements SampleService {
     authorizationManager.throwIfNotWritable(sample);
     User user = authorizationManager.getCurrentUser();
 
-    if (sampleDto.getParentId() == null && isParentedSample(sample)) {
+    if (sampleDto.getSampleAdditionalInfo() != null && sampleDto.getSampleAdditionalInfo().getParentId() == null) {
       log.debug("No parent has been provided.");
       if (sampleDto.getSampleIdentity() != null && !LimsUtils.isStringEmptyOrNull(sampleDto.getSampleIdentity().getExternalName())) {
         log.debug("Obtaining parent based on external name.");
@@ -112,7 +112,7 @@ public class DefaultSampleService implements SampleService {
         Identity existingIdentity = identityService.get(sampleDto.getSampleIdentity().getExternalName());
         if (existingIdentity != null) {
           log.debug("Parent with existing external name already exists. Using that parent.");
-          sample.setParent(existingIdentity.getSample());
+          sample.getSampleAdditionalInfo().setParent(existingIdentity.getSample());
         } else {
           log.debug("Creating a new Identity to use as a parent.");
           String number = sampleNumberPerProjectService.nextNumber(sample.getProject());
@@ -131,7 +131,7 @@ public class DefaultSampleService implements SampleService {
               .sampleTissue(sample.getSampleTissue()).build();
           setChangeDetails(identitySample, true);
           
-          sample.setParent(identitySample);
+          sample.getSampleAdditionalInfo().setParent(identitySample);
         }
       } else {
         throw new IllegalArgumentException(
@@ -216,10 +216,10 @@ public class DefaultSampleService implements SampleService {
     ServiceUtils.throwIfNull(project, "projectId", sampleDto.getProjectId());
     sample.setProject(project);
 
-    if (sampleDto.getParentId() != null) {
-      Sample parent = sampleDao.getSample(sampleDto.getParentId());
-      ServiceUtils.throwIfNull(parent, "parentId", sampleDto.getParentId());
-      sample.setParent(parent);
+    if (sampleDto.getSampleAdditionalInfo() != null && sampleDto.getSampleAdditionalInfo().getParentId() != null) {
+      Sample parent = sampleDao.getSample(sampleDto.getSampleAdditionalInfo().getParentId());
+      ServiceUtils.throwIfNull(parent, "parentId", sampleDto.getSampleAdditionalInfo().getParentId());
+      sample.getSampleAdditionalInfo().setParent(parent);
     }
 
     if (sampleDto.getSampleIdentity() != null) {

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
@@ -172,7 +172,6 @@ public class DefaultSampleService implements SampleService {
     User user = authorizationManager.getCurrentUser();
     Date now = new Date();
     sample.setLastModifier(user);
-    sample.setLastUpdated(now);
     if (sample.getSampleAdditionalInfo() != null) {
       if (setCreated) {
         sample.getSampleAdditionalInfo().setCreatedBy(user);

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleAdditionalInfoController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleAdditionalInfoController.java
@@ -110,6 +110,10 @@ public class SampleAdditionalInfoController extends RestController {
       sampleAdditionalInfoDto.setPrepKitUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/kitdescriptor/{id}")
           .buildAndExpand(sampleAdditionalInfoDto.getPrepKitId()).toUriString());
     }
+    if (sampleAdditionalInfoDto.getParentId() != null) {
+      sampleAdditionalInfoDto.setParentUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/sample/{id}")
+          .buildAndExpand(sampleAdditionalInfoDto.getParentId()).toUriString());
+    }
     return sampleAdditionalInfoDto;
   }
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleController.java
@@ -80,9 +80,9 @@ public class SampleController extends RestController {
   private static SampleDto writeUrls(SampleDto sampleDto, UriComponentsBuilder uriBuilder) {
     URI baseUri = uriBuilder.build().toUri();
     sampleDto.setUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/tree/sample/{id}").buildAndExpand(sampleDto.getId()).toUriString());
-    if (sampleDto.getParentId() != null) {
-      sampleDto.setParentUrl(
-          UriComponentsBuilder.fromUri(baseUri).path("/rest/tree/sample/{id}").buildAndExpand(sampleDto.getParentId()).toUriString());
+    if (sampleDto.getSampleAdditionalInfo() != null && sampleDto.getSampleAdditionalInfo().getParentId() != null) {
+      sampleDto.getSampleAdditionalInfo().setParentUrl(
+          UriComponentsBuilder.fromUri(baseUri).path("/rest/tree/sample/{id}").buildAndExpand(sampleDto.getSampleAdditionalInfo().getParentId()).toUriString());
     }
     if (sampleDto.getRootSampleClassId() != null) {
       sampleDto.setRootSampleClassUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/sampleclass/{id}")

--- a/sqlstore/src/main/resources/db/migration/V0010__sample_hierarchy.sql
+++ b/sqlstore/src/main/resources/db/migration/V0010__sample_hierarchy.sql
@@ -149,6 +149,7 @@ CREATE TABLE `SampleAdditionalInfo` (
   `archived` bit(1) NOT NULL,
   `externalInstituteIdentifier` varchar(255) DEFAULT NULL,
   `labId` bigint(20) DEFAULT NULL,
+  `parentId` bigint(20) DEFAULT NULL,
   `createdBy` bigint(20) NOT NULL,
   `creationDate` datetime NOT NULL,
   `updatedBy` bigint(20) NOT NULL,
@@ -169,6 +170,7 @@ CREATE TABLE `SampleAdditionalInfo` (
   CONSTRAINT `FKlgx09pit706ehsyqq2tpe42do` FOREIGN KEY (`subprojectId`) REFERENCES `Subproject` (`subprojectId`),
   CONSTRAINT `FKoulifnc7plonin8pbreiovb3x` FOREIGN KEY (`tissueTypeId`) REFERENCES `TissueType` (`tissueTypeId`),
   CONSTRAINT `sampleadditionalinfo_lab_fkey` FOREIGN KEY (`labId`) REFERENCES `Lab` (`labId`),
+  CONSTRAINT `sampleadditionalinfo_parent_fkey` FOREIGN KEY (`parentId`) REFERENCES `Sample` (`sampleId`),
   CONSTRAINT `FKp8bvx3e7jsmnyw51toi7mq7cq` FOREIGN KEY (`updatedBy`) REFERENCES `User` (`userId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -255,9 +257,6 @@ CREATE TABLE `SampleAnalyte` (
   CONSTRAINT `FKpras819b6p7vh12xbeovne8o0` FOREIGN KEY (`createdBy`) REFERENCES `User` (`userId`),
   CONSTRAINT `FKprqyhv40bntjrf5l64mjdgl1j` FOREIGN KEY (`updatedBy`) REFERENCES `User` (`userId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-ALTER TABLE Sample ADD COLUMN `parentId` BIGINT (20) DEFAULT NULL;
-ALTER TABLE Sample ADD FOREIGN KEY (parentId) REFERENCES Sample (sampleId);
 
 CREATE TABLE `SampleNumberPerProject` (
   `sampleNumberPerProjectId` bigint(20) NOT NULL AUTO_INCREMENT,

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
@@ -21,6 +21,7 @@ import com.eaglegenomics.simlims.core.store.SecurityStore;
 
 import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAdditionalInfoImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.DefaultSampleNamingScheme;
 import uk.ac.bbsrc.tgac.miso.core.store.ChangeLogStore;
@@ -63,6 +64,7 @@ public class HibernateSampleDaoTest extends AbstractDAOTest {
   @Test
   public void parentNameNotModifiedWhenParentNullTest() throws Exception {
     Sample sample = new SampleImpl();
+    sample.setSampleAdditionalInfo(new SampleAdditionalInfoImpl());
     sut.updateParentSampleNameIfRequired(sample);
     assertNull("Null parent will remain null. No need to udate sample name.", sample.getParent());
   }
@@ -71,7 +73,8 @@ public class HibernateSampleDaoTest extends AbstractDAOTest {
   public void parentNameNotModifiedWhenParentNameNotTemporaryTest() throws Exception {
     Sample sample = new SampleImpl();
     Sample parent = new SampleImpl();
-    sample.setParent(parent);
+    sample.setSampleAdditionalInfo(new SampleAdditionalInfoImpl());
+    sample.getSampleAdditionalInfo().setParent(parent);
     String nonTemporaryName = "RealSampleName";
     parent.setName(nonTemporaryName);
     sut.updateParentSampleNameIfRequired(sample);
@@ -82,7 +85,8 @@ public class HibernateSampleDaoTest extends AbstractDAOTest {
   public void parentNameNotModifiedWhenParentIdNotSetTest() throws Exception {
     Sample sample = new SampleImpl();
     Sample parent = new SampleImpl();
-    sample.setParent(parent);
+    sample.setSampleAdditionalInfo(new SampleAdditionalInfoImpl());
+    sample.getSampleAdditionalInfo().setParent(parent);
     String temporaryName = HibernateSampleDao.generateTemporaryName();
     parent.setName(temporaryName);
     parent.setId(Sample.UNSAVED_ID);
@@ -94,7 +98,8 @@ public class HibernateSampleDaoTest extends AbstractDAOTest {
   public void parentNameModifiedTest() throws Exception {
     Sample sample = new SampleImpl();
     Sample parent = new SampleImpl();
-    sample.setParent(parent);
+    sample.setSampleAdditionalInfo(new SampleAdditionalInfoImpl());
+    sample.getSampleAdditionalInfo().setParent(parent);
     String temporaryName = HibernateSampleDao.generateTemporaryName();
     parent.setName(temporaryName);
     parent.setId(42);
@@ -135,6 +140,18 @@ public class HibernateSampleDaoTest extends AbstractDAOTest {
     Sample sample = sut.get(15L);
     assertNotNull(sample.getChildren());
     assertEquals(2,sample.getChildren().size());
+    for (@SuppressWarnings("unused") Sample child : sample.getChildren()) {
+      // will throw ClassCastException if children are not correctly loaded as Samples
+    }
+  }
+  
+  @Test
+  public void getSampleWithParentTest() throws Exception {
+    SampleImpl sample = (SampleImpl) sut.get(16L);
+    assertNotNull(sample);
+    assertNotNull(sample.getSampleAdditionalInfo());
+    assertNotNull(sample.getParent());
+    assertEquals(15L, sample.getParent().getId());
   }
 
 }

--- a/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
+++ b/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
@@ -198,19 +198,19 @@ VALUES (1,NULL,'SAM1','Inherited from TEST_0001',1,'SAM1::TEST_0001_Bn_P_nn_1-1_
 (13,NULL,'SAM13','Inherited from TEST_0007',1,'SAM13::TEST_0007_Bn_P_nn_1-1_D_1','Freezer1_13','GENOMIC','2015-01-27','true','TEST_0007_Bn_P_nn_1-1_D_1',1,'Homo sapiens',NULL,1),
 (14,NULL,'SAM14','Inherited from TEST_0007',1,'SAM14::TEST_0007_Bn_R_nn_1-1_D_1','Freezer1_14','GENOMIC','2015-01-27','true','TEST_0007_Bn_R_nn_1-1_D_1',1,'Homo sapiens',NULL,1);
 
-INSERT INTO `Sample`(`sampleId`, `accession`, `name`, `description`, `securityProfile_profileId`, `identificationBarcode`, `locationBarcode`, `sampleType`, `receivedDate`, `qcPassed`, `alias`, `project_projectId`, `scientificName`, `taxonIdentifier`, `lastModifier`,`parentId`) 
-VALUES (15,NULL,'SAM15','identity1',1,'SAM15::TEST_0001_IDENTITY_1','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_IDENTITY_1',1,'Homo sapiens',NULL,1,NULL),
-(16,NULL,'SAM16','tissue1',1,'SAM16::TEST_0001_TISSUE_1','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_TISSUE_1',1,'Homo sapiens',NULL,1,15),
-(17,NULL,'SAM17','tissue2',1,'SAM17::TEST_0001_TISSUE_2','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_TISSUE_2',1,'Homo sapiens',NULL,1,15);
+INSERT INTO `Sample`(`sampleId`, `accession`, `name`, `description`, `securityProfile_profileId`, `identificationBarcode`, `locationBarcode`, `sampleType`, `receivedDate`, `qcPassed`, `alias`, `project_projectId`, `scientificName`, `taxonIdentifier`, `lastModifier`) 
+VALUES (15,NULL,'SAM15','identity1',1,'SAM15::TEST_0001_IDENTITY_1','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_IDENTITY_1',1,'Homo sapiens',NULL,1),
+(16,NULL,'SAM16','tissue1',1,'SAM16::TEST_0001_TISSUE_1','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_TISSUE_1',1,'Homo sapiens',NULL,1),
+(17,NULL,'SAM17','tissue2',1,'SAM17::TEST_0001_TISSUE_2','Freezer1_1','GENOMIC','2016-04-05','true','TEST_0001_TISSUE_2',1,'Homo sapiens',NULL,1);
 
 INSERT INTO `SampleClass`(`sampleClassId`, `alias`, `sampleCategory`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
 VALUES (1,'Identity','Identity',1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00'),
 (2,'Primary Tumor Tissue','Tissue',1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00');
 
-INSERT INTO `SampleAdditionalInfo`(`sampleId`, `sampleClassId`, `archived`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
-VALUES (15,1,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00'),
-(16,2,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00'),
-(17,2,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00');
+INSERT INTO `SampleAdditionalInfo`(`sampleId`, `sampleClassId`, `archived`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`, `parentId`)
+VALUES (15,1,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00',NULL),
+(16,2,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00',15),
+(17,2,0,1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00',15);
 
 INSERT INTO `Identity`(`sampleId`, `internalName`, `externalName`, `createdBy`, `creationDate`, `updatedBy`, `lastUpdated`)
 VALUES (15,'INT1','EXT1',1,'2016-04-05 14:57:00',1,'2016-04-05 14:57:00');


### PR DESCRIPTION
Moved parentId field to SampleAdditionalInfo, as it only applies to detailed samples. This also enables creating a composite unique key that is required (or at least helpful) for sample alias generation.

Also removed unused lastUpdated field from Sample. This field did not exist in the database, and the data is available via SampleChangeLog already