### PR TITLE
GLT-608 fix OxfordNanopore enum & LibAddInfo save

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/PlatformType.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/type/PlatformType.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * @since 0.0.2
  */
 public enum PlatformType {
-  ILLUMINA("Illumina"), LS454("LS454"), SOLID("Solid"), IONTORRENT("IonTorrent"), PACBIO("PacBio"), OXFORD_NANOPORE("OxfordNanopore");
+  ILLUMINA("Illumina"), LS454("LS454"), SOLID("Solid"), IONTORRENT("IonTorrent"), PACBIO("PacBio"), OXFORDNANOPORE("OxfordNanopore");
 
   /**
    * Field key

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLibraryAdditionalInfoService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLibraryAdditionalInfoService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.eaglegenomics.simlims.core.User;
 import com.google.common.collect.Sets;
 
+import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.LibraryAdditionalInfo;
 import uk.ac.bbsrc.tgac.miso.core.store.KitStore;
 import uk.ac.bbsrc.tgac.miso.core.store.LibraryStore;
@@ -55,7 +56,7 @@ public class DefaultLibraryAdditionalInfoService implements LibraryAdditionalInf
   @Override
   public Long create(LibraryAdditionalInfo libraryAdditionalInfo, Long libraryId)
       throws IOException {
-    authorizationManager.throwIfNotWritable(libraryAdditionalInfo.getLibrary());
+    authorizationManager.throwIfNotWritable(libraryStore.get(libraryId));
     libraryAdditionalInfo.setLibrary(libraryStore.get(libraryId));
     libraryAdditionalInfo.setTissueOrigin(tissueOriginDao.getTissueOrigin(libraryAdditionalInfo.getTissueOrigin().getId()));
     libraryAdditionalInfo.setTissueType(tissueTypeDao.getTissueType(libraryAdditionalInfo.getTissueType().getId()));

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLibraryController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditLibraryController.java
@@ -887,6 +887,7 @@ public class EditLibraryController {
       boolean create = library.getId() == AbstractLibrary.UNSAVED_ID;
       long id = requestManager.saveLibrary(library);
       if (library.getLibraryAdditionalInfo() != null) {
+        library.getLibraryAdditionalInfo().setLibrary(library);
         if (create) {
           libraryAdditionalInfoService.create(library.getLibraryAdditionalInfo(), id);
         } else {

--- a/miso-web/src/main/webapp/pages/editLibrary.jsp
+++ b/miso-web/src/main/webapp/pages/editLibrary.jsp
@@ -384,7 +384,7 @@
 </tr>
 </table>
 
-<c:if test="${!empty library.libraryAdditionalInfo}">
+<c:if test="${detailedSample}">
 <br/>
 <br/>
 <h2>Details</h2>

--- a/miso-web/src/main/webapp/pages/editSample.jsp
+++ b/miso-web/src/main/webapp/pages/editSample.jsp
@@ -282,7 +282,7 @@
       <td><form:checkbox id="empty" path="empty"/></td>
     </tr>
   </table>
-  <c:if test="${!empty sample.sampleAdditionalInfo}">
+  <c:if test="${detailedSample}">
     
     <script type="text/javascript">
       Sample.options.all = ${sampleOptions};


### PR DESCRIPTION
- fixes the enum error found when adding an OxfordNanopore container
- also finishes the fix for GLT-729 (corrects the check for resource writability)