### PR TITLE
fix sample service create method for propagation

### DIFF
--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -247,6 +247,11 @@ public class Dtos {
     dto.setLastUpdated(dateTimeFormatter.print(from.getLastUpdated().getTime()));
     dto.setExternalInstituteIdentifier(from.getExternalInstituteIdentifier());
     dto.setTubeNumber(from.getTubeNumber());
+    if (from.getParent() != null) {
+      dto.setParentId(from.getParent().getId());
+      dto.setParentAlias(from.getParent().getAlias());
+      dto.setParentSampleClassId(from.getSampleClass().getId());
+    }
     return dto;
   }
 
@@ -295,6 +300,26 @@ public class Dtos {
       SampleClass sampleClass = new SampleClassImpl();
       sampleClass.setId(from.getSampleClassId());
       to.setSampleClass(sampleClass);
+    }
+    Sample parent = null;
+    if (from.getParentId() != null) {
+      parent = new SampleImpl();
+      parent.setId(from.getParentId());
+    }
+    if (from.getParentAlias() != null) {
+      if (parent == null) parent = new SampleImpl();
+      parent.setAlias(from.getParentAlias());
+    }
+    if (from.getParentSampleClassId() != null) {
+      if (parent == null) {
+        parent = new SampleImpl();
+        parent.setSampleAdditionalInfo(new SampleAdditionalInfoImpl());
+        parent.getSampleAdditionalInfo().setSampleClass(new SampleClassImpl());
+        parent.getSampleAdditionalInfo().getSampleClass().setId(from.getParentSampleClassId());
+      }
+    }
+    if (parent != null) {
+      to.setParent(parent);
     }
     return to;
   }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
@@ -87,7 +87,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleAnalyte.StrStatus;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
-import uk.ac.bbsrc.tgac.miso.core.data.SampleGroupId;
 import uk.ac.bbsrc.tgac.miso.core.data.SamplePurpose;
 import uk.ac.bbsrc.tgac.miso.core.data.Subproject;
 import uk.ac.bbsrc.tgac.miso.core.data.TissueMaterial;
@@ -101,7 +100,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.QcPassedDetailImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAdditionalInfoImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAnalyteImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleClassImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleGroupImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SamplePurposeImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleTissueImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SubprojectImpl;
@@ -603,19 +601,6 @@ public class EditSampleController {
       }
     });
     
-    binder.registerCustomEditor(SampleGroupId.class, "sampleAnalyte.sampleGroup", new PropertyEditorSupport() {
-      @Override
-      public void setAsText(String text) throws IllegalArgumentException {
-        if (isStringEmptyOrNull(text)) {
-          setValue(null);
-        } else {
-          SampleGroupId sg = new SampleGroupImpl();
-          sg.setId(Long.valueOf(text));
-          setValue(sg);
-        }
-      }
-    });
-    
     binder.registerCustomEditor(SamplePurpose.class, "sampleAnalyte.samplePurpose", new PropertyEditorSupport() {
       @Override
       public void setAsText(String text) throws IllegalArgumentException {
@@ -639,6 +624,13 @@ public class EditSampleController {
           tm.setId(Long.valueOf(text));
           setValue(tm);
         }
+      }
+    });
+    
+    binder.registerCustomEditor(Long.class, new PropertyEditorSupport() {
+      @Override
+      public void setAsText(String text) throws IllegalArgumentException {
+        setValue(isStringEmptyOrNull(text) ? null : Long.valueOf(text));
       }
     });
   }


### PR DESCRIPTION
Makes the DefaultSampleService more flexible in how parent information is specified (may be in sample.sampleAddtionalInfo.parent or sample.identity). Also includes binding fix for sample.groupId