### PR TITLE
Avoid all HTML special characters in field names

### DIFF
--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -232,7 +232,7 @@ Utils.fileUpload = {
 Utils.validation = {
   dateRegex: '^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[012])\/(19|20)[0-9]{2}$',
   dateTimeRegex: '^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[012])\/(19|20)[0-9]{2} ([01][0-9]|2[0-3]):[0-5][0-9]$',
-  sanitizeRegex: '[^<>\'\/]+',
+  sanitizeRegex: '[^<>\'\"\/&]+',
   unicodeWordRegex: '^[\\p{L}0-9_\\^\\-\\.\\s]+$',
   _unicodeWord: XRegExp('^[\\p{L}0-9_\\^\\-\\.\\s]+$'),
 


### PR DESCRIPTION
In the original ticket, it was requested to do the encoding. Since we have so many encoding mechanism (JSON, JSON containing HTML, and HTML written by JSPs), getting encoding and decoding HTML special characters consistently right is going to be very difficult and error-prone. I've opted for the lazy approach of just banning them in Parsley.