### PR TITLE
GLT-585 Add Service Record only available to Admin and Tech in web ui

### DIFF
--- a/miso-web/src/main/webapp/pages/editSequencerReference.jsp
+++ b/miso-web/src/main/webapp/pages/editSequencerReference.jsp
@@ -235,10 +235,13 @@
       <h1>Service Records</h1>
       <ul class="sddm">
         <li>
-          <a onmouseover="mopen('recordmenu')" onmouseout="mclosetime()">
-            Options
-            <span style="float:right" class="ui-icon ui-icon-triangle-1-s"></span>
-          </a>
+          <c:if test="${fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')
+            or fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_TECH')}">
+              <a onmouseover="mopen('recordmenu')" onmouseout="mclosetime()">
+                Options
+                <span style="float:right" class="ui-icon ui-icon-triangle-1-s"></span>
+              </a>
+          </c:if>
           <div id="recordmenu" onmouseover="mcancelclosetime()" onmouseout="mclosetime()">
             <c:choose>
               <c:when test="${sequencerReference.dateDecommissioned == null}">


### PR DESCRIPTION
The 'add service record' menu is only displayed for users who have permissions to create service records (ADMIN and TECH). This prevents 'permission denied' errors for regular users.