### PR TITLE
GLT-704 update library design

### DIFF
--- a/sqlstore/src/main/resources/db/migration/V0025__lib_design_update.sql
+++ b/sqlstore/src/main/resources/db/migration/V0025__lib_design_update.sql
@@ -1,0 +1,1 @@
+ALTER TABLE LibraryDesign CHANGE `suffix` `suffix` VARCHAR(255) NOT NULL DEFAULT '';


### PR DESCRIPTION
'text' field cannot have default items, but varchar field can.