### PR TITLE
Proper success/error message display in all saves

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
@@ -507,7 +507,6 @@ public abstract class AbstractLibrary extends AbstractBoxable implements Library
     sb.append(getAlias());
     sb.append(" : ");
     sb.append(getDescription());
-    sb.append(" : ");
     return sb.toString();
   }
 

--- a/miso-web/src/main/webapp/scripts/library_hot.js
+++ b/miso-web/src/main/webapp/scripts/library_hot.js
@@ -658,8 +658,9 @@ Library.hot = {
         // send it through the parser to get a sampleData array that isn't merely a reference to Library.hot.hotTable.getSourceData()
         libsData = JSON.parse(JSON.parse(JSON.stringify(Library.hot.hotTable.getSourceData())));
           
-        Library.hot.messages.success = libsData.filter(function (lib) { return (lib.saved === true); })
-                                               .map(function (lib) { return lib.alias; });
+        // add aliases of previously-saved items to the position corresponding to their row (zero-index data, one-index UI)
+        // aliases of successfully-saved items will be added after save
+        Library.hot.messages.success = libsData.map(function (lib) { return (lib.saved === true ? lib.alias : null); });
     
         // Array of save functions, one for each line in the table
         var libsSaveArray = Library.hot.getArrayOfNewObjects(libsData);
@@ -680,8 +681,10 @@ Library.hot = {
         // send it through the parser to get a sampleData array that isn't merely a reference to Library.hot.hotTable.getSourceData()
         libsData = JSON.parse(JSON.parse(JSON.stringify(Library.hot.hotTable.getSourceData())));
         
-        Library.hot.messages.success = libsData.filter(function (lib) { return (lib.saved === true); })
-                                               .map(function (lib) { return lib.alias; });
+        
+        // add aliases of previously-saved items to the position corresponding to their row (zero-index data, one-index UI)
+        // aliases of successfully-saved items will be added after save
+        Library.hot.messages.success = libsData.map(function (lib) { return (lib.saved === true ? lib.alias : null); });
         
         // Array of save functions, one for each line in the table
         var libsSaveArray = Library.hot.getArrayOfUpdatedObjects(libsData);

--- a/miso-web/src/main/webapp/scripts/sample_hot.js
+++ b/miso-web/src/main/webapp/scripts/sample_hot.js
@@ -1285,6 +1285,10 @@ Sample.hot = {
         // send it through the parser to get a sampleData array that isn't merely a reference to Sample.hot.hotTable.getSourceData()
         var sampleData = JSON.parse(JSON.parse(JSON.stringify(Sample.hot.hotTable.getSourceData())));
         
+        // add aliases of previously-saved items to the position corresponding to their row (zero-index data, one-index UI)
+        // aliases of successfully-saved items will be added after save
+        Sample.hot.messages.success = sampleData.map(function (sam) { return (sam.saved === true ? sam.alias : null); });
+        
         var samplesArray = Sample.hot.getArrayOfNewObjects(sampleData);
         
         Fluxion.doAjax(
@@ -1342,9 +1346,9 @@ Sample.hot = {
         // send data through the parser to get a sampleData array that isn't merely a reference to Sample.hot.hotTable.getSourceData()
         var sampleData = JSON.parse(JSON.parse(JSON.stringify(Sample.hot.hotTable.getSourceData())));
         
-        // add previously-saved aliases to success message
-        Sample.hot.messages.success = sampleData.filter(function (sample) { return (sample.saved === true); })
-                                                .map(function (sample) { return sample.alias; });
+        // add aliases of previously-saved items to the position corresponding to their row (zero-index data, one-index UI)
+        // aliases of successfully-saved items will be added after save
+        Sample.hot.messages.success = sampleData.map(function (sample) { return (sample.saved === true ? sample.alias : null); });
         
         // Array of save functions, one for each line in the table
         var sampleSaveArray = Sample.hot.getArrayOfUpdatedObjects(sampleData);
@@ -1371,10 +1375,10 @@ Sample.hot = {
     }
     
     Sample.hot.hotTable.validateCells(function (isValid) {
-      if (isValid) {        
-        
-        Sample.hot.messages.success = sampleData.filter(function (sample) { return (sample.saved === true); })
-                                                .map(function (sample) { return sample.alias; });
+      if (isValid) {      
+        // add aliases of previously-saved items to the position corresponding to their row (zero-index data, one-index UI)
+        // aliases of successfully-saved items will be added after save
+        Sample.hot.messages.success = sampleData.map(function (sample) { return (sample.saved === true ? sample.alias : null); });
         
         // Array of save functions, one for each line in the table
         var sampleSaveArray = Sample.hot.getArrayOfNewObjects(sampleData);


### PR DESCRIPTION
Follows up on work in PR #216 and expands the correct save method to all saves/propagates in samples & libraries.