### PR TITLE
GLT-704 Fix bad migration

### DIFF
--- a/sqlstore/src/main/resources/db/migration/V0022__library_design.sql
+++ b/sqlstore/src/main/resources/db/migration/V0022__library_design.sql
@@ -8,7 +8,7 @@ ALTER TABLE LibraryDesign ADD CONSTRAINT `LibraryDesign_librarySelectionType_fke
 ALTER TABLE LibraryDesign DROP FOREIGN KEY `FK_lpr_strategytype`;
 ALTER TABLE LibraryDesign CHANGE `libraryStrategyType` `libraryStrategyType` bigint(20) NOT NULL;
 ALTER TABLE LibraryDesign ADD CONSTRAINT `LibraryDesign_libraryStrategyType_fkey` FOREIGN KEY (libraryStrategyType) REFERENCES LibraryStrategyType (libraryStrategyTypeId);
-ALTER TABLE LibraryDesign ADD COLUMN `suffix` text NOT NULL DEFAULT '';
+ALTER TABLE LibraryDesign ADD COLUMN `suffix` VARCHAR(5) NOT NULL DEFAULT '';
 
 ALTER TABLE LibraryAdditionalInfo ADD COLUMN libraryDesign bigint(20) DEFAULT NULL;
 ALTER TABLE LibraryAdditionalInfo ADD CONSTRAINT `LibraryAdditionalInfo_libraryDesign_fkey` FOREIGN KEY (libraryDesign) REFERENCES LibraryDesign (libraryDesignId);


### PR DESCRIPTION
V0022 failed because `text`-type columns cannot have defaults. Since this was a recent commit, we've agreed to update the migration itself, manually do the changes required to fix our db: 
- compile with the commit below
- `DROP TABLE LibraryDesign`
- re-run the `CREATE TABLE LibraryPropagationRule` from [V0010](https://github.com/oicr-gsi/miso-lims/commit/4bcfd21f3480f89e8470e691cac62b29f79b13ea#diff-eeebc84bf2b2309ec4e54271f1cd2b65R334)
- run `flyway:repair` on the database, which will roll it back to V0021
- run migrations as usual

This way, we fix our db once and nobody in the future will have to fix this failed migration.