### PR TITLE
GLT-661 hide HOT IDBC col if BCs are autogenerated

### DIFF
--- a/miso-web/src/main/webapp/pages/bulkEditLibraries.jsp
+++ b/miso-web/src/main/webapp/pages/bulkEditLibraries.jsp
@@ -89,6 +89,7 @@
       Hot.saveButton = document.getElementById('saveLibraries');
       Library.hot.propagateOrEdit = "${method}";
       Library.designs = ${libraryDesignsJSON};
+      Hot.autoGenerateIdBarcodes = ${autoGenerateIdBarcodes};
 
       Library.hot.makeBulkCreateTable = function () {
         Library.hot.librariesJSON = Library.hot.prepLibrariesForTable(Library.hot.librariesJSON);

--- a/miso-web/src/main/webapp/pages/bulkEditSamples.jsp
+++ b/miso-web/src/main/webapp/pages/bulkEditSamples.jsp
@@ -88,6 +88,7 @@
 	    Hot.detailedSample = JSON.parse(document.getElementById('HOTbulkForm').dataset.detailedSample);
 	    Hot.saveButton = document.getElementById('saveSamples');
 	    Sample.hot.createOrEdit = "${method}";
+      Hot.autoGenerateIdBarcodes = ${autoGenerateIdBarcodes};
 
 	    Sample.hot.makeBulkEditTable = function () {
         Sample.hot.samplesJSON = Sample.hot.modifySamplesForEdit(Sample.hot.samplesJSON);

--- a/miso-web/src/main/webapp/pages/editSample.jsp
+++ b/miso-web/src/main/webapp/pages/editSample.jsp
@@ -698,6 +698,7 @@
     <script type="text/javascript">
       Hot.dropdownRef = ${referenceDataJSON};
       Sample.hot.aliasGenerationEnabled = ${aliasGenerationEnabled};
+      Hot.autoGenerateIdBarcodes = ${autoGenerateIdBarcodes};
       Sample.hot.selectedProjectId = parseInt('${sample.project.id}') || null;
       Hot.detailedSample = JSON.parse(document.getElementById('HOTbulkForm').dataset.detailedSample);
       if (Boolean(Hot.detailedSample)) {

--- a/miso-web/src/main/webapp/scripts/library_hot.js
+++ b/miso-web/src/main/webapp/scripts/library_hot.js
@@ -227,11 +227,22 @@ Library.hot = {
    */
   setColumnData: function (detailedBool) {
     var qcBool = Library.hot.showQcs;
+    var cols;
     if (detailedBool) {
-      return Hot.concatArrays(setAliasCol(), setPlainCols(), setDetailedCols());
+      cols = Hot.concatArrays(setAliasCol(), setPlainCols(), setDetailedCols());
     } else {
-      return Hot.concatArrays(setAliasCol(), setPlainCols());
+      cols = Hot.concatArrays(setAliasCol(), setPlainCols());
     }
+    // add the ID Barcode column if it is not auto-generated
+    if (!Hot.autoGenerateIdBarcodes) {
+      cols.splice(3, 0, {
+          header: 'Matrix Barcode',
+          data: 'identificationBarcode',
+          type: 'text'
+        }
+      );
+    }
+    return cols;
     
     function setPlainCols () {
       var libCols = [
@@ -245,10 +256,6 @@ Library.hot = {
           data: 'description',
           type: 'text',
           validator: requiredText
-        },{
-          header: 'Matrix Barcode',
-          data: 'identificationBarcode',
-          type: 'text'
         },{
           header: 'Platform',
           data: 'platformName',

--- a/miso-web/src/main/webapp/scripts/sample_hot.js
+++ b/miso-web/src/main/webapp/scripts/sample_hot.js
@@ -533,19 +533,30 @@ Sample.hot = {
    */
   setColumnData: function (detailedBool, sampleCategory, idColBoolean) {
     var qcBool = Sample.hot.showQcs;
+    var cols;
     if (!detailedBool && !qcBool) {
      // if neither detailed sample not qcs are requested
-      return Hot.concatArrays(setAliasCol(), setPlainCols());
+      cols = Hot.concatArrays(setAliasCol(), setPlainCols());
     } else if (!detailedBool && qcBool) {
       // if detailed sample is not requested but qcs are
-      return Hot.concatArrays(setAliasCol(), setPlainCols(), setQcCols());
+      cols = Hot.concatArrays(setAliasCol(), setPlainCols(), setQcCols());
     } else if (detailedBool && !qcBool){
       // if detailed sample is requested but qcs are
-      return Hot.concatArrays(setAliasCol(), setPlainCols(), setDetailedCols(sampleCategory, idColBoolean));
+      cols = Hot.concatArrays(setAliasCol(), setPlainCols(), setDetailedCols(sampleCategory, idColBoolean));
     } else if (detailedBool && qcBool) {
       // if detailed sample and qcs are requested
-      return Hot.concatArrays(setAliasCol(), setPlainCols(), setDetailedCols(sampleCategory, idColBoolean), setQcCols());
+      cols = Hot.concatArrays(setAliasCol(), setPlainCols(), setDetailedCols(sampleCategory, idColBoolean), setQcCols());
     }
+    // add the ID Barcode column if it is not auto-generated
+    if (!Hot.autoGenerateIdBarcodes) {
+      cols.splice(3, 0, {
+          header: 'Matrix Barcode',
+          data: 'identificationBarcode',
+          type: 'text'
+        }
+      );
+    }
+    return cols;
     
     function setPlainCols () {
       var sampleCols = [
@@ -573,10 +584,6 @@ Sample.hot = {
           source: Sample.hot.getSampleTypes(),
           validator: validateSampleTypes,
           extraneous: true
-        },{
-          header: 'Matrix Barcode',
-          data: 'identificationBarcode',
-          type: 'text'
         },{
           header: 'Sci. Name',
           data: 'scientificName',


### PR DESCRIPTION
- visibility of Matrix (Identification) Barcode column in Handontable (sample & library) is turned off if these barcodes are auto-generated (set in miso.properties)