### PR TITLE
GLT-278 add runs to containers page & GLT-590 new run NPE

### DIFF
--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditRunController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditRunController.java
@@ -299,6 +299,12 @@ public class EditRunController {
               MisoWebUtils.generateErrorDivMessage("Cannot retrieve status XML for the given run: " + run.getAlias(), e.getMessage()));
           log.error("transform XML status", e);
         }
+        if (run.getSequencerReference() != null) {
+          model.put("sequencingParameters",
+              sequencingParametersService.getForPlatform((long) run.getSequencerReference().getPlatform().getPlatformId()));
+        } else {
+          model.put("sequencingParameters", Collections.emptyList());
+        }
       }
 
       model.put("formObj", run);
@@ -306,8 +312,6 @@ public class EditRunController {
       model.put("owners", LimsSecurityUtils.getPotentialOwners(user, run, securityManager.listAllUsers()));
       model.put("accessibleUsers", LimsSecurityUtils.getAccessibleUsers(user, run, securityManager.listAllUsers()));
       model.put("accessibleGroups", LimsSecurityUtils.getAccessibleGroups(user, run, securityManager.listAllGroups()));
-      model.put("sequencingParameters",
-          sequencingParametersService.getForPlatform((long) run.getSequencerReference().getPlatform().getPlatformId()));
 
       Map<Long, String> runMap = new HashMap<Long, String>();
       if (run.getWatchers().contains(user)) {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSequencerPartitionContainerController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSequencerPartitionContainerController.java
@@ -118,6 +118,7 @@ public class EditSequencerPartitionContainerController {
 
       model.put("formObj", container);
       model.put("container", container);
+      model.put("containerRuns", requestManager.listRunsBySequencerPartitionContainerId(container.getId()));
       return new ModelAndView("/pages/editSequencerPartitionContainer.jsp", model);
     } catch (IOException ex) {
       if (log.isDebugEnabled()) {

--- a/miso-web/src/main/webapp/pages/editSequencerPartitionContainer.jsp
+++ b/miso-web/src/main/webapp/pages/editSequencerPartitionContainer.jsp
@@ -28,6 +28,7 @@
   Time: 12:07
  --%>
 <%@ include file="../header.jsp" %>
+<script src="<c:url value='/scripts/jquery/datatables/js/jquery.dataTables.min.js'/>" type="text/javascript"></script>
 <script src="<c:url value='/scripts/parsley/parsley.min.js'/>" type="text/javascript"></script>
 <!--  sequencer_partition_container_ajax.js is already included in header -->
 
@@ -318,32 +319,89 @@
 <script type="text/javascript">
   jQuery(document).ready(function () {
     // Attach Parsley form validator
-    Validate.attachParsley('#container-form');
-  })
+    if (document.getElementById('container-form')) {
+      Validate.attachParsley('#container-form');
+    }
+  });
 </script>
 
-<c:if test="${not empty container.changeLog}">
-  <br/>
-  <h1>Changes</h1>
-  <span style="clear:both">
-    <table class="list" id="changelog_table">
-      <thead>
-      <tr>
-        <th>Summary</th>
-        <th>Time</th>
-      </tr>
-      </thead>
-      <tbody>
-      <c:forEach items="${container.changeLog}" var="change">
-        <tr onMouseOver="this.className='highlightrow'" onMouseOut="this.className='normalrow'">
-          <td><b>${change.summary}</b></td>
-          <td>${change.time}</td>
+<c:if test="${not empty containerRuns}">
+  <div>
+    <h1>${fn:length(containerRuns)} Runs</h1>
+    <span class="clear">
+      <table class="list" id="run_table">
+        <thead>
+        <tr>
+          <th>Run Name</th>
+          <th>Run Alias</th>
+          <th>Status</th>
+          <sec:authorize access="hasRole('ROLE_ADMIN')">
+          <th class="fit">DELETE</th>
+          </sec:authorize>
         </tr>
-      </c:forEach>
-      </tbody>
-    </table>
-  </span>
+        </thead>
+        <tbody>
+        <c:forEach items="${containerRuns}" var="run" varStatus="runCount">
+          <tr runId="${run.id}" onMouseOver="this.className='highlightrow'" onMouseOut="this.className='normalrow'">
+            <td><b><a href='<c:url value="/miso/run/${run.id}"/>'>${run.name}</a></b></td>
+            <td><a href='<c:url value="/miso/run/${run.id}"/>'>${run.alias}</a></td>
+            <td>${run.status.health}</td>
+            <sec:authorize access="hasRole('ROLE_ADMIN')">
+            <td class="misoicon" onclick="Run.deleteRun(${run.id}, Utils.page.pageReload);">
+              <span class="ui-icon ui-icon-trash"/>
+            </td>
+            </sec:authorize>
+          </tr>
+        </c:forEach>
+        </tbody>
+      </table>
+    </span>
+  </div>
+  <script type="text/javascript">
+    jQuery(document).ready(function () {
+      jQuery('#run_table').dataTable({
+        "aaSorting": [
+          [0, 'asc'],
+          [1, 'asc']
+        ],
+        "aoColumns": [
+          null,
+          null,
+          null
+          <sec:authorize access="hasRole('ROLE_ADMIN')">, null</sec:authorize>
+        ],
+        "iDisplayLength": 50,
+        "bJQueryUI": true,
+        "bRetrieve": true
+      });
+    });
+  </script>
 </c:if>
+
+<c:if test="${not empty container.changeLog}">
+  <div>
+	  <h1>Changes</h1>
+	  <span class="clear">
+	    <table class="list" id="changelog_table">
+	      <thead>
+	      <tr>
+	        <th>Summary</th>
+	        <th>Time</th>
+	      </tr>
+	      </thead>
+	      <tbody>
+	      <c:forEach items="${container.changeLog}" var="change">
+	        <tr onMouseOver="this.className='highlightrow'" onMouseOut="this.className='normalrow'">
+	          <td><b>${change.summary}</b></td>
+	          <td>${change.time}</td>
+	        </tr>
+	      </c:forEach>
+	      </tbody>
+	    </table>
+	  </span>
+  </div>
+</c:if>
+
 </div>
 </div>
 
@@ -361,5 +419,4 @@
 </script>
 
 <%@ include file="adminsub.jsp" %>
-
 <%@ include file="../footer.jsp" %>

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunDAO.java
@@ -448,8 +448,10 @@ public class SQLRunDAO implements RunStore {
         params.addValue("status_statusId", statusId);
         params.addValue("sequencerReference_sequencerReferenceId", run.getSequencerReference().getId());
         params.addValue("lastModifier", run.getLastModifier().getUserId());
-        params.addValue("sequencingParameters_parametersId", run.getSequencingParametersId());
-
+        if (run.getSequencingParametersId() != null) {
+          params.addValue("sequencingParameters_parametersId", run.getSequencingParametersId());
+        }
+        
         if (run.getId() == AbstractRun.UNSAVED_ID) {
           SimpleJdbcInsert insert = new SimpleJdbcInsert(template).withTableName(TABLE_NAME).usingGeneratedKeyColumns("runId");
           try {


### PR DESCRIPTION
On the Partition Containers page: displays a table of the runs associated with the container
- adds sequencing parameters to the view/edit run page only if the run already has an associated sequencer reference (ie. not on create, as that was causing a NPE -- GLT-590)
- also adds a check for container form existence before attaching a Parsley validator to the form (the form is only available on the create page)