### PR TITLE
GLT-700 use Group ID and Group Description as text fields

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/LibraryAdditionalInfo.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/LibraryAdditionalInfo.java
@@ -24,9 +24,13 @@ public interface LibraryAdditionalInfo {
 
   void setTissueType(TissueType tissueType);
 
-  SampleGroupId getSampleGroupId();
+  Long getGroupId();
 
-  void setSampleGroupId(SampleGroupId sampleGroupId);
+  void setGroupId(Long groupId);
+
+  String getGroupDescription();
+
+  void setGroupDescription(String groupDescription);
 
   KitDescriptor getPrepKit();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAnalyte.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/SampleAnalyte.java
@@ -27,9 +27,29 @@ public interface SampleAnalyte {
 
   void setSamplePurpose(SamplePurpose samplePurpose);
 
-  SampleGroupId getSampleGroup();
+  /**
+   * Gets the Group ID string of this sample analyte.
+   * @return Long groupId
+   */
+  Long getGroupId();
 
-  void setSampleGroup(SampleGroupId sampleGroup);
+  /**
+   * Sets the Group ID string of this sample analyte.
+   * @param Long groupId
+   */
+  void setGroupId(Long groupId);
+
+  /**
+   * Gets the Group Description string of this sample analyte.
+   * @return String groupDescription
+   */
+  String getGroupDescription();
+
+  /**
+   * Sets the Group Description string of this sample analyte.
+   * @param String groupDescription
+   */
+  void setGroupDescription(String groupDescription);
 
   TissueMaterial getTissueMaterial();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryAdditionalInfoImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryAdditionalInfoImpl.java
@@ -41,9 +41,8 @@ public class LibraryAdditionalInfoImpl implements LibraryAdditionalInfo {
   @JoinColumn(name = "tissueTypeId", nullable = false)
   private TissueType tissueType;
 
-  @OneToOne(targetEntity = SampleGroupImpl.class)
-  @JoinColumn(name = "sampleGroupId", nullable = true)
-  private SampleGroupId sampleGroupId;
+  private Long groupId;
+  private String groupDescription;
 
   private Long kitDescriptorId;
 
@@ -112,13 +111,23 @@ public class LibraryAdditionalInfoImpl implements LibraryAdditionalInfo {
   }
 
   @Override
-  public SampleGroupId getSampleGroupId() {
-    return sampleGroupId;
+  public Long getGroupId() {
+    return groupId;
   }
 
   @Override
-  public void setSampleGroupId(SampleGroupId sampleGroupId) {
-    this.sampleGroupId = sampleGroupId;
+  public void setGroupId(Long groupId) {
+    this.groupId = groupId;
+  }
+
+  @Override
+  public String getGroupDescription() {
+    return groupDescription;
+  }
+
+  @Override
+  public void setGroupDescription(String groupDescription) {
+    this.groupDescription = groupDescription;
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAnalyteImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAnalyteImpl.java
@@ -36,9 +36,8 @@ public class SampleAnalyteImpl implements SampleAnalyte {
   @JoinColumn(name = "samplePurposeId")
   private SamplePurpose samplePurpose;
 
-  @OneToOne(targetEntity = SampleGroupImpl.class)
-  @JoinColumn(name = "sampleGroupId")
-  private SampleGroupId sampleGroup;
+  private Long groupId;
+  private String groupDescription;
 
   @OneToOne(targetEntity = TissueMaterialImpl.class)
   @JoinColumn(name = "tissueMaterialId")
@@ -95,13 +94,23 @@ public class SampleAnalyteImpl implements SampleAnalyte {
   }
 
   @Override
-  public SampleGroupId getSampleGroup() {
-    return sampleGroup;
+  public Long getGroupId() {
+    return groupId;
   }
 
   @Override
-  public void setSampleGroup(SampleGroupId sampleGroup) {
-    this.sampleGroup = sampleGroup;
+  public void setGroupId(Long groupId) {
+    this.groupId = groupId;
+  }
+
+  @Override
+  public String getGroupDescription() {
+    return groupDescription;
+  }
+
+  @Override
+  public void setGroupDescription(String groupDescription) {
+    this.groupDescription = groupDescription;
   }
 
   @Override
@@ -173,17 +182,17 @@ public class SampleAnalyteImpl implements SampleAnalyte {
   public void setLastUpdated(Date lastUpdated) {
     this.lastUpdated = lastUpdated;
   }
-  
+
   @Override
   public StrStatus getStrStatus() {
     return strStatus;
   }
-  
+
   @Override
   public void setStrStatus(StrStatus strStatus) {
     this.strStatus = strStatus;
   }
-  
+
   @Override
   public void setStrStatus(String strStatus) {
     this.strStatus = StrStatus.get(strStatus);
@@ -192,7 +201,7 @@ public class SampleAnalyteImpl implements SampleAnalyte {
   @Override
   public String toString() {
     return "SampleAnalyteImpl [sampleId=" + sampleId + ", sample=" + sample
-        + ", samplePurpose=" + samplePurpose + ", sampleGroup=" + sampleGroup
+        + ", samplePurpose=" + samplePurpose + ", groupId=" + groupId + ", groupDescription=" + groupDescription
         + ", tissueMaterial=" + tissueMaterial + ", strStatus=" + strStatus
         + ", region=" + region + ", tubeId=" + tubeId + ", createdBy="
         + createdBy + ", creationDate=" + creationDate + ", updatedBy="

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -390,8 +390,11 @@ public class Dtos {
     if (from.getSamplePurpose() != null) {
       dto.setSamplePurposeId(from.getSamplePurpose().getId());
     }
-    if (from.getSampleGroup() != null) {
-      dto.setSampleGroupId(from.getSampleGroup().getId());
+    if (from.getGroupId() != null) {
+      dto.setGroupId(from.getGroupId());
+    }
+    if (from.getGroupDescription() != null) {
+      dto.setGroupDescription(from.getGroupDescription());
     }
     if (from.getTissueMaterial() != null) {
       dto.setTissueMaterialId(from.getTissueMaterial().getId());
@@ -422,9 +425,9 @@ public class Dtos {
     to.setId(from.getSampleId());
     to.setRegion(from.getRegion());
     to.setTubeId(from.getTubeId());
-    if (from.getSampleGroupId() != null) {
-      to.setSampleGroup(new SampleGroupImpl());
-      to.getSampleGroup().setId(from.getSampleGroupId());
+    if (from.getGroupId() != null) {
+      to.setGroupId(from.getGroupId());
+      to.setGroupDescription(from.getGroupDescription());
     }
     if (from.getSamplePurposeId() != null) {
       to.setSamplePurpose(new SamplePurposeImpl());
@@ -748,8 +751,11 @@ public class Dtos {
     dto.setLibraryId(from.getLibrary().getId());
     dto.setTissueOrigin(asDto(from.getTissueOrigin()));
     dto.setTissueType(asDto(from.getTissueType()));
-    if (from.getSampleGroupId() != null) {
-      dto.setSampleGroup(asDto(from.getSampleGroupId()));
+    if (from.getGroupId() != null) {
+      dto.setGroupId(from.getGroupId());
+    }
+    if (from.getGroupDescription() != null) {
+      dto.setGroupDescription(from.getGroupDescription());
     }
     if (from.getPrepKit() != null) {
       dto.setPrepKit(asDto(from.getPrepKit()));
@@ -778,8 +784,9 @@ public class Dtos {
     to.setLibraryId(from.getLibraryId());
     to.setTissueOrigin(to(from.getTissueOrigin()));
     to.setTissueType(to(from.getTissueType()));
-    if (from.getSampleGroup() != null) {
-      to.setSampleGroupId(to(from.getSampleGroup()));
+    if (from.getGroupId() != null) {
+      to.setGroupId(from.getGroupId());
+      to.setGroupDescription(from.getGroupDescription());
     }
     if (from.getPrepKit() != null) {
       to.setPrepKit(to(from.getPrepKit()));

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/LibraryAdditionalInfoDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/LibraryAdditionalInfoDto.java
@@ -11,7 +11,8 @@ public class LibraryAdditionalInfoDto {
   private String libraryUrl;
   private TissueOriginDto tissueOrigin;
   private TissueTypeDto tissueType;
-  private SampleGroupDto sampleGroup;
+  private Long groupId;
+  private String groupDescription;
   private KitDescriptorDto prepKit;
   private Long createdById;
   private String createdByUrl;
@@ -70,12 +71,20 @@ public class LibraryAdditionalInfoDto {
     this.tissueType = tissueType;
   }
 
-  public SampleGroupDto getSampleGroup() {
-    return sampleGroup;
+  public Long getGroupId() {
+    return groupId;
   }
 
-  public void setSampleGroup(SampleGroupDto sampleGroup) {
-    this.sampleGroup = sampleGroup;
+  public void setGroupId(Long groupId) {
+    this.groupId = groupId;
+  }
+
+  public String getGroupDescription() {
+    return groupDescription;
+  }
+
+  public void setGroupDescription(String groupDescription) {
+    this.groupDescription = groupDescription;
   }
 
   public Long getCreatedById() {
@@ -153,7 +162,7 @@ public class LibraryAdditionalInfoDto {
   @Override
   public String toString() {
     return "LibraryAdditionalInfoDto [id=" + id + ", url=" + url + ", libraryId=" + libraryId + ", libraryUrl=" + libraryUrl
-        + ", tissueOrigin=" + tissueOrigin + ", tissueType=" + tissueType + ", sampleGroup=" + sampleGroup + ", prepKit=" + prepKit
+        + ", tissueOrigin=" + tissueOrigin + ", tissueType=" + tissueType + ", groupId=" + groupId + ", groupDescription=" + groupDescription + ", prepKit=" + prepKit
         + ", createdById=" + createdById + ", createdByUrl=" + createdByUrl + ", creationDate=" + creationDate + ", updatedById="
         + updatedById + ", updatedByUrl=" + updatedByUrl + ", lastUpdated=" + lastUpdated + ", archived=" + archived + ", libraryDesignId="
         + libraryDesignId + "]";

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAnalyteDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleAnalyteDto.java
@@ -10,8 +10,8 @@ public class SampleAnalyteDto {
   private String sampleUrl;
   private Long samplePurposeId;
   private String samplePurposeUrl;
-  private Long sampleGroupId;
-  private String sampleGroupUrl;
+  private Long groupId;
+  private String groupDescription;
   private Long tissueMaterialId;
   private String tissueMaterialUrl;
 
@@ -114,20 +114,20 @@ public class SampleAnalyteDto {
     this.samplePurposeUrl = samplePurposeUrl;
   }
 
-  public Long getSampleGroupId() {
-    return sampleGroupId;
+  public Long getGroupId() {
+    return groupId;
   }
 
-  public void setSampleGroupId(Long sampleGroupId) {
-    this.sampleGroupId = sampleGroupId;
+  public void setGroupId(Long groupId) {
+    this.groupId = groupId;
   }
 
-  public String getSampleGroupUrl() {
-    return sampleGroupUrl;
+  public String getGroupDescription() {
+    return groupDescription;
   }
 
-  public void setSampleGroupUrl(String sampleGroupUrl) {
-    this.sampleGroupUrl = sampleGroupUrl;
+  public void setGroupDescription(String groupDescription) {
+    this.groupDescription = groupDescription;
   }
 
   public String getTissueMaterialUrl() {

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLibraryAdditionalInfoService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLibraryAdditionalInfoService.java
@@ -41,9 +41,6 @@ public class DefaultLibraryAdditionalInfoService implements LibraryAdditionalInf
   private TissueTypeDao tissueTypeDao;
   
   @Autowired
-  private SampleGroupDao sampleGroupDao;
-  
-  @Autowired
   private KitStore kitStore;
   
   @Autowired
@@ -62,11 +59,12 @@ public class DefaultLibraryAdditionalInfoService implements LibraryAdditionalInf
     libraryAdditionalInfo.setLibrary(libraryStore.get(libraryId));
     libraryAdditionalInfo.setTissueOrigin(tissueOriginDao.getTissueOrigin(libraryAdditionalInfo.getTissueOrigin().getId()));
     libraryAdditionalInfo.setTissueType(tissueTypeDao.getTissueType(libraryAdditionalInfo.getTissueType().getId()));
-    if (libraryAdditionalInfo.getSampleGroupId() != null) {
-      libraryAdditionalInfo.setSampleGroupId(sampleGroupDao.getSampleGroup(libraryAdditionalInfo.getSampleGroupId().getId()));
-    }
     if (libraryAdditionalInfo.getPrepKit() != null) {
       libraryAdditionalInfo.setPrepKit(kitStore.getKitDescriptorById(libraryAdditionalInfo.getPrepKit().getId()));
+    }
+    if (libraryAdditionalInfo.getLibrary().getSample().getSampleAnalyte().getGroupId() != null) {
+      libraryAdditionalInfo.setGroupId(libraryAdditionalInfo.getLibrary().getSample().getSampleAnalyte().getGroupId());
+      libraryAdditionalInfo.setGroupDescription(libraryAdditionalInfo.getLibrary().getSample().getSampleAnalyte().getGroupDescription());
     }
     User user = authorizationManager.getCurrentUser();
     libraryAdditionalInfo.setCreatedBy(user);
@@ -81,9 +79,8 @@ public class DefaultLibraryAdditionalInfoService implements LibraryAdditionalInf
     LibraryAdditionalInfo updated = get(libraryAdditionalInfo.getLibraryId());
     updated.setTissueOrigin(tissueOriginDao.getTissueOrigin(libraryAdditionalInfo.getTissueOrigin().getId()));
     updated.setTissueType(tissueTypeDao.getTissueType(libraryAdditionalInfo.getTissueType().getId()));
-    if (libraryAdditionalInfo.getSampleGroupId() != null) {
-      updated.setSampleGroupId(sampleGroupDao.getSampleGroup(libraryAdditionalInfo.getSampleGroupId().getId()));
-    }
+    updated.setGroupId(libraryAdditionalInfo.getGroupId());
+    updated.setGroupDescription(libraryAdditionalInfo.getGroupDescription());
     if (libraryAdditionalInfo.getPrepKit() != null) {
       updated.setPrepKit(kitStore.getKitDescriptorById(libraryAdditionalInfo.getPrepKit().getId()));
     }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleAnalyteService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleAnalyteService.java
@@ -45,9 +45,6 @@ public class DefaultSampleAnalyteService implements SampleAnalyteService {
   private SamplePurposeDao samplePurposeDao;
 
   @Autowired
-  private SampleGroupDao sampleGroupDao;
-
-  @Autowired
   private TissueMaterialDao tissueMaterialDao;
 
   @Autowired
@@ -86,9 +83,6 @@ public class DefaultSampleAnalyteService implements SampleAnalyteService {
     if (sampleAnalyteDto.getSamplePurposeId() != null) {
       sampleAnalyte.setSamplePurpose(samplePurposeDao.getSamplePurpose(sampleAnalyteDto.getSamplePurposeId()));
     }
-    if (sampleAnalyteDto.getSampleGroupId() != null) {
-      sampleAnalyte.setSampleGroup(sampleGroupDao.getSampleGroup(sampleAnalyteDto.getSampleGroupId()));
-    }
     if (sampleAnalyteDto.getTissueMaterialId() != null) {
       sampleAnalyte.setTissueMaterial(tissueMaterialDao.getTissueMaterial(sampleAnalyteDto.getTissueMaterialId()));
     }
@@ -113,11 +107,6 @@ public class DefaultSampleAnalyteService implements SampleAnalyteService {
       SamplePurpose samplePurpose = samplePurposeDao.getSamplePurpose(sampleAnalyteDto.getSamplePurposeId());
       ServiceUtils.throwIfNull(samplePurpose, "SampleAnalyte.samplePurposeId", sampleAnalyteDto.getSamplePurposeId());
       sampleAnalyte.setSamplePurpose(samplePurpose);
-    }
-    if (sampleAnalyteDto.getSampleGroupId() != null) {
-      SampleGroupId sampleGroup = sampleGroupDao.getSampleGroup(sampleAnalyteDto.getSampleGroupId());
-      ServiceUtils.throwIfNull(sampleGroup, "SampleAnalyte.sampleGroupId", sampleAnalyteDto.getSampleGroupId());
-      sampleAnalyte.setSampleGroup(sampleGroup);
     }
     if (sampleAnalyteDto.getTissueMaterialId() != null) {
       TissueMaterial tissueMaterial = tissueMaterialDao.getTissueMaterial(sampleAnalyteDto.getTissueMaterialId());
@@ -144,6 +133,8 @@ public class DefaultSampleAnalyteService implements SampleAnalyteService {
     target.setRegion(source.getRegion());
     target.setTubeId(source.getTubeId());
     target.setStrStatus(source.getStrStatus());
+    target.setGroupId(source.getGroupId());
+    target.setGroupDescription(source.getGroupDescription());
     loadMembers(target, source);
   }
 
@@ -168,9 +159,6 @@ public class DefaultSampleAnalyteService implements SampleAnalyteService {
   @Override
   public void loadMembers(SampleAnalyte target, SampleAnalyte source)
       throws IOException {
-    if (source.getSampleGroup() != null) {
-      target.setSampleGroup(sampleGroupDao.getSampleGroup(source.getSampleGroup().getId()));
-    }
     if (source.getSamplePurpose() != null) {
       target.setSamplePurpose(samplePurposeDao.getSamplePurpose(source.getSamplePurpose().getId()));
     }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
@@ -348,9 +348,6 @@ public class DefaultSampleService implements SampleService {
         if (sa.getSamplePurpose() != null && sa.getSamplePurpose().getId() != null) {
           sa.setSamplePurpose(samplePurposeDao.getSamplePurpose(sa.getSamplePurpose().getId()));
         }
-        if (sa.getSampleGroup() != null && sa.getSampleGroup().getId() != null) {
-          sa.setSampleGroup(sampleGroupDao.getSampleGroup(sa.getSampleGroup().getId()));
-        }
         if (sa.getTissueMaterial() != null && sa.getTissueMaterial().getId() != null) {
           sa.setTissueMaterial(tissueMaterialDao.getTissueMaterial(sa.getTissueMaterial().getId()));
         }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryAdditionalInfoController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryAdditionalInfoController.java
@@ -90,10 +90,6 @@ public class LibraryAdditionalInfoController extends RestController {
         .buildAndExpand(libraryAdditionalInfoDto.getTissueOrigin().getId()).toUriString());
     libraryAdditionalInfoDto.getTissueType().setUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/tissuetype/{id}")
         .buildAndExpand(libraryAdditionalInfoDto.getTissueType().getId()).toUriString());
-    if (libraryAdditionalInfoDto.getSampleGroup() != null) {
-      libraryAdditionalInfoDto.getSampleGroup().setUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/samplegroup/{id}")
-          .buildAndExpand(libraryAdditionalInfoDto.getSampleGroup().getId()).toUriString());
-    }
     if (libraryAdditionalInfoDto.getPrepKit() != null && libraryAdditionalInfoDto.getPrepKit().getId() != null) {
       libraryAdditionalInfoDto.getPrepKit().setUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/kitdescriptor/{id}")
           .buildAndExpand(libraryAdditionalInfoDto.getPrepKit().getId()).toUriString());

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleAnalyteController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleAnalyteController.java
@@ -89,10 +89,6 @@ public class SampleAnalyteController extends RestController {
       sampleAnalyteDto.setSamplePurposeUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/samplepurpose/{id}")
           .buildAndExpand(sampleAnalyteDto.getSamplePurposeId()).toUriString());
     }
-    if (sampleAnalyteDto.getSampleGroupId() != null) {
-      sampleAnalyteDto.setSampleGroupUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/samplegroup/{id}")
-          .buildAndExpand(sampleAnalyteDto.getSampleGroupId()).toUriString());
-    }
     if (sampleAnalyteDto.getTissueMaterialId() != null) {
       sampleAnalyteDto.setTissueMaterialUrl(UriComponentsBuilder.fromUri(baseUri).path("/rest/tissuematerial/{id}")
           .buildAndExpand(sampleAnalyteDto.getTissueMaterialId()).toUriString());

--- a/miso-web/src/main/webapp/pages/editLibrary.jsp
+++ b/miso-web/src/main/webapp/pages/editLibrary.jsp
@@ -436,10 +436,63 @@
   <td>Emptied:</td>
   <td><form:checkbox id="empty" path="empty"/></td>
 </tr>
+</table>
+
+<c:if test="${detailedSample}">
+<br/>
+<br/>
+<h2>Details</h2>
+<br/>
+<table class="in">
+<c:choose>
+<c:when test="${library.id == 0}">
+  <tr>
+    <td class="h">Tissue Origin:</td>
+    <td>${library.sample.sampleAdditionalInfo.tissueOrigin.alias}</td>
+  </tr>
+  <tr>
+    <td class="h">Tissue Type:</td>
+    <td>${library.sample.sampleAdditionalInfo.tissueType.alias}</td>
+  </tr>
+  <c:if test="${not empty library.sample.sampleAnalyte.groupId}">
+  <tr>
+    <td class="h">Group ID:</td>
+    <td>${library.sample.sampleAnalyte.groupId}</td>
+  </tr>
+  <tr>
+    <td class="h">Group Description:</td>
+    <td>${library.sample.sampleAnalyte.groupDescription}</td>
+  </tr>
+  </c:if>
+</c:when>
+<c:otherwise>
+  <tr>
+    <td class="h">Tissue Origin:</td>
+    <td>${library.libraryAdditionalInfo.tissueOrigin.alias}</td>
+  </tr>
+  <tr>
+    <td class="h">Tissue Type:</td>
+    <td>${library.libraryAdditionalInfo.tissueType.alias}</td>
+  </tr>
+  <c:if test="${not empty library.libraryAdditionalInfo.groupId}">
+  <tr>
+    <td class="h">Group ID:</td>
+    <td>${library.libraryAdditionalInfo.groupId}</td>
+  </tr>
+  <tr>
+    <td class="h">Group Description:</td>
+    <td>${library.libraryAdditionalInfo.groupDescription}</td>
+  </tr>
+  </c:if>
+</c:otherwise>
+</c:choose>
+</table>
+</c:if>
 
 <c:choose>
   <c:when
       test="${!empty library.sample and library.securityProfile.profileId eq library.sample.project.securityProfile.profileId}">
+    <table class="in">
     <tr>
       <td>Permissions</td>
       <td><i>Inherited from sample </i>
@@ -451,7 +504,6 @@
     </table>
   </c:when>
   <c:otherwise>
-    </table>
     <%@ include file="permissions.jsp" %>
   </c:otherwise>
 </c:choose>

--- a/miso-web/src/main/webapp/pages/editSample.jsp
+++ b/miso-web/src/main/webapp/pages/editSample.jsp
@@ -514,21 +514,13 @@
             <tr>
               <td class="h">Group ID:</td>
               <td>
-                <c:choose>
-                  <c:when test="${sample.id == 0}">
-                    <form:select id="sampleGroup" path="sampleAnalyte.sampleGroup">
-                      <%-- list filtered and filled by js --%>
-                      <script type="text/javascript">
-                        jQuery(document).ready(function () {
-                          Sample.ui.filterSampleGroupOptions();
-                        });
-                      </script>
-                    </form:select>
-                  </c:when>
-                  <c:otherwise>
-                    ${!empty sample.sampleAnalyte.sampleGroup ? sample.sampleAnalyte.sampleGroup.groupId : 'n/a'}
-                  </c:otherwise>
-                </c:choose>
+                <form:input id="groupId" path="sampleAnalyte.groupId"/>
+              </td>
+            </tr>
+            <tr>
+              <td class="h">Group Description:</td>
+              <td>
+                <form:input id="groupDescription" path="sampleAnalyte.groupDescription"/>
               </td>
             </tr>
             <tr>

--- a/miso-web/src/main/webapp/scripts/sample_ajax.js
+++ b/miso-web/src/main/webapp/scripts/sample_ajax.js
@@ -155,6 +155,15 @@ var Sample = Sample || {
         jQuery('#tubeId').attr('class', 'form-control');
         jQuery('#tubeId').attr('data-parsley-maxlength', '255');
         jQuery('#tubeId').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
+        
+        // Group ID validation
+        jQuery('#groupId').attr('class', 'form-control');
+        jQuery('#groupId').attr('data-parsley-type', 'integer');
+        
+        // Group Description validation
+        jQuery('#groupDescription').attr('class', 'form-control');
+        jQuery('#groupDescription').attr('data-parsley-maxlength', '255');
+        jQuery('#groupDescription').attr('data-parsley-pattern', Utils.validation.sanitizeRegex);
         break;
       }
     }

--- a/sqlstore/src/main/resources/db/migration/V0026__groupId_groupDescription.sql
+++ b/sqlstore/src/main/resources/db/migration/V0026__groupId_groupDescription.sql
@@ -1,0 +1,8 @@
+ALTER TABLE SampleAnalyte DROP FOREIGN KEY `FKmirq92ew3h3732cexgqdeyehk`;
+ALTER TABLE SampleAnalyte DROP COLUMN `sampleGroupId`;
+ALTER TABLE SampleAnalyte ADD COLUMN `groupId` INT(10) DEFAULT NULL;
+ALTER TABLE SampleAnalyte ADD COLUMN `groupDescription` VARCHAR(255) DEFAULT NULL;
+ALTER TABLE LibraryAdditionalInfo DROP FOREIGN KEY `libraryAdditionalInfo_sampleGroup_fkey`;
+ALTER TABLE LibraryAdditionalInfo DROP COLUMN `sampleGroupId`;
+ALTER TABLE LibraryAdditionalInfo ADD COLUMN `groupId` INT(10) DEFAULT NULL;
+ALTER TABLE LibraryAdditionalInfo ADD COLUMN `groupDescription` VARCHAR(255) DEFAULT NULL;


### PR DESCRIPTION
The original thought had been to control the vocabulary of Group ID and Group Description. However, this implementation would prove challenging for migration, and we will have to study the lab further in order to determine whether controlling this vocabulary would be useful.

With that in mind, this commit implements Group ID and Group Description as text fields on Sample Analyte (LibraryAdditionalInfo inherits these fields from Sample). The controlled vocabulary SampleGroup code has been commented out but left in place in case we end up making use of it later. (Thoughts on whether it should be deleted outright?)