### PR TITLE
Fix problem with potential base64-encoded strings in searches

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtils.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtils.java
@@ -94,8 +94,6 @@ public class LimsUtils {
 
   protected static final Logger log = LoggerFactory.getLogger(LimsUtils.class);
 
-  private static final Pattern p = Pattern.compile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$");
-
   public static String unicodeify(String barcode) {
     log.debug("ORIGINAL :: " + barcode);
     StringBuilder b = new StringBuilder();
@@ -111,12 +109,6 @@ public class LimsUtils {
     }
     log.debug("UNICODED :: " + b.toString());
     return b.toString();
-  }
-
-  public static boolean isBase64String(String base64) {
-    // nasty 20-character length hack for base64 strings.
-    // just have to hope that people don't generally search for 4-mer 20+ length strings very often
-    return base64.length() > 20 && p.matcher(base64).matches();
   }
 
   public static boolean isUrlValid(URL url) {

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -233,7 +233,6 @@ Utils.validation = {
   dateRegex: '^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[012])\/(19|20)[0-9]{2}$',
   dateTimeRegex: '^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[012])\/(19|20)[0-9]{2} ([01][0-9]|2[0-3]):[0-5][0-9]$',
   sanitizeRegex: '[^<>\'\/]+',
-  //_base64 : XRegExp('^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$'),
   unicodeWordRegex: '^[\\p{L}0-9_\\^\\-\\.\\s]+$',
   _unicodeWord: XRegExp('^[\\p{L}0-9_\\^\\-\\.\\s]+$'),
 
@@ -254,143 +253,10 @@ Utils.validation = {
     return {"okstatus": okstatus, "errormsg": errormsg};
   },
 
-  base64Check: function (str) {
-    var base64 = new RegExp('^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$');
-    if (base64.test(str)) {
-      return Utils.codec.base64_decode(str);
-    }
-    else {
-      return str;
-    }
-  },
-
   // Clean input fields by removing leading and trailing whitespace
   clean_input_field: function (field) {
     var oldval = field.val();
     field.val(oldval.trim(oldval));
-  }
-};
-
-Utils.codec = {
-  // private property
-  _keyStr: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
-
-  // public method for encoding
-  base64_encode: function (input) {
-    var self = this;
-    var output = "";
-    var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
-    var i = 0;
-
-    input = self._utf8_encode(input);
-
-    while (i < input.length) {
-      chr1 = input.charCodeAt(i++);
-      chr2 = input.charCodeAt(i++);
-      chr3 = input.charCodeAt(i++);
-
-      enc1 = chr1 >> 2;
-      enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
-      enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
-      enc4 = chr3 & 63;
-
-      if (isNaN(chr2)) {
-        enc3 = enc4 = 64;
-      }
-      else if (isNaN(chr3)) {
-        enc4 = 64;
-      }
-
-      output = output +
-               self._keyStr.charAt(enc1) + self._keyStr.charAt(enc2) +
-               self._keyStr.charAt(enc3) + self._keyStr.charAt(enc4);
-    }
-    return output;
-  },
-
-  // public method for decoding
-  base64_decode: function (input) {
-    var self = this;
-    var output = "";
-    var chr1, chr2, chr3;
-    var enc1, enc2, enc3, enc4;
-    var i = 0;
-
-    input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
-
-    while (i < input.length) {
-
-      enc1 = self._keyStr.indexOf(input.charAt(i++));
-      enc2 = self._keyStr.indexOf(input.charAt(i++));
-      enc3 = self._keyStr.indexOf(input.charAt(i++));
-      enc4 = self._keyStr.indexOf(input.charAt(i++));
-
-      chr1 = (enc1 << 2) | (enc2 >> 4);
-      chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
-      chr3 = ((enc3 & 3) << 6) | enc4;
-
-      output = output + String.fromCharCode(chr1);
-
-      if (enc3 != 64) {
-        output = output + String.fromCharCode(chr2);
-      }
-      if (enc4 != 64) {
-        output = output + String.fromCharCode(chr3);
-      }
-    }
-    output = self._utf8_decode(output);
-    return output;
-  },
-
-  // private method for UTF-8 encoding
-  _utf8_encode: function (string) {
-    string = string.replace(/\r\n/g, "\n");
-    var utftext = "";
-
-    for (var n = 0; n < string.length; n++) {
-      var c = string.charCodeAt(n);
-      if (c < 128) {
-        utftext += String.fromCharCode(c);
-      }
-      else if ((c > 127) && (c < 2048)) {
-        utftext += String.fromCharCode((c >> 6) | 192);
-        utftext += String.fromCharCode((c & 63) | 128);
-      }
-      else {
-        utftext += String.fromCharCode((c >> 12) | 224);
-        utftext += String.fromCharCode(((c >> 6) & 63) | 128);
-        utftext += String.fromCharCode((c & 63) | 128);
-      }
-    }
-
-    return utftext;
-  },
-
-  // private method for UTF-8 decoding
-  _utf8_decode: function (utftext) {
-    var string = "";
-    var i = 0;
-    var c = c1 = c2 = 0;
-
-    while (i < utftext.length) {
-      c = utftext.charCodeAt(i);
-      if (c < 128) {
-        string += String.fromCharCode(c);
-        i++;
-      }
-      else if ((c > 191) && (c < 224)) {
-        c2 = utftext.charCodeAt(i + 1);
-        string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
-        i += 2;
-      }
-      else {
-        c2 = utftext.charCodeAt(i + 1);
-        c3 = utftext.charCodeAt(i + 2);
-        string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
-        i += 3;
-      }
-    }
-    return string;
   }
 };
 

--- a/miso-web/src/main/webapp/scripts/sample_ajax.js
+++ b/miso-web/src/main/webapp/scripts/sample_ajax.js
@@ -684,8 +684,6 @@ Sample.ui = {
   receiveSample: function (input) {
     var barcode = jQuery(input).val();
     if (!Utils.validation.isNullCheck(barcode)) {
-      barcode = Utils.validation.base64Check(barcode);
-      jQuery(input).val(barcode);
 
       Fluxion.doAjax(
         'sampleControllerHelperService',

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/ContainerControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/ContainerControllerHelperService.java
@@ -74,10 +74,7 @@ import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 
 /**
- * Created by IntelliJ IDEA.
- * User: davey
- * Date: 25-May-2010
- * Time: 16:39:52
+ * Created by IntelliJ IDEA. User: davey Date: 25-May-2010 Time: 16:39:52
  */
 @Ajaxified
 public class ContainerControllerHelperService {
@@ -545,14 +542,11 @@ public class ContainerControllerHelperService {
     int partition = json.getInt("partition");
 
     try {
-      if (isStringEmptyOrNull(barcode)) {
-        if (LimsUtils.isBase64String(barcode)) {
-          // Base64-encoded string, most likely a barcode image beeped in. decode and search
-          barcode = new String(Base64.decodeBase64(barcode));
-        }
-      }
-
       Pool p = requestManager.getPoolByBarcode(barcode);
+      // Base64-encoded string, most likely a barcode image beeped in. decode and search
+      if (p == null) {
+        p = requestManager.getPoolByBarcode(new String(Base64.decodeBase64(barcode)));
+      }
       SequencerPartitionContainer<SequencerPoolPartition> lf = (SequencerPartitionContainer<SequencerPoolPartition>) session
           .getAttribute("container_" + json.getString("container_cId"));
       if (lf.getPlatform().getPlatformType().equals(p.getPlatformType())) {
@@ -904,18 +898,20 @@ public class ContainerControllerHelperService {
         if (spc.getRun() != null) {
           run = TableHelper.hyperLinkify("/miso/run/" + spc.getRun().getId(), spc.getRun().getAlias());
           if (spc.getRun().getSequencerReference() != null) {
-            sequencer = TableHelper.hyperLinkify("/miso/sequencer/" + spc.getRun().getSequencerReference().getId(), 
-                                     spc.getRun().getSequencerReference().getPlatform().getNameAndModel());
+            sequencer = TableHelper.hyperLinkify("/miso/sequencer/" + spc.getRun().getSequencerReference().getId(),
+                spc.getRun().getSequencerReference().getPlatform().getNameAndModel());
           }
         }
-        String identificationBarcode = (isStringEmptyOrNull(spc.getIdentificationBarcode()) ? "Unknown Barcode" : spc.getIdentificationBarcode());
-        
+        String identificationBarcode = (isStringEmptyOrNull(spc.getIdentificationBarcode()) ? "Unknown Barcode"
+            : spc.getIdentificationBarcode());
+
         JSONArray inner = new JSONArray();
-        inner.add(TableHelper.hyperLinkify("/miso/container/" + spc.getId(),identificationBarcode));
-        inner.add(spc.getPlatform() != null && spc.getPlatform().getPlatformType() != null ? spc.getPlatform().getPlatformType().getKey() : "");
+        inner.add(TableHelper.hyperLinkify("/miso/container/" + spc.getId(), identificationBarcode));
+        inner.add(
+            spc.getPlatform() != null && spc.getPlatform().getPlatformType() != null ? spc.getPlatform().getPlatformType().getKey() : "");
         inner.add(run);
         inner.add(sequencer);
-        
+
         jsonArray.add(inner);
       }
       j.put("array", jsonArray);

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/DashboardHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/DashboardHelperService.java
@@ -310,11 +310,11 @@ public class DashboardHelperService {
       List<Library> libraries;
       StringBuilder b = new StringBuilder();
       if (!isStringEmptyOrNull(searchStr)) {
-        if (LimsUtils.isBase64String(searchStr)) {
-          // Base64-encoded string, most likely a barcode image beeped in. decode and search
-          searchStr = new String(Base64.decodeBase64(searchStr));
-        }
         libraries = new ArrayList<Library>(requestManager.listAllLibrariesBySearch(searchStr));
+        if (libraries.isEmpty()) {
+          // Base64-encoded string, most likely a barcode image beeped in. decode and search
+          libraries = new ArrayList<Library>(requestManager.listAllLibrariesBySearch(new String(Base64.decodeBase64(searchStr))));
+        }
       } else {
         libraries = new ArrayList<Library>(requestManager.listAllLibrariesWithLimit(50));
       }
@@ -345,11 +345,10 @@ public class DashboardHelperService {
       List<Sample> samples;
       StringBuilder b = new StringBuilder();
       if (!isStringEmptyOrNull(searchStr)) {
-        if (LimsUtils.isBase64String(searchStr)) {
-          // Base64-encoded string, most likely a barcode image beeped in. decode and search
-          searchStr = new String(Base64.decodeBase64(searchStr));
-        }
         samples = new ArrayList<>(requestManager.listAllSamplesBySearch(searchStr));
+        if (samples.isEmpty()) {
+          samples = new ArrayList<>(requestManager.listAllSamplesBySearch(new String(Base64.decodeBase64(searchStr))));
+        }
       } else {
         samples = new ArrayList<>(requestManager.listAllSamplesWithLimit(50));
       }
@@ -498,8 +497,8 @@ public class DashboardHelperService {
     try {
       StringBuilder b = new StringBuilder();
       Collection<Sample> samples = requestManager.listAllSamplesByReceivedDate(100);
-      
-      Set<Long> uniqueProjects = new HashSet<>();   
+
+      Set<Long> uniqueProjects = new HashSet<>();
 
       if (samples.size() > 0) {
         for (Sample s : samples) {
@@ -510,7 +509,7 @@ public class DashboardHelperService {
             b.append("Alias: <b>" + s.getProject().getAlias() + "</b><br/>");
             b.append("Last Received: <b>" + LimsUtils.getDateAsString(s.getReceivedDate()) + "</b><br/>");
             b.append("</div>");
-            
+
             uniqueProjects.add(s.getProject().getId());
           }
         }

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/PoolControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/PoolControllerHelperService.java
@@ -247,11 +247,11 @@ public class PoolControllerHelperService {
     StringBuilder sb = new StringBuilder();
     sb.append("<div id='dilslist' class='checklist' style='width: 100%;'>");
     for (String s : codes) {
-      if (LimsUtils.isBase64String(s)) {
-        // Base64-encoded string, most likely a barcode image beeped in. decode and search
-        s = new String(Base64.decodeBase64(s));
-      }
       Dilution ed = requestManager.getDilutionByBarcode(s);
+      // Base64-encoded string, most likely a barcode image beeped in. decode and search
+      if (ed == null) {
+        ed = requestManager.getDilutionByBarcode(new String(Base64.decodeBase64(s)));
+      }
       if (ed != null) {
         sb.append("<span>");
         sb.append("<input type='checkbox' value='" + s + "' name='importdilslist' id='importdilslist_" + ed.getName() + "'/>");
@@ -716,7 +716,7 @@ public class PoolControllerHelperService {
 
     JSONObject j = new JSONObject();
 
-      try {
+    try {
       for (Pool pool : requestManager.listAllPools()) {
         poolMap.get(pool.getPlatformType().getKey()).add(pool);
       }
@@ -739,10 +739,10 @@ public class PoolControllerHelperService {
         j.put(poolType, arr);
       }
 
-        return j;
-      } catch (IOException e) {
-        log.debug("Failed", e);
-        return JSONUtils.SimpleJSONError("Failed: " + e.getMessage());
+      return j;
+    } catch (IOException e) {
+      log.debug("Failed", e);
+      return JSONUtils.SimpleJSONError("Failed: " + e.getMessage());
     }
   }
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAO.java
@@ -629,6 +629,9 @@ public class SQLPoolDAO implements PoolStore {
   @Override
   public Pool<? extends Poolable> getPoolByBarcode(String barcode, PlatformType platformType) throws IOException {
     if (barcode == null) throw new NullPointerException("cannot look up null barcode");
+    if (platformType == null) {
+      return getByBarcode(barcode);
+    }
     List<Pool<? extends Poolable>> pools = listAllByPlatformAndSearch(platformType, barcode);
     return pools.size() == 1 ? pools.get(0) : null;
   }

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAOTest.java
@@ -51,11 +51,11 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
-  
+
   @Autowired
   @Spy
   private JdbcTemplate jdbcTemplate;
-  
+
   @Mock
   private ExperimentStore experimentDAO;
   @Mock
@@ -77,14 +77,14 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
   @Mock
   private com.eaglegenomics.simlims.core.manager.SecurityManager securityManager;
   @Mock
-  private MisoNamingScheme<Pool<? extends Poolable<?,?>>> namingScheme;
-  
+  private MisoNamingScheme<Pool<? extends Poolable<?, ?>>> namingScheme;
+
   @InjectMocks
   private SQLPoolDAO dao;
 
   // Auto-increment sequence doesn't roll back with transactions, so must be tracked
   private static long nextAutoIncrementId = 11L;
-  
+
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
@@ -92,205 +92,205 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     dao.setDataObjectFactory(new TgacDataObjectFactory());
     mockLibraryDilutionStore();
   }
-  
+
   private void mockLibraryDilutionStore() throws IOException {
     @SuppressWarnings("unchecked")
     Store<LibraryDilution> ldiStore = Mockito.mock(Store.class);
     Mockito.when(daoLookup.lookup(LibraryDilution.class)).thenReturn(ldiStore);
     Mockito.when(ldiStore.get(Mockito.anyLong())).thenReturn(new LibraryDilution());
   }
-  
+
   private void mockAutoIncrement(long value) {
     Map<String, Object> rs = new HashMap<>();
     rs.put("Auto_increment", value);
     Mockito.doReturn(rs).when(jdbcTemplate).queryForMap(Matchers.anyString());
   }
-  
+
   @Test
   public void testListAll() throws IOException {
     assertEquals(10, dao.listAll().size());
   }
-  
+
   @Test
   public void testCount() throws IOException {
     assertEquals(10, dao.count());
   }
-  
+
   @Test
   public void testGet() throws IOException {
     Pool<?> pool = dao.get(1L);
     assertNotNull(pool);
     assertEquals(1L, pool.getId());
   }
-  
+
   @Test
   public void testGetNone() throws IOException {
     assertNull(dao.get(100L));
   }
-  
+
   @Test
   public void testLazyGet() throws IOException {
     Pool<?> pool = dao.lazyGet(1L);
     assertNotNull(pool);
     assertEquals(1L, pool.getId());
   }
-  
+
   @Test
   public void testLazyGetNone() throws IOException {
     assertNull(dao.lazyGet(100L));
   }
-  
+
   @Test
   public void testListByProjectId() throws IOException {
     assertEquals(10, dao.listByProjectId(1L).size());
   }
-  
+
   @Test
   public void testListByProjectNone() throws IOException {
     assertEquals(0, dao.listByProjectId(100L).size());
   }
-  
+
   @Test
   public void testListBySampleId() throws IOException {
     assertEquals(2, dao.listBySampleId(2L).size());
   }
-  
+
   @Test
   public void testListBySampleIdNone() throws IOException {
     assertEquals(0, dao.listBySampleId(100L).size());
   }
-  
+
   @Test
   public void testListByLibraryId() throws IOException {
     assertEquals(2, dao.listByLibraryId(1L).size());
   }
-  
+
   @Test
   public void testListByLibraryIdNone() throws IOException {
     assertEquals(0, dao.listByLibraryId(100L).size());
   }
-  
+
   @Test
   public void testListAllByPlatform() throws IOException {
     assertEquals(10, dao.listAllByPlatform(PlatformType.ILLUMINA).size());
   }
-  
+
   @Test
   public void testListAllByPlatformNone() throws IOException {
     assertEquals(0, dao.listAllByPlatform(PlatformType.SOLID).size());
   }
-  
+
   @Test
   public void testListAllByPlatformNull() throws IOException {
     expectedException.expect(NullPointerException.class);
     dao.listAllByPlatform(null);
   }
-  
+
   @Test
   public void testListAllByPlatformAndSearchByName() throws IOException {
     assertEquals(1, dao.listAllByPlatformAndSearch(PlatformType.ILLUMINA, "IPO5").size());
   }
-  
+
   @Test
   public void testListAllByPlatformAndSearchByAlias() throws IOException {
     assertEquals(1, dao.listAllByPlatformAndSearch(PlatformType.ILLUMINA, "Pool 5").size());
   }
-  
+
   @Test
   public void testListAllByPlatformAndSearchByIdentificationBarcode() throws IOException {
     assertEquals(1, dao.listAllByPlatformAndSearch(PlatformType.ILLUMINA, "IPO5::Illumina").size());
   }
-  
+
   @Test
   public void testListAllByPlatformAndSearchWithEmptyString() throws IOException {
     assertEquals(10, dao.listAllByPlatformAndSearch(PlatformType.ILLUMINA, "").size());
   }
-  
+
   @Test
   public void testListAllByPlatformAndSearchNoneForPlatformType() throws IOException {
     assertEquals(0, dao.listAllByPlatformAndSearch(PlatformType.SOLID, "").size());
   }
-  
+
   @Test
   public void testListAllByPlatformAndSearchNoneForQuery() throws IOException {
     assertEquals(0, dao.listAllByPlatformAndSearch(PlatformType.ILLUMINA, "asdf").size());
   }
-  
+
   @Test
   public void testListAllByPlatformAndSearchNullPlatformType() throws IOException {
     expectedException.expect(NullPointerException.class);
     dao.listAllByPlatformAndSearch(null, "");
   }
-  
+
   @Test
   public void testListAllByPlatformAndSearchNullQuery() throws IOException {
     assertEquals(10, dao.listAllByPlatformAndSearch(PlatformType.ILLUMINA, null).size());
   }
-  
+
   @Test
   public void testListReadyByPlatform() throws IOException {
     assertEquals(5, dao.listReadyByPlatform(PlatformType.ILLUMINA).size());
   }
-  
+
   @Test
   public void testListReadyByPlatformNone() throws IOException {
     assertEquals(0, dao.listReadyByPlatform(PlatformType.SOLID).size());
   }
-  
+
   @Test
   public void testListReadyByPlatformNull() throws IOException {
     expectedException.expect(NullPointerException.class);
     dao.listReadyByPlatform(null).size();
   }
-  
+
   @Test
   public void testListReadyByPlatformAndSearchByName() throws IOException {
     assertEquals(1, dao.listReadyByPlatformAndSearch(PlatformType.ILLUMINA, "IPO3").size());
   }
-  
+
   @Test
   public void testListReadyByPlatformAndSearchByAlias() throws IOException {
     assertEquals(1, dao.listReadyByPlatformAndSearch(PlatformType.ILLUMINA, "Pool 3").size());
   }
-  
+
   @Test
   public void testListReadyByPlatformAndSearchByIdentificationBarcode() throws IOException {
     assertEquals(1, dao.listReadyByPlatformAndSearch(PlatformType.ILLUMINA, "IPO3::Illumina").size());
   }
-  
+
   @Test
   public void testListReadyByPlatformAndSearchWithEmptyString() throws IOException {
     assertEquals(5, dao.listReadyByPlatformAndSearch(PlatformType.ILLUMINA, "").size());
   }
-  
+
   @Test
   public void testListReadyByPlatformAndSearchNoneForPlatformType() throws IOException {
     assertEquals(0, dao.listReadyByPlatformAndSearch(PlatformType.SOLID, "").size());
   }
-  
+
   @Test
   public void testListReadyByPlatformAndSearchNoneForQuery() throws IOException {
     assertEquals(0, dao.listReadyByPlatformAndSearch(PlatformType.ILLUMINA, "asdf").size());
   }
-  
+
   @Test
   public void testListReadyByPlatformAndSearchWithNullPlatformType() throws IOException {
     expectedException.expect(NullPointerException.class);
     dao.listReadyByPlatformAndSearch(null, "IPO3").size();
   }
-  
+
   @Test
   public void testListReadyByPlatformAndSearchWithNullQuery() throws IOException {
     assertEquals(5, dao.listReadyByPlatformAndSearch(PlatformType.ILLUMINA, null).size());
   }
-  
+
   @Test
   public void testGetPoolColumnSizes() throws IOException {
     Map<String, Integer> map = dao.getPoolColumnSizes();
     assertNotNull(map);
     assertFalse(map.isEmpty());
   }
-  
+
   @Test
   public void testAutoGenerateIdBarcode() {
     Pool<LibraryDilution> p = new PoolImpl<>();
@@ -299,7 +299,7 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     dao.autoGenerateIdBarcode(p);
     assertEquals("name::" + PlatformType.ILLUMINA.getKey(), p.getIdentificationBarcode());
   }
-  
+
   @Test
   public void testGetPoolByExperiment() throws IOException {
     Experiment exp = new ExperimentImpl();
@@ -310,19 +310,19 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     Pool<?> p = dao.getPoolByExperiment(exp);
     assertNotNull(p);
   }
-  
+
   @Test
   public void testGetPoolByExperimentNull() throws IOException {
     expectedException.expect(NullPointerException.class);
     dao.getPoolByExperiment(null);
   }
-  
+
   @Test
   public void testGetPoolByExperimentNullPlatform() throws IOException {
     Experiment exp = new ExperimentImpl();
     assertNull(dao.getPoolByExperiment(exp));
   }
-  
+
   @Test
   public void testGetPoolByExperimentNoneForPlatform() {
     Experiment exp = new ExperimentImpl();
@@ -332,7 +332,7 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     exp.setPlatform(plat);
     assertNull(dao.getPoolByExperiment(exp));
   }
-  
+
   @Test
   public void testGetPoolByExperimentNoneForExperiment() {
     Experiment exp = new ExperimentImpl();
@@ -342,45 +342,44 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     exp.setPlatform(plat);
     assertNull(dao.getPoolByExperiment(exp));
   }
-  
+
   @Test
   public void testGetPoolByBarcode() throws IOException {
     assertNotNull(dao.getPoolByBarcode("IPO3::Illumina", PlatformType.ILLUMINA));
   }
-  
+
   @Test
   public void testGetPoolByBarcodeNone() throws IOException {
     assertNull(dao.getPoolByBarcode("asdf", PlatformType.ILLUMINA));
   }
-  
+
   @Test
   public void testGetPoolByBarcodeNull() throws IOException {
     expectedException.expect(NullPointerException.class);
     dao.getPoolByBarcode(null, PlatformType.ILLUMINA);
   }
-  
+
   @Test
   public void testGetPoolByBarcodeNullPlatform() throws IOException {
-    expectedException.expect(NullPointerException.class);
-    dao.getPoolByBarcode("", null);
+    assertNull(dao.getPoolByBarcode("", null));
   }
-  
+
   @Test
   public void testGetByBarcode() throws IOException {
     assertNotNull(dao.getByBarcode("IPO3::Illumina"));
   }
-  
+
   @Test
   public void testGetByBarcodeNone() throws IOException {
     assertNull(dao.getByBarcode("asdf"));
   }
-  
+
   @Test
   public void testGetByBarcodeNull() throws IOException {
     expectedException.expect(NullPointerException.class);
     dao.getByBarcode(null);
   }
-  
+
   @Test
   public void testGetByBarcodeList() throws IOException {
     List<String> barcodes = new ArrayList<>();
@@ -388,7 +387,7 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     barcodes.add("IPO3::Illumina");
     assertEquals(2, dao.getByBarcodeList(barcodes).size());
   }
-  
+
   @Test
   public void testGetByBarcodeListNone() throws IOException {
     List<String> barcodes = new ArrayList<>();
@@ -396,28 +395,28 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     barcodes.add("jkl;");
     assertEquals(0, dao.getByBarcodeList(barcodes).size());
   }
-  
+
   @Test
   public void testGetByBarcodeListNull() {
     expectedException.expect(NullPointerException.class);
     dao.getByBarcodeList(null);
   }
-  
+
   @Test
   public void testGetByBarcodeListEmpty() {
     assertEquals(0, dao.getByBarcodeList(new ArrayList<String>()).size());
   }
-  
+
   @Test
   public void testGetByPositionId() throws IOException {
     assertNotNull(dao.getByPositionId(201L));
   }
-  
+
   @Test
   public void testGetByPositionIdNone() throws IOException {
     assertNull(dao.getByPositionId(9999L));
   }
-  
+
   @Test
   public void testRemove() throws IOException {
     Pool<?> pool = dao.get(1L);
@@ -427,7 +426,7 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     assertTrue(dao.remove(pool));
     assertNull(dao.get(1L));
   }
-  
+
   @Test
   public void testSaveNew() throws IOException, MisoNamingException {
     long autoIncrementId = nextAutoIncrementId;
@@ -444,7 +443,7 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     assertNotNull(dao.get(autoIncrementId));
     nextAutoIncrementId++;
   }
-  
+
   @Test
   public void testSaveEdit() throws IOException, MisoNamingException {
     Pool<?> oldPool = dao.get(1L);
@@ -458,7 +457,7 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     user.setUserId(1L);
     oldPool.setLastModifier(user);
     Mockito.when(namingScheme.validateField(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
-    
+
     assertEquals(1L, dao.save(oldPool));
     Pool<?> newPool = dao.get(1L);
     assertNotNull(newPool);


### PR DESCRIPTION
Rather than trying to guess (usually wrongly), it searches for the string as
provided and, if that yeilds nothing, searches using a base64-decoded string.
This removes all attempts to do base64 decoding in JavaScript.