### PR TITLE
corrected transactional annotations

### DIFF
--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultIdentityService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultIdentityService.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
@@ -21,7 +20,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.IdentityDao;
 import uk.ac.bbsrc.tgac.miso.service.IdentityService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultIdentityService implements IdentityService {
 
@@ -48,7 +47,6 @@ public class DefaultIdentityService implements IdentityService {
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public Identity get(String externalName) {
     return identityDao.getIdentity(externalName);
   }
@@ -91,7 +89,6 @@ public class DefaultIdentityService implements IdentityService {
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public Identity to(SampleIdentityDto sampleIdentityDto) throws IOException {
     authorizationManager.throwIfUnauthenticated();
     User user = authorizationManager.getCurrentUser();

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultInstituteService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultInstituteService.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.InstituteDao;
 import uk.ac.bbsrc.tgac.miso.service.InstituteService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultInstituteService implements InstituteService {
   

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLabService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLabService.java
@@ -5,7 +5,6 @@ import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
@@ -17,7 +16,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.LabDao;
 import uk.ac.bbsrc.tgac.miso.service.LabService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultLabService implements LabService {
 
@@ -43,7 +42,6 @@ public class DefaultLabService implements LabService {
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public Lab get(Long id) throws IOException {
     authorizationManager.throwIfUnauthenticated();
     return labDao.getLab(id);

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLibraryAdditionalInfoService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultLibraryAdditionalInfoService.java
@@ -12,18 +12,16 @@ import org.springframework.transaction.annotation.Transactional;
 import com.eaglegenomics.simlims.core.User;
 import com.google.common.collect.Sets;
 
-import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.LibraryAdditionalInfo;
 import uk.ac.bbsrc.tgac.miso.core.store.KitStore;
 import uk.ac.bbsrc.tgac.miso.core.store.LibraryStore;
 import uk.ac.bbsrc.tgac.miso.persistence.LibraryAdditionalInfoDao;
-import uk.ac.bbsrc.tgac.miso.persistence.SampleGroupDao;
 import uk.ac.bbsrc.tgac.miso.persistence.TissueOriginDao;
 import uk.ac.bbsrc.tgac.miso.persistence.TissueTypeDao;
 import uk.ac.bbsrc.tgac.miso.service.LibraryAdditionalInfoService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultLibraryAdditionalInfoService implements LibraryAdditionalInfoService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderCompletionService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderCompletionService.java
@@ -16,7 +16,7 @@ import uk.ac.bbsrc.tgac.miso.service.PoolOrderCompletionService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationException;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 
 public class DefaultPoolOrderCompletionService implements PoolOrderCompletionService {

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPoolOrderService.java
@@ -21,7 +21,7 @@ import uk.ac.bbsrc.tgac.miso.service.PoolOrderService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationException;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultPoolOrderService implements PoolOrderService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultQcPassedDetailService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultQcPassedDetailService.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.QcPassedDetailDao;
 import uk.ac.bbsrc.tgac.miso.service.QcPassedDetailService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultQcPassedDetailService implements QcPassedDetailService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultReferenceGenomeService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultReferenceGenomeService.java
@@ -2,7 +2,6 @@ package uk.ac.bbsrc.tgac.miso.service.impl;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,20 +9,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.eaglegenomics.simlims.core.User;
-import com.google.common.collect.Sets;
-
-import uk.ac.bbsrc.tgac.miso.core.data.Project;
 import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
-import uk.ac.bbsrc.tgac.miso.core.data.Subproject;
 import uk.ac.bbsrc.tgac.miso.persistence.ReferenceGenomeDao;
-import uk.ac.bbsrc.tgac.miso.persistence.SubprojectDao;
 import uk.ac.bbsrc.tgac.miso.service.ReferenceGenomeService;
-import uk.ac.bbsrc.tgac.miso.service.SubprojectService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
-import uk.ac.bbsrc.tgac.miso.sqlstore.SQLProjectDAO;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultReferenceGenomeService implements ReferenceGenomeService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleAdditionalInfoService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleAdditionalInfoService.java
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
@@ -33,7 +32,7 @@ import uk.ac.bbsrc.tgac.miso.service.SampleAdditionalInfoService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 import uk.ac.bbsrc.tgac.miso.sqlstore.SQLKitDAO;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSampleAdditionalInfoService implements SampleAdditionalInfoService {
 
@@ -130,7 +129,6 @@ public class DefaultSampleAdditionalInfoService implements SampleAdditionalInfoS
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public SampleAdditionalInfo to(SampleAdditionalInfoDto sampleAdditionalInfoDto) throws IOException {
     authorizationManager.throwIfUnauthenticated();
     checkArgument(sampleAdditionalInfoDto.getSampleClassId() != null,

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleAnalyteService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleAnalyteService.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
@@ -27,7 +26,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.TissueMaterialDao;
 import uk.ac.bbsrc.tgac.miso.service.SampleAnalyteService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSampleAnalyteService implements SampleAnalyteService {
 
@@ -89,7 +88,6 @@ public class DefaultSampleAnalyteService implements SampleAnalyteService {
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public Long create(SampleAnalyteDto sampleAnalyteDto) throws IOException {
     authorizationManager.throwIfNonAdmin();
     User user = authorizationManager.getCurrentUser();
@@ -109,7 +107,6 @@ public class DefaultSampleAnalyteService implements SampleAnalyteService {
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public SampleAnalyte to(SampleAnalyteDto sampleAnalyteDto) throws IOException {
     authorizationManager.throwIfUnauthenticated();
     User user = authorizationManager.getCurrentUser();

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleClassService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleClassService.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.SampleClassDao;
 import uk.ac.bbsrc.tgac.miso.service.SampleClassService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSampleClassService implements SampleClassService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleGroupService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleGroupService.java
@@ -22,7 +22,7 @@ import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationException;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 import uk.ac.bbsrc.tgac.miso.sqlstore.SQLProjectDAO;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSampleGroupService implements SampleGroupService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleNumberPerProjectService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleNumberPerProjectService.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
@@ -20,7 +19,7 @@ import uk.ac.bbsrc.tgac.miso.service.SampleNumberPerProjectService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 import uk.ac.bbsrc.tgac.miso.sqlstore.SQLProjectDAO;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSampleNumberPerProjectService implements SampleNumberPerProjectService {
 
@@ -88,7 +87,6 @@ public class DefaultSampleNumberPerProjectService implements SampleNumberPerProj
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public String nextNumber(Project project) throws IOException {
     User user = authorizationManager.getCurrentUser();
     return sampleNumberPerProjectDao.nextNumber(project, user);

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSamplePurposeService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSamplePurposeService.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.SamplePurposeDao;
 import uk.ac.bbsrc.tgac.miso.service.SamplePurposeService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSamplePurposeService implements SamplePurposeService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
@@ -54,7 +54,7 @@ import uk.ac.bbsrc.tgac.miso.service.SampleTissueService;
 import uk.ac.bbsrc.tgac.miso.service.SampleValidRelationshipService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSampleService implements SampleService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleTissueService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleTissueService.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
@@ -23,7 +22,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.SampleTissueDao;
 import uk.ac.bbsrc.tgac.miso.service.SampleTissueService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSampleTissueService implements SampleTissueService {
   protected static final Logger log = LoggerFactory.getLogger(DefaultSampleTissueService.class);
@@ -89,7 +88,6 @@ public class DefaultSampleTissueService implements SampleTissueService {
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public SampleTissue to(SampleTissueDto sampleTissueDto) throws IOException {
     authorizationManager.throwIfUnauthenticated();
     User user = authorizationManager.getCurrentUser();

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleValidRelationshipService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleValidRelationshipService.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
@@ -20,7 +19,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.SampleValidRelationshipDao;
 import uk.ac.bbsrc.tgac.miso.service.SampleValidRelationshipService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSampleValidRelationshipService implements SampleValidRelationshipService {
 
@@ -82,7 +81,6 @@ public class DefaultSampleValidRelationshipService implements SampleValidRelatio
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public Set<SampleValidRelationship> getAll() throws IOException {
     authorizationManager.throwIfUnauthenticated();
     return Sets.newHashSet(sampleValidRelationshipDao.getSampleValidRelationship());

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSequencingParametersService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSequencingParametersService.java
@@ -2,7 +2,6 @@ package uk.ac.bbsrc.tgac.miso.service.impl;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -16,12 +15,11 @@ import com.eaglegenomics.simlims.core.User;
 import com.google.common.collect.Sets;
 
 import uk.ac.bbsrc.tgac.miso.core.data.SequencingParameters;
-import uk.ac.bbsrc.tgac.miso.core.service.SequencingParametersCollection;
 import uk.ac.bbsrc.tgac.miso.persistence.SequencingParametersDao;
 import uk.ac.bbsrc.tgac.miso.service.SequencingParametersService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSequencingParametersService implements SequencingParametersService {
   protected static final Logger log = LoggerFactory.getLogger(DefaultSequencingParametersService.class);

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSubprojectService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSubprojectService.java
@@ -19,7 +19,7 @@ import uk.ac.bbsrc.tgac.miso.service.SubprojectService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 import uk.ac.bbsrc.tgac.miso.sqlstore.SQLProjectDAO;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultSubprojectService implements SubprojectService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTagBarcodeService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTagBarcodeService.java
@@ -12,7 +12,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.service.TagBarcodeService;
 import uk.ac.bbsrc.tgac.miso.core.store.TagBarcodeStore;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultTagBarcodeService implements TagBarcodeService {
   @Autowired

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTissueMaterialService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTissueMaterialService.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.TissueMaterialDao;
 import uk.ac.bbsrc.tgac.miso.service.TissueMaterialService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultTissueMaterialService implements TissueMaterialService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTissueOriginService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTissueOriginService.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.TissueOriginDao;
 import uk.ac.bbsrc.tgac.miso.service.TissueOriginService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultTissueOriginService implements TissueOriginService {
 

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTissueTypeService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultTissueTypeService.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.TissueTypeDao;
 import uk.ac.bbsrc.tgac.miso.service.TissueTypeService;
 import uk.ac.bbsrc.tgac.miso.service.security.AuthorizationManager;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Service
 public class DefaultTissueTypeService implements TissueTypeService {
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIdentityDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIdentityDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.IdentityImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.IdentityDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateIdentityDao implements IdentityDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateIdentityDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstituteDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateInstituteDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.InstituteImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.InstituteDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateInstituteDao implements InstituteDao {
   
   protected static final Logger log = LoggerFactory.getLogger(HibernateInstituteDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLabDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLabDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.LabImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.LabDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateLabDao implements LabDao {
   
   protected static final Logger log = LoggerFactory.getLogger(HibernateLabDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryAdditionalInfoDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryAdditionalInfoDao.java
@@ -18,7 +18,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryAdditionalInfoImpl;
 import uk.ac.bbsrc.tgac.miso.core.store.KitStore;
 import uk.ac.bbsrc.tgac.miso.persistence.LibraryAdditionalInfoDao;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateLibraryAdditionalInfoDao implements LibraryAdditionalInfoDao {
   
   protected static final Logger log = LoggerFactory.getLogger(HibernateLibraryAdditionalInfoDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryDesignDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryDesignDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
 import uk.ac.bbsrc.tgac.miso.core.store.LibraryDesignDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateLibraryDesignDao implements LibraryDesignDao {
   protected static final Logger log = LoggerFactory.getLogger(HibernateLibraryDesignDao.class);
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolOrderCompletionDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolOrderCompletionDao.java
@@ -16,7 +16,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.PlatformStore;
 import uk.ac.bbsrc.tgac.miso.core.store.PoolStore;
 import uk.ac.bbsrc.tgac.miso.persistence.PoolOrderCompletionDao;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Repository
 public class HibernatePoolOrderCompletionDao implements PoolOrderCompletionDao {
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolOrderDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolOrderDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolOrderImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.PoolOrderDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernatePoolOrderDao implements PoolOrderDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernatePoolOrderDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateQcPassedDetailDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateQcPassedDetailDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.QcPassedDetailImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.QcPassedDetailDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateQcPassedDetailDao implements QcPassedDetailDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateQcPassedDetailDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateReferenceGenomeDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateReferenceGenomeDao.java
@@ -16,7 +16,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 import uk.ac.bbsrc.tgac.miso.persistence.ReferenceGenomeDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateReferenceGenomeDao implements ReferenceGenomeDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateReferenceGenomeDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleAdditionalInfoDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleAdditionalInfoDao.java
@@ -19,7 +19,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
 import uk.ac.bbsrc.tgac.miso.core.store.KitStore;
 import uk.ac.bbsrc.tgac.miso.persistence.SampleAdditionalInfoDao;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSampleAdditionalInfoDao implements SampleAdditionalInfoDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSampleAdditionalInfoDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleAnalyteDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleAnalyteDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAnalyteImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.SampleAnalyteDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSampleAnalyteDao implements SampleAnalyteDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSampleAnalyteDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
@@ -51,7 +51,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * that Hibernate cannot access. Similarly, it then follows any necessary links on save. All the SqlStore-populated fields are marked
  * “transient” in the Sample class.
  */
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSampleDao implements SampleDao, SampleStore {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSampleDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleGroupDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleGroupDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleGroupImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.SampleGroupDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSampleGroupDao implements SampleGroupDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSampleGroupDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleNumberPerProjectDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleNumberPerProjectDao.java
@@ -20,7 +20,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleNumberPerProjectImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.SampleNumberPerProjectDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSampleNumberPerProjectDao implements SampleNumberPerProjectDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSampleNumberPerProjectDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSamplePurposeDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSamplePurposeDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SamplePurposeImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.SamplePurposeDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSamplePurposeDao implements SamplePurposeDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSamplePurposeDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleTissueDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleTissueDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleTissueImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.SampleTissueDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSampleTissueDao implements SampleTissueDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSampleTissueDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleValidRelationshipDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleValidRelationshipDao.java
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.SampleValidRelationship;
@@ -18,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleValidRelationshipImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.SampleValidRelationshipDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSampleValidRelationshipDao implements SampleValidRelationshipDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSampleValidRelationshipDao.class);
@@ -35,7 +34,6 @@ public class HibernateSampleValidRelationshipDao implements SampleValidRelations
   }
 
   @Override
-  @Transactional(propagation = Propagation.REQUIRED)
   public List<SampleValidRelationship> getSampleValidRelationship() {
     Query query = currentSession().createQuery("from SampleValidRelationshipImpl");
     @SuppressWarnings("unchecked")

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencingParametersDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencingParametersDao.java
@@ -21,7 +21,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.PlatformStore;
 import uk.ac.bbsrc.tgac.miso.persistence.SequencingParametersDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSequencingParametersDao implements SequencingParametersDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSequencingParametersDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSubprojectDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSubprojectDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.SubprojectImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.SubprojectDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateSubprojectDao implements SubprojectDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSubprojectDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTagBarcodeDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTagBarcodeDao.java
@@ -16,7 +16,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.TagBarcodeFamily;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.store.TagBarcodeStore;
 
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 @Repository
 public class HibernateTagBarcodeDao implements TagBarcodeStore {
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTissueMaterialDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTissueMaterialDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.TissueMaterialImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.TissueMaterialDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateTissueMaterialDao implements TissueMaterialDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateTissueMaterialDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTissueOriginDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTissueOriginDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.TissueOriginImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.TissueOriginDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateTissueOriginDao implements TissueOriginDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateTissueOriginDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTissueTypeDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTissueTypeDao.java
@@ -17,7 +17,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.TissueTypeImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.TissueTypeDao;
 
 @Repository
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class HibernateTissueTypeDao implements TissueTypeDao {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateTissueTypeDao.class);

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLAlertDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLAlertDAO.java
@@ -29,6 +29,10 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 
+import net.sf.ehcache.CacheException;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,9 +49,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.CacheException;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.event.Alert;
 import uk.ac.bbsrc.tgac.miso.core.event.impl.DefaultAlert;
 import uk.ac.bbsrc.tgac.miso.core.event.impl.SystemAlert;
@@ -67,6 +68,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @date 07/10/11
  * @since 0.1.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLAlertDAO implements AlertStore {
   private static final String TABLE_NAME = "Alert";
 
@@ -120,7 +122,6 @@ public class SQLAlertDAO implements AlertStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = "alertCache", keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
       @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
   public boolean remove(Alert alert) throws IOException {
@@ -128,7 +129,6 @@ public class SQLAlertDAO implements AlertStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = "alertCache", keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
       @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
   public long save(Alert alert) throws IOException {

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLBoxDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLBoxDAO.java
@@ -23,6 +23,7 @@ import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.SecurityProfile;
 import com.eaglegenomics.simlims.core.store.SecurityStore;
@@ -49,6 +50,7 @@ import uk.ac.bbsrc.tgac.miso.core.util.BoxUtils;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
+@Transactional(rollbackFor = Exception.class)
 public class SQLBoxDAO implements BoxStore {
   public class BoxMapper extends CacheAwareRowMapper<Box> {
     public BoxMapper() {

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLChangeLogDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLChangeLogDAO.java
@@ -6,11 +6,13 @@ import java.util.Collection;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.ChangeLog;
 import uk.ac.bbsrc.tgac.miso.core.store.ChangeLogStore;
 import uk.ac.bbsrc.tgac.miso.core.util.CoverageIgnore;
 
+@Transactional(rollbackFor = Exception.class)
 public class SQLChangeLogDAO implements ChangeLogStore {
   private static class ChangeLogMapper implements RowMapper<ChangeLog> {
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLEmPCRDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLEmPCRDAO.java
@@ -31,6 +31,9 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,8 +49,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryDilution;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.emPCR;
 import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
@@ -69,6 +70,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLEmPCRDAO implements EmPCRStore {
   private static final String TABLE_NAME = "emPCR";
 
@@ -165,7 +167,6 @@ public class SQLEmPCRDAO implements EmPCRStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "emPCRCache",
       "lazyEmPCRCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
@@ -271,7 +272,6 @@ public class SQLEmPCRDAO implements EmPCRStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "emPCRCache",
       "lazyEmPCRCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLEmPCRDilutionDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLEmPCRDilutionDAO.java
@@ -32,6 +32,9 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,8 +50,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractDilution;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.emPCR;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.emPCRDilution;
@@ -71,6 +72,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLEmPCRDilutionDAO implements EmPCRDilutionStore {
   public static String DILUTION_SELECT_BY_ID_AND_LIBRARY_PLATFORM = "SELECT DISTINCT * " + "FROM Library l "
       + "INNER JOIN emPCRDilution ed ON ed.library_libraryId = l.libraryId " + "WHERE ld.dilutionId = ? OR ed.dilutionId = ? "
@@ -262,7 +264,6 @@ public class SQLEmPCRDilutionDAO implements EmPCRDilutionStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "emPCRDilutionCache",
       "lazyEmPCRDilutionCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
@@ -340,7 +341,6 @@ public class SQLEmPCRDilutionDAO implements EmPCRDilutionStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "emPCRDilutionCache",
       "lazyEmPCRDilutionCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLEntityGroupDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLEntityGroupDAO.java
@@ -12,6 +12,9 @@ import java.util.Set;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+
 import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,9 +23,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
 import uk.ac.bbsrc.tgac.miso.core.data.EntityGroup;
 import uk.ac.bbsrc.tgac.miso.core.data.Nameable;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.EntityGroupImpl;
@@ -43,6 +45,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @date 23/10/13
  * @since 0.2.1-SNAPSHOT
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLEntityGroupDAO implements EntityGroupStore {
   private static final String TABLE_NAME = "EntityGroup";
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLExperimentDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLExperimentDAO.java
@@ -46,6 +46,13 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.store.SecurityStore;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
+
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractExperiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Kit;
@@ -68,13 +75,6 @@ import uk.ac.bbsrc.tgac.miso.core.util.CoverageIgnore;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.store.SecurityStore;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
-
 /**
  * A data access object designed for retrieving Experiments from the LIMS database. This DAO should be configured with a spring
  * {@link JdbcTemplate} object which will be used to query the database.
@@ -82,6 +82,7 @@ import com.googlecode.ehcache.annotations.TriggersRemove;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLExperimentDAO implements ExperimentStore {
   private static final String TABLE_NAME = "Experiment";
 
@@ -268,7 +269,6 @@ public class SQLExperimentDAO implements ExperimentStore {
    *          the experiment to write
    */
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "experimentCache",
       "lazyExperimentCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))
@@ -437,7 +437,6 @@ public class SQLExperimentDAO implements ExperimentStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "experimentCache",
       "lazyExperimentCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLKitDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLKitDAO.java
@@ -32,6 +32,9 @@ import java.util.Map;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,12 +43,11 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.Note;
 import com.eaglegenomics.simlims.core.store.SecurityStore;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractKit;
 import uk.ac.bbsrc.tgac.miso.core.data.Kit;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.ClusterKit;
@@ -71,6 +73,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLKitDAO implements KitStore {
   private static final String KIT_TABLE_NAME = "Kit";
   private static final String DESCRIPTOR_TABLE_NAME = "KitDescriptor";

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLLibraryDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLLibraryDAO.java
@@ -97,6 +97,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLLibraryDAO implements LibraryStore {
   private static String TABLE_NAME = "Library";
 
@@ -323,7 +324,6 @@ public class SQLLibraryDAO implements LibraryStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = Exception.class)
   @TriggersRemove(cacheName = { "libraryCache",
       "lazyLibraryCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
@@ -579,7 +579,6 @@ public class SQLLibraryDAO implements LibraryStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "libraryCache",
       "lazyLibraryCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLLibraryDilutionDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLLibraryDilutionDAO.java
@@ -31,6 +31,9 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,8 +49,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractDilution;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryDilution;
@@ -71,6 +72,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLLibraryDilutionDAO implements LibraryDilutionStore {
   public static String DILUTION_SELECT_BY_ID_AND_LIBRARY_PLATFORM = "SELECT DISTINCT * " + "FROM Library l "
       + "INNER JOIN LibraryDilution ld ON ld.library_libraryId = l.libraryId "
@@ -285,7 +287,6 @@ public class SQLLibraryDilutionDAO implements LibraryDilutionStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = Exception.class)
   @TriggersRemove(cacheName = { "libraryDilutionCache",
       "lazyLibraryDilutionCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))
@@ -375,7 +376,6 @@ public class SQLLibraryDilutionDAO implements LibraryDilutionStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "libraryDilutionCache",
       "lazyLibraryDilutionCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLLibraryQCDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLLibraryQCDAO.java
@@ -31,6 +31,9 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,8 +44,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractQC;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.LibraryQC;
@@ -63,6 +64,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLLibraryQCDAO implements LibraryQcStore {
   private static final String TABLE_NAME = "LibraryQC";
 
@@ -129,7 +131,6 @@ public class SQLLibraryQCDAO implements LibraryQcStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   public long save(LibraryQC libraryQC) throws IOException {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("library_libraryId", libraryQC.getLibrary().getId());

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLNoteDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLNoteDAO.java
@@ -38,6 +38,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.Note;
 import com.eaglegenomics.simlims.core.store.SecurityStore;
@@ -60,6 +61,7 @@ import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLNoteDAO implements NoteStore {
   private static final String TABLE_NAME = "Note";
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlateDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlateDAO.java
@@ -48,6 +48,13 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.store.SecurityStore;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
+
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractPlate;
 import uk.ac.bbsrc.tgac.miso.core.data.Dilution;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
@@ -69,13 +76,6 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DaoLookup;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.store.SecurityStore;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
-
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
  * <p/>
@@ -85,6 +85,7 @@ import com.googlecode.ehcache.annotations.TriggersRemove;
  * @date 12-Sep-2011
  * @since 0.1.1
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLPlateDAO implements PlateStore {
   private static final String TABLE_NAME = "Plate";
 
@@ -277,7 +278,6 @@ public class SQLPlateDAO implements PlateStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = Exception.class)
   @TriggersRemove(cacheName = { "plateCache",
       "lazyPlateCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlatformDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPlatformDAO.java
@@ -34,6 +34,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractPlatform;
 import uk.ac.bbsrc.tgac.miso.core.data.Platform;
@@ -51,6 +52,7 @@ import uk.ac.bbsrc.tgac.miso.core.util.CoverageIgnore;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLPlatformDAO implements PlatformStore {
   private static final String TABLE_NAME = "Platform";
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAO.java
@@ -51,8 +51,16 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.eaglegenomics.simlims.core.Note;
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.User;
+import com.eaglegenomics.simlims.core.store.SecurityStore;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractPool;
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
@@ -81,15 +89,6 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DaoLookup;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
-import com.eaglegenomics.simlims.core.Note;
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.User;
-import com.eaglegenomics.simlims.core.store.SecurityStore;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
-
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
  * <p/>
@@ -98,6 +97,7 @@ import com.googlecode.ehcache.annotations.TriggersRemove;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLPoolDAO implements PoolStore {
   private static final String TABLE_NAME = "Pool";
 
@@ -420,7 +420,6 @@ public class SQLPoolDAO implements PoolStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = Exception.class)
   @TriggersRemove(cacheName = { "poolCache",
       "lazyPoolCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolQCDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolQCDAO.java
@@ -31,6 +31,9 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,8 +44,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractQC;
 import uk.ac.bbsrc.tgac.miso.core.data.Pool;
 import uk.ac.bbsrc.tgac.miso.core.data.PoolQC;
@@ -63,6 +64,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.1.9
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLPoolQCDAO implements PoolQcStore {
   private static final String TABLE_NAME = "PoolQC";
 
@@ -127,7 +129,6 @@ public class SQLPoolQCDAO implements PoolQcStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   public long save(PoolQC poolQC) throws IOException {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("pool_poolId", poolQC.getPool().getId());

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPrintJobDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPrintJobDAO.java
@@ -42,6 +42,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
@@ -63,6 +64,7 @@ import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
  * @date 01-Jul-2011
  * @since 0.0.3
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLPrintJobDAO implements PrintJobStore {
   private static final String TABLE_NAME = "PrintJob";
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPrintServiceDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPrintServiceDAO.java
@@ -29,6 +29,9 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,11 +40,10 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
-import net.sf.json.JSONException;
-import net.sf.json.JSONObject;
 import uk.ac.bbsrc.tgac.miso.core.data.Barcodable;
 import uk.ac.bbsrc.tgac.miso.core.manager.MisoFilesManager;
 import uk.ac.bbsrc.tgac.miso.core.manager.PrintManager;
@@ -62,6 +64,7 @@ import uk.ac.bbsrc.tgac.miso.core.util.PrintServiceUtils;
  * @date 16-Apr-2012
  * @since 0.1.6
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLPrintServiceDAO implements PrintServiceStore {
   private static final String TABLE_NAME = "PrintService";
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLProjectDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLProjectDAO.java
@@ -90,6 +90,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLProjectDAO implements ProjectStore {
   private static final String TABLE_NAME = "Project";
 
@@ -282,7 +283,6 @@ public class SQLProjectDAO implements ProjectStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = Exception.class)
   @TriggersRemove(cacheName = { "projectCache",
       "lazyProjectCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))
@@ -465,7 +465,6 @@ public class SQLProjectDAO implements ProjectStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "projectCache",
       "lazyProjectCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunDAO.java
@@ -93,6 +93,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLRunDAO implements RunStore {
   private static final String TABLE_NAME = "Run";
 
@@ -278,7 +279,6 @@ public class SQLRunDAO implements RunStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "runCache",
       "lazyRunCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
@@ -644,7 +644,6 @@ public class SQLRunDAO implements RunStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "runCache",
       "lazyRunCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunQCDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunQCDAO.java
@@ -33,6 +33,9 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,8 +47,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractQC;
 import uk.ac.bbsrc.tgac.miso.core.data.Partition;
 import uk.ac.bbsrc.tgac.miso.core.data.Run;
@@ -70,6 +71,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.3
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLRunQCDAO implements RunQcStore {
   private static final String TABLE_NAME = "RunQC";
 
@@ -138,7 +140,6 @@ public class SQLRunQCDAO implements RunQcStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   public long save(RunQC runQC) throws IOException {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("run_runId", runQC.getRun().getId());

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleQCDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleQCDAO.java
@@ -32,6 +32,9 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,8 +50,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractQC;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleQC;
@@ -69,6 +70,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLSampleQCDAO implements SampleQcStore {
   private static final String TABLE_NAME = "SampleQC";
 
@@ -134,7 +136,6 @@ public class SQLSampleQCDAO implements SampleQcStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "sampleQCCache",
       "lazySampleQCCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSecurityDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSecurityDAO.java
@@ -54,6 +54,14 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.eaglegenomics.simlims.core.Group;
+import com.eaglegenomics.simlims.core.SecurityProfile;
+import com.eaglegenomics.simlims.core.User;
+import com.googlecode.ehcache.annotations.Cacheable;
+import com.googlecode.ehcache.annotations.KeyGenerator;
+import com.googlecode.ehcache.annotations.Property;
+import com.googlecode.ehcache.annotations.TriggersRemove;
+
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import uk.ac.bbsrc.tgac.miso.core.security.PasswordCodecService;
 import uk.ac.bbsrc.tgac.miso.core.store.SecurityStore;
@@ -63,14 +71,6 @@ import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
-import com.eaglegenomics.simlims.core.Group;
-import com.eaglegenomics.simlims.core.SecurityProfile;
-import com.eaglegenomics.simlims.core.User;
-import com.googlecode.ehcache.annotations.Cacheable;
-import com.googlecode.ehcache.annotations.KeyGenerator;
-import com.googlecode.ehcache.annotations.Property;
-import com.googlecode.ehcache.annotations.TriggersRemove;
-
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore
  * <p/>
@@ -79,6 +79,7 @@ import com.googlecode.ehcache.annotations.TriggersRemove;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLSecurityDAO implements SecurityStore {
   private static final String USER_TABLE_NAME = "User";
   private static final String GROUP_TABLE_NAME = "_Group";
@@ -161,7 +162,6 @@ public class SQLSecurityDAO implements SecurityStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "userCache",
       "lazyUserCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSecurityProfileDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSecurityProfileDAO.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.sf.ehcache.CacheManager;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +42,6 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.Group;
@@ -52,7 +53,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.CacheManager;
 import uk.ac.bbsrc.tgac.miso.core.store.Store;
 
 /**
@@ -63,6 +63,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.Store;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLSecurityProfileDAO implements Store<SecurityProfile> {
   private static final String TABLE_NAME = "SecurityProfile";
 
@@ -86,7 +87,7 @@ public class SQLSecurityProfileDAO implements Store<SecurityProfile> {
 
   private SecurityManager securityManager;
   private JdbcTemplate template;
-  private int maxQueryParams = 500;
+  private final int maxQueryParams = 500;
 
   @Autowired
   private CacheManager cacheManager;
@@ -108,7 +109,6 @@ public class SQLSecurityProfileDAO implements Store<SecurityProfile> {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class, propagation = Propagation.REQUIRED)
   @TriggersRemove(cacheName = { "securityProfileCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
       @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))
   public long save(SecurityProfile securityProfile) throws IOException {

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerPartitionContainerDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerPartitionContainerDAO.java
@@ -33,6 +33,10 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,9 +55,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractSequencerPartitionContainer;
 import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerPartitionContainer;
@@ -78,6 +79,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.1.6
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLSequencerPartitionContainerDAO implements SequencerPartitionContainerStore {
   private static final String TABLE_NAME = "SequencerPartitionContainer";
 
@@ -301,7 +303,6 @@ public class SQLSequencerPartitionContainerDAO implements SequencerPartitionCont
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "sequencerPartitionContainerCache",
       "lazySequencerPartitionContainerCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
@@ -420,7 +421,6 @@ public class SQLSequencerPartitionContainerDAO implements SequencerPartitionCont
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "sequencerPartitionContainerCache",
       "lazySequencerPartitionContainerCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerPoolPartitionDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerPoolPartitionDAO.java
@@ -31,6 +31,10 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,9 +50,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractPartition;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerPoolPartition;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
@@ -67,6 +68,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.1.6
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLSequencerPoolPartitionDAO implements PartitionStore {
   private static final String TABLE_NAME = "_Partition";
 
@@ -166,7 +168,6 @@ public class SQLSequencerPoolPartitionDAO implements PartitionStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "sequencerPoolPartitionCache",
       "lazySequencerPoolPartitionCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )
@@ -302,7 +303,6 @@ public class SQLSequencerPoolPartitionDAO implements PartitionStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "sequencerPoolPartitionCache",
       "lazySequencerPoolPartitionCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }) )

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerReferenceDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerReferenceDAO.java
@@ -42,6 +42,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractSequencerReference;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerReference;
@@ -59,6 +60,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLSequencerReferenceDAO implements SequencerReferenceStore {
   private static final String TABLE_NAME = "SequencerReference";
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerServiceRecordDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSequencerServiceRecordDAO.java
@@ -14,6 +14,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractSequencerServiceRecord;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerServiceRecord;
@@ -23,6 +24,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.SequencerReferenceStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SequencerServiceRecordStore;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
+@Transactional(rollbackFor = Exception.class)
 public class SQLSequencerServiceRecordDAO implements SequencerServiceRecordStore {
   
   private static final String TABLE_NAME = "SequencerServiceRecord";

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLStatusDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLStatusDAO.java
@@ -42,6 +42,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Status;
 import uk.ac.bbsrc.tgac.miso.core.data.type.HealthType;
@@ -57,6 +58,7 @@ import uk.ac.bbsrc.tgac.miso.core.util.CoverageIgnore;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLStatusDAO implements StatusStore {
   private static final String TABLE_NAME = "Status";
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLStudyDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLStudyDAO.java
@@ -32,6 +32,10 @@ import java.util.regex.Matcher;
 
 import javax.persistence.CascadeType;
 
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,9 +53,6 @@ import com.googlecode.ehcache.annotations.KeyGenerator;
 import com.googlecode.ehcache.annotations.Property;
 import com.googlecode.ehcache.annotations.TriggersRemove;
 
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractStudy;
 import uk.ac.bbsrc.tgac.miso.core.data.Experiment;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
@@ -77,6 +78,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLStudyDAO implements StudyStore {
   private static final String TABLE_NAME = "Study";
 
@@ -199,7 +201,6 @@ public class SQLStudyDAO implements StudyStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "studyCache",
       "lazyStudyCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))
@@ -310,7 +311,6 @@ public class SQLStudyDAO implements StudyStore {
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   @TriggersRemove(cacheName = { "studyCache",
       "lazyStudyCache" }, keyGenerator = @KeyGenerator(name = "HashCodeCacheKeyGenerator", properties = {
           @Property(name = "includeMethod", value = "false"), @Property(name = "includeParameterTypes", value = "false") }))

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLTargetedResequencingDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLTargetedResequencingDAO.java
@@ -7,6 +7,9 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,13 +18,12 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
 import com.eaglegenomics.simlims.core.store.SecurityStore;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.TargetedResequencing;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.store.KitStore;
@@ -30,6 +32,7 @@ import uk.ac.bbsrc.tgac.miso.core.util.CoverageIgnore;
 import uk.ac.bbsrc.tgac.miso.sqlstore.cache.CacheAwareRowMapper;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
+@Transactional(rollbackFor = Exception.class)
 public class SQLTargetedResequencingDAO implements TargetedResequencingStore {
 
   private static String SELECT = "SELECT targetedResequencingId, alias, description, kitDescriptorId, "

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLTgacSubmissionDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLTgacSubmissionDAO.java
@@ -78,6 +78,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * @author Rob Davey
  * @since 0.0.2
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLTgacSubmissionDAO implements SubmissionStore, NamingSchemeAware<Submission> {
   private static final String TABLE_NAME = "Submission";
 
@@ -165,7 +166,6 @@ public class SQLTgacSubmissionDAO implements SubmissionStore, NamingSchemeAware<
   }
 
   @Override
-  @Transactional(readOnly = false, rollbackFor = IOException.class)
   public long save(Submission submission) throws IOException {
     SimpleJdbcInsert insert = new SimpleJdbcInsert(template).withTableName("Submission");
 

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLWatcherDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLWatcherDAO.java
@@ -37,6 +37,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.eaglegenomics.simlims.core.User;
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
@@ -53,6 +54,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.WatcherStore;
  * @date 07/10/11
  * @since 0.1.3
  */
+@Transactional(rollbackFor = Exception.class)
 public class SQLWatcherDAO implements WatcherStore {
   private static final String WATCHER_SELECT = "SELECT entityName, userId " + "FROM Watcher";
 


### PR DESCRIPTION
In most places, transactions only rolled back on RuntimeExceptions before. Now they will roll back on all Exceptions. Added annotation to all Service and DAO classes (Hibernate and SQL). Removed method-level annotations as none of them required different handling than is set at the class level.

Notes:
* Default propagation is REQUIRED, which means the method must be run in a transaction. If there is an existing transaction, it will be joined; otherwise a new transaction will be started.
* Default readOnly is false
* Many tables in the MISO DB are still MyISAM, which does not support transactions, so these tables will never actually get rolled back. We should convert them all to InnoDB at some point