### PR TITLE
added config for miso.properties location

### DIFF
--- a/miso-web/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/miso-web/src/main/webapp/WEB-INF/applicationContext.xml
@@ -27,11 +27,7 @@
   default-autowire="byName">
 
   <bean id="propertyConfigurer" class="uk.ac.bbsrc.tgac.miso.webapp.util.MisoPropertyExporter">
-    <property name="locations">
-      <list>
-        <value>classpath:miso.properties</value>
-      </list>
-    </property>
+    <property name="location" value="${miso.propertiesFile}" />
   </bean>
 
   <bean id="applicationContextProvider" name="applicationContextProvider" class="uk.ac.bbsrc.tgac.miso.webapp.context.ApplicationContextProvider" />

--- a/miso-web/src/main/webapp/WEB-INF/miso-servlet.xml
+++ b/miso-web/src/main/webapp/WEB-INF/miso-servlet.xml
@@ -40,14 +40,7 @@
   <context:component-scan annotation-config="true" base-package="uk.ac.bbsrc.tgac.miso" />
   <context:component-scan annotation-config="true" base-package="net.sourceforge.fluxion.ajax" />
 
-  <context:property-placeholder location="classpath:miso.properties" />
-
-  <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
-    <property name="location">
-      <value>classpath:miso.properties</value>
-    </property>
-    <property name="ignoreUnresolvablePlaceholders" value="true" />
-  </bean>
+  <context:property-placeholder location="${miso.propertiesFile}" />
 
   <bean name="webBindingInitializer" class="uk.ac.bbsrc.tgac.miso.spring.LimsBindingInitializer" />
 

--- a/miso-web/src/main/webapp/WEB-INF/web.xml
+++ b/miso-web/src/main/webapp/WEB-INF/web.xml
@@ -147,4 +147,9 @@
   <session-config>
     <session-timeout>60</session-timeout>
   </session-config>
+  
+  <context-param>
+    <param-name>miso.propertiesFile</param-name>
+    <param-value>classpath:miso.properties</param-value>
+  </context-param>
 </web-app>


### PR DESCRIPTION
You can now provide an external miso.properties file by adding the following parameter to ROOT.xml:

`<Parameter name="miso.propertiesFile" value="file:${CATALINA_HOME}/conf/Catalina/localhost/miso.properties" override="false"/>`

value must begin with `file:` and you must include `override=false`; otherwise, the parameter will be overridden by the default in web.xml (`classpath:miso.properties`). If this parameter is absent in ROOT.xml, the default in web.xml will be used as well, so current deployments will not be affected and may continue to use the packaged miso.properties file