### PR TITLE
Allow multiple status in pool order completions

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/PoolOrderCompletion.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/PoolOrderCompletion.java
@@ -3,6 +3,8 @@ package uk.ac.bbsrc.tgac.miso.core.data;
 import java.io.Serializable;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -10,14 +12,20 @@ import javax.persistence.Table;
 import javax.persistence.Transient;
 
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SequencingParametersImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.type.HealthType;
 
+/**
+ * Information about completion (success/failure/pending/requested) lanes. This maps over a view in the database for pool orders and run
+ * information.
+ */
 @Entity
 @Table(name = "OrderCompletion")
 public class PoolOrderCompletion implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private int completed_partitions;
-  private int desired_partitions;
+  @Enumerated(EnumType.STRING)
+  private HealthType health;
+  private int num_partitions;
   @Id
   @ManyToOne(targetEntity = SequencingParametersImpl.class)
   @JoinColumn(name = "parametersId", nullable = false)
@@ -27,12 +35,12 @@ public class PoolOrderCompletion implements Serializable {
   @Id
   private Long poolId;
 
-  public int getCompletedPartitions() {
-    return completed_partitions;
+  public HealthType getHealth() {
+    return health;
   }
 
-  public int getDesiredPartitions() {
-    return desired_partitions;
+  public int getNumPartitions() {
+    return num_partitions;
   }
 
   public Pool<?> getPool() {
@@ -43,13 +51,12 @@ public class PoolOrderCompletion implements Serializable {
     return poolId;
   }
 
-  public int getRemainingPartitions() {
-    if (desired_partitions > completed_partitions) return desired_partitions - completed_partitions;
-    return 0;
-  }
-
   public SequencingParameters getSequencingParameters() {
     return parameters;
+  }
+
+  public void setHealth(HealthType health) {
+    this.health = health;
   }
 
   public void setPool(Pool<?> pool) {

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/PoolOrderCompletionGroup.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/PoolOrderCompletionGroup.java
@@ -1,0 +1,41 @@
+package uk.ac.bbsrc.tgac.miso.core.data;
+
+import java.util.TreeMap;
+
+import uk.ac.bbsrc.tgac.miso.core.data.type.HealthType;
+
+public class PoolOrderCompletionGroup extends TreeMap<HealthType, PoolOrderCompletion> {
+
+  private static final long serialVersionUID = 1L;
+
+  public PoolOrderCompletionGroup() {
+    super(HealthType.COMPARATOR);
+  }
+
+  public int getRemaining() {
+    int remaining = 0;
+    for (PoolOrderCompletion completion : values()) {
+      remaining += completion.getNumPartitions() * completion.getHealth().getMultiplier();
+    }
+    return remaining > 0 ? remaining : 0;
+  }
+
+  public void add(PoolOrderCompletion item) {
+    put(item.getHealth(), item);
+  }
+
+  @Override
+  public PoolOrderCompletion get(Object key) {
+    if (key instanceof String) {
+      key = HealthType.get((String) key);
+    }
+    if (containsKey(key)) {
+      return super.get(key);
+    } else {
+      PoolOrderCompletion empty = new PoolOrderCompletion();
+      empty.setHealth((HealthType) key);
+      return empty;
+    }
+  }
+
+}

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StatusImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StatusImpl.java
@@ -132,7 +132,11 @@ public class StatusImpl implements Status, Serializable {
 
   @Override
   public void setHealth(HealthType health) {
-    this.health = health;
+    if (health.isAllowedFromSequencer()) {
+      this.health = health;
+    } else {
+      throw new IllegalArgumentException("Cannot set a status to " + health.getKey());
+    }
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/HealthType.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/HealthType.java
@@ -24,6 +24,7 @@
 package uk.ac.bbsrc.tgac.miso.core.data.type;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,10 +36,17 @@ import java.util.Map;
  * @since 0.0.2
  */
 public enum HealthType {
-  Unknown("Unknown"), Completed("Completed"), Failed("Failed"), Started("Started"), Stopped("Stopped"), Running("Running");
+  Unknown("Unknown", 0, true), Completed("Completed", -1, true), Failed("Failed", 0, true), Started("Started", -1, true), Stopped("Stopped",
+      -1, true), Running("Running", -1, true), Requested("Requested", 1, false);
 
-  /** Field key */
-  private String key;
+  public static final Comparator<HealthType> COMPARATOR = new Comparator<HealthType>() {
+    @Override
+    public int compare(HealthType o1, HealthType o2) {
+      int p1 = o1 == null ? -1 : o1.ordinal();
+      int p2 = o2 == null ? -1 : o2.ordinal();
+      return p1 - p2;
+    }
+  };
   /**
    * Field lookup
    */
@@ -47,16 +55,6 @@ public enum HealthType {
   static {
     for (HealthType s : EnumSet.allOf(HealthType.class))
       lookup.put(s.getKey(), s);
-  }
-
-  /**
-   * Constructs a HealthType based on a given key
-   * 
-   * @param key
-   *          of type String
-   */
-  HealthType(String key) {
-    this.key = key;
   }
 
   /**
@@ -71,15 +69,6 @@ public enum HealthType {
   }
 
   /**
-   * Returns the key of this HealthType enum.
-   * 
-   * @return String key.
-   */
-  public String getKey() {
-    return key;
-  }
-
-  /**
    * Returns the keys of this HealthType enum.
    * 
    * @return ArrayList<String> keys.
@@ -90,5 +79,46 @@ public enum HealthType {
       keys.add(h.getKey());
     }
     return keys;
+  }
+
+  /** Field key */
+  private final String key;
+
+  private final int multiplier;
+
+  private final boolean allowedFromSequencer;
+
+  /**
+   * Constructs a HealthType based on a given key
+   * 
+   * @param key
+   *          of type String
+   */
+  HealthType(String key, int multiplier, boolean allowedFromSequencer) {
+    this.key = key;
+    this.multiplier = multiplier;
+    this.allowedFromSequencer = allowedFromSequencer;
+  }
+
+  /**
+   * Returns the key of this HealthType enum.
+   * 
+   * @return String key.
+   */
+  public String getKey() {
+    return key;
+  }
+
+  public int getMultiplier() {
+    return multiplier;
+  }
+
+  /**
+   * Whether is health type may be used as a status from a sequencer.
+   * 
+   * Some health information is used for pool order completions that cannot be a state of an actual sequencer run's status.
+   */
+  public boolean isAllowedFromSequencer() {
+    return allowedFromSequencer;
   }
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/PoolOrderCompletionService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/PoolOrderCompletionService.java
@@ -9,5 +9,5 @@ import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationException;
 public interface PoolOrderCompletionService {
   public Collection<PoolOrderCompletion> getOrderCompletionForPool(long id) throws AuthorizationException, IOException;
 
-  public Collection<PoolOrderCompletion> getOutstandingOrders() throws AuthorizationException, IOException;
+  public Collection<PoolOrderCompletion> getAllOrders() throws AuthorizationException, IOException;
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderCompletionService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderCompletionService.java
@@ -38,9 +38,9 @@ public class DefaultPoolOrderCompletionService implements PoolOrderCompletionSer
   }
 
   @Override
-  public Collection<PoolOrderCompletion> getOutstandingOrders() throws AuthorizationException, IOException {
+  public Collection<PoolOrderCompletion> getAllOrders() throws AuthorizationException, IOException {
     authorizationManager.throwIfUnauthenticated();
-    return poolOrderCompletionDao.getUnfulfilled();
+    return poolOrderCompletionDao.list();
   }
 
 }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPoolController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditPoolController.java
@@ -60,6 +60,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.Dilution;
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Platform;
 import uk.ac.bbsrc.tgac.miso.core.data.Pool;
+import uk.ac.bbsrc.tgac.miso.core.data.PoolOrderCompletion;
 import uk.ac.bbsrc.tgac.miso.core.data.Poolable;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryDilution;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolImpl;
@@ -68,6 +69,7 @@ import uk.ac.bbsrc.tgac.miso.core.exception.MalformedDilutionException;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils;
+import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.dto.Dtos;
 import uk.ac.bbsrc.tgac.miso.dto.SequencingParametersDto;
 import uk.ac.bbsrc.tgac.miso.service.PoolOrderCompletionService;
@@ -227,7 +229,9 @@ public class EditPoolController {
       model.put("accessibleUsers", LimsSecurityUtils.getAccessibleUsers(user, pool, securityManager.listAllUsers()));
       model.put("accessibleGroups", LimsSecurityUtils.getAccessibleGroups(user, pool, securityManager.listAllGroups()));
       model.put("platforms", getFilteredPlatforms(pool.getPlatformType()));
-      model.put("ordercompletions", poolOrderCompletionService.getOrderCompletionForPool(poolId));
+      Collection<PoolOrderCompletion> completions = poolOrderCompletionService.getOrderCompletionForPool(poolId);
+      model.put("ordercompletionheadings", LimsUtils.getUsedHealthTypes(completions));
+      model.put("ordercompletions", LimsUtils.groupCompletions(completions).get(pool));
 
       return new ModelAndView("/pages/editPool.jsp", model);
     } catch (IOException ex) {

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ListOutstandingOrdersController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/ListOutstandingOrdersController.java
@@ -1,6 +1,9 @@
 package uk.ac.bbsrc.tgac.miso.webapp.controller;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -8,6 +11,11 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
+import uk.ac.bbsrc.tgac.miso.core.data.PoolOrderCompletionGroup;
+import uk.ac.bbsrc.tgac.miso.core.data.Pool;
+import uk.ac.bbsrc.tgac.miso.core.data.SequencingParameters;
+import uk.ac.bbsrc.tgac.miso.core.data.type.HealthType;
+import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.service.PoolOrderCompletionService;
 
 @Controller
@@ -23,7 +31,16 @@ public class ListOutstandingOrdersController {
   @RequestMapping("/poolorders/outstanding")
   public ModelAndView listPools() throws IOException {
     ModelAndView model = new ModelAndView("/pages/listPoolOrders.jsp");
-    model.addObject("ordercompletions", poolOrderCompletionService.getOutstandingOrders());
+    Map<Pool<?>, Map<SequencingParameters, PoolOrderCompletionGroup>> groups = LimsUtils
+        .filterUnfulfilledCompletions(LimsUtils.groupCompletions(poolOrderCompletionService.getAllOrders()));
+    SortedSet<HealthType> healths = new TreeSet<>(HealthType.COMPARATOR);
+    for (Map<SequencingParameters, PoolOrderCompletionGroup> parameterGroup : groups.values()) {
+      for (PoolOrderCompletionGroup completions : parameterGroup.values()) {
+        LimsUtils.addUsedHealthTypes(completions.values(), healths);
+      }
+    }
+    model.addObject("ordercompletions", groups);
+    model.addObject("ordercompletionheadings", healths);
     return model;
   }
 }

--- a/miso-web/src/main/webapp/pages/editPool.jsp
+++ b/miso-web/src/main/webapp/pages/editPool.jsp
@@ -370,19 +370,21 @@
         <tr>
           <th>Platform</th>
           <th>Parameters</th>
-          <th>Requested</th>
-          <th>Completed</th>
+          <c:forEach items="${ordercompletionheadings}" var="heading">
+            <th>${heading.key}</th>
+          </c:forEach>
           <th>Remaining</th>
         </tr>
         </thead>
         <tbody>
-        <c:forEach items="${ordercompletions}" var="completion">
+        <c:forEach items="${ordercompletions}" var="parameterGroup">
           <tr onMouseOver="this.className='highlightrow'" onMouseOut="this.className='normalrow'">
-            <td>${completion.sequencingParameters.platform.nameAndModel}</td>
-            <td>${completion.sequencingParameters.name}</td>
-            <td>${completion.desiredPartitions}</td>
-            <td>${completion.completedPartitions}</td>
-            <td>${completion.remainingPartitions}</td>
+            <td>${parameterGroup.key.platform.nameAndModel}</td>
+            <td>${parameterGroup.key.name}</td>
+            <c:forEach items="${ordercompletionheadings}" var="heading">
+              <td>${parameterGroup.value[heading].numPartitions}</td>
+            </c:forEach>
+            <td>${parameterGroup.value.getRemaining()}</td>
           </tr>
         </c:forEach>
         </tbody>

--- a/miso-web/src/main/webapp/pages/listPoolOrders.jsp
+++ b/miso-web/src/main/webapp/pages/listPoolOrders.jsp
@@ -43,16 +43,18 @@
        jQuery('#listingPoolOrderTable').html('');
        jQuery('#listingPoolOrderTable').dataTable({
          "aaData": [
-           <c:forEach items="${ordercompletions}" var="completion">[
-            '<a href="/miso/pool/${completion.poolId}">${completion.pool.name}</a>', 
-            '<a href="/miso/pool/${completion.poolId}">${completion.pool.alias}</a>',
-            '${completion.sequencingParameters.platform.nameAndModel}',
-            '${completion.sequencingParameters.name}',
-            ${completion.desiredPartitions},
-            ${completion.completedPartitions},
-            ${completion.remainingPartitions},
-            ${completion.poolId}
+           <c:forEach items="${ordercompletions}" var="poolGroup">
+            <c:forEach items="${poolGroup.value}" var="parameterGroup">[
+              '<a href="/miso/pool/${poolGroup.key.id}">${poolGroup.key.name}</a>', 
+              '<a href="/miso/pool/${poolGroup.key.id}">${poolGroup.key.alias}</a>',
+              '${parameterGroup.key.platform.nameAndModel}',
+              '${parameterGroup.key.name}',
+              <c:forEach items="${ordercompletionheadings}" var="heading">
+                '${parameterGroup.value[heading].numPartitions}',
+              </c:forEach>
+              '${parameterGroup.value.getRemaining()}'
           ],
+           </c:forEach>
          </c:forEach>
          ],
          "aoColumns": [
@@ -60,10 +62,10 @@
            { "sTitle": "Alias"},
            { "sTitle": "Platform"},
            { "sTitle": "Sequencing Parameters"},
-           { "sTitle": "Requested"},
-           { "sTitle": "Completed"},
-           { "sTitle": "Remaining"},
-           { "sTitle": "ID", "bVisible": false}
+           <c:forEach items="${ordercompletionheadings}" var="heading">
+           { "sTitle": "${heading.key}"},
+           </c:forEach>
+           { "sTitle": "Remaining"}
          ],
          "bJQueryUI": true,
          "bAutoWidth": false,

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/PoolOrderCompletionDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/PoolOrderCompletionDao.java
@@ -11,5 +11,5 @@ public interface PoolOrderCompletionDao {
 
   public Collection<PoolOrderCompletion> getForPool(Long poolId) throws HibernateException, IOException;
 
-  public Collection<PoolOrderCompletion> getUnfulfilled() throws HibernateException, IOException;
+  public Collection<PoolOrderCompletion> list() throws HibernateException, IOException;
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolOrderCompletionDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolOrderCompletionDao.java
@@ -43,8 +43,8 @@ public class HibernatePoolOrderCompletionDao implements PoolOrderCompletionDao {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Collection<PoolOrderCompletion> getUnfulfilled() throws HibernateException, IOException {
-    Query query = currentSession().createQuery("from PoolOrderCompletion where desired_partitions > completed_partitions");
+  public Collection<PoolOrderCompletion> list() throws HibernateException, IOException {
+    Query query = currentSession().createQuery("from PoolOrderCompletion");
     return fetchSqlStore(query.list());
   }
 

--- a/sqlstore/src/main/resources/db/migration/afterMigrate.sql
+++ b/sqlstore/src/main/resources/db/migration/afterMigrate.sql
@@ -479,23 +479,22 @@ FOR EACH ROW
 
 DELIMITER ;
 
-CREATE OR REPLACE VIEW CompletedPartitions AS
-  SELECT pool_poolId AS poolId, sequencingParameters_parametersId as parametersId, COUNT(*) AS completed_partitions
+DROP VIEW IF EXISTS CompletedPartitions;
+CREATE OR REPLACE VIEW RunPartitionsByHealth AS
+  SELECT pool_poolId AS poolId, sequencingParameters_parametersId as parametersId, COUNT(*) AS num_partitions, Status.health AS health
     FROM Run JOIN Run_SequencerPartitionContainer ON Run.runId = Run_SequencerPartitionContainer.Run_runId
      JOIN SequencerPartitionContainer_Partition ON Run_SequencerPartitionContainer.containers_containerId = SequencerPartitionContainer_Partition.container_containerId
      JOIN _Partition ON SequencerPartitionContainer_Partition.partitions_partitionId = _Partition.partitionId
      JOIN Status ON Status.statusId = Run.status_statusId
-    WHERE Status.health = 'Completed' AND sequencingParameters_parametersId IS NOT NULL
-    GROUP BY pool_poolId, platformRunId;
+    WHERE sequencingParameters_parametersId IS NOT NULL
+    GROUP BY pool_poolId, platformRunId, Status.health;
 
 CREATE OR REPLACE VIEW DesiredPartitions AS
-  SELECT poolId, parametersId, SUM(partitions) AS desired_partitions
+  SELECT poolId, parametersId, SUM(partitions) AS num_partitions
     FROM PoolOrder
     GROUP BY poolId, parametersId;
 
 CREATE OR REPLACE VIEW OrderCompletion AS
-  (SELECT CompletedPartitions.poolId AS poolId, CompletedPartitions.parametersId AS parametersId, completed_partitions, COALESCE(desired_partitions, 0) AS desired_partitions
-    FROM CompletedPartitions LEFT JOIN DesiredPartitions ON CompletedPartitions.poolId = DesiredPartitions.poolId AND CompletedPartitions.parametersId = DesiredPartitions.parametersId)
+  (SELECT poolId, parametersId, num_partitions, health FROM RunPartitionsByHealth)
   UNION
-  (SELECT DesiredPartitions.poolId AS poolId, DesiredPartitions.parametersId AS parametersId, COALESCE(completed_partitions, 0), desired_partitions
-    FROM CompletedPartitions RIGHT JOIN DesiredPartitions ON CompletedPartitions.poolId = DesiredPartitions.poolId AND CompletedPartitions.parametersId = DesiredPartitions.parametersId);
+  (SELECT poolId, parametersId, num_partitions, 'Requested' AS health FROM DesiredPartitions);


### PR DESCRIPTION
Instead of having simply requested and completed, provide pool order completion
counts for all possible sequencing states.