### PR TITLE
Switch to Metrix fork

### DIFF
--- a/notification-server/pom.xml
+++ b/notification-server/pom.xml
@@ -90,6 +90,10 @@
       <id>onejar-maven-plugin.googlecode.com</id>
       <url>http://onejar-maven-plugin.googlecode.com/svn/mavenrepo</url>
     </pluginRepository>
+    <pluginRepository>
+      <id>seqwaremaven.oicr.on.ca</id>
+      <url>http://seqwaremaven.oicr.on.ca/artifactory/seqware-dependencies</url>
+    </pluginRepository>
   </pluginRepositories>
 
   <dependencies>
@@ -165,11 +169,16 @@
       <version>1.3.146</version>
     </dependency>
     <dependency>
-      <groupId>nki</groupId>
+      <groupId>ca.on.oicr.pde</groupId>
       <artifactId>metrix</artifactId>
-      <version>1.1</version>
+      <version>1.2-2016</version>
     </dependency>
     <dependency>
+        <groupId>com.googlecode.json-simple</groupId>
+        <artifactId>json-simple</artifactId>
+        <version>1.1.1</version>
+    </dependency>
+     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/notification-server/src/main/java/uk/ac/bbsrc/tgac/miso/notification/service/IlluminaTransformer.java
+++ b/notification-server/src/main/java/uk/ac/bbsrc/tgac/miso/notification/service/IlluminaTransformer.java
@@ -658,7 +658,7 @@ public class IlluminaTransformer implements FileSetTransformer<String, String, F
 
       // Metrix fails to set current cycle, and parsing ErrorMetricsOut.bin depends on this, so set it here
       final String extractionMetricsPath = rootFile.getCanonicalPath() + "/InterOp/" + nki.constants.Constants.EXTRACTION_METRICS;
-      ExtractionMetrics eim = new ExtractionMetrics(extractionMetricsPath, 0);
+      ExtractionMetrics eim = new ExtractionMetrics(extractionMetricsPath, null);
       sum.setCurrentCycle(eim.getLastCycle());
 
       RunInfoHandler.parseAll(runInfo, sum);


### PR DESCRIPTION
The fork uses log4j and removes a mysterious `sleep` causing performance issues