### PR TITLE
Refactor finding of temp folder for id barcodes

### DIFF
--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ControllerHelperServiceUtils.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ControllerHelperServiceUtils.java
@@ -1,0 +1,19 @@
+package uk.ac.bbsrc.tgac.miso.spring;
+
+import java.io.File;
+import javax.servlet.http.HttpSession;
+
+/**
+ * For when you need web utils, since this module can't access `miso-web`.
+ *
+ */
+public class ControllerHelperServiceUtils {
+  /**
+   * Returns the location of the identificationBarcode image storage folder
+   * @param HttpSession session
+   * @return File 
+   */
+  public static File getBarcodeFileLocation(HttpSession session) {
+    return new File(session.getServletContext().getRealPath("/temp/"));
+  }
+}

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/BoxControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/BoxControllerHelperService.java
@@ -1,6 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.spring.ajax;
 
 import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.isStringEmptyOrNull;
+import static uk.ac.bbsrc.tgac.miso.spring.ControllerHelperServiceUtils.getBarcodeFileLocation;
 
 import java.awt.image.RenderedImage;
 import java.io.File;
@@ -574,7 +575,7 @@ public class BoxControllerHelperService {
    */
   public JSONObject getBoxBarcode(HttpSession session, JSONObject json) {
     Long boxId = json.getLong("boxId");
-    File temploc = new File(session.getServletContext().getRealPath("/") + "temp/");
+    File temploc = getBarcodeFileLocation(session);
     try {
       Box box = requestManager.getBoxById(boxId);
       barcodeFactory.setPointPixels(1.5f);

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/LibraryControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/LibraryControllerHelperService.java
@@ -24,6 +24,7 @@
 package uk.ac.bbsrc.tgac.miso.spring.ajax;
 
 import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.isStringEmptyOrNull;
+import static uk.ac.bbsrc.tgac.miso.spring.ControllerHelperServiceUtils.getBarcodeFileLocation;
 
 import java.awt.image.RenderedImage;
 import java.io.File;
@@ -231,7 +232,7 @@ public class LibraryControllerHelperService {
 
   public JSONObject getLibraryBarcode(HttpSession session, JSONObject json) {
     Long libraryId = json.getLong("libraryId");
-    File temploc = new File(session.getServletContext().getRealPath("/") + "temp/");
+    File temploc = getBarcodeFileLocation(session);
     try {
       Library library = requestManager.getLibraryById(libraryId);
       barcodeFactory.setPointPixels(1.5f);
@@ -429,7 +430,7 @@ public class LibraryControllerHelperService {
 
   public JSONObject getLibraryDilutionBarcode(HttpSession session, JSONObject json) {
     Long dilutionId = json.getLong("dilutionId");
-    File temploc = new File(session.getServletContext().getRealPath("/") + "temp/");
+    File temploc = getBarcodeFileLocation(session);
     try {
       LibraryDilution dil = requestManager.getLibraryDilutionById(dilutionId);
       barcodeFactory.setPointPixels(1.5f);
@@ -787,7 +788,7 @@ public class LibraryControllerHelperService {
         }
         sb.append("</tr>");
 
-        File temploc = new File(session.getServletContext().getRealPath("/") + "temp/");
+        File temploc = getBarcodeFileLocation(session);
         for (LibraryDilution dil : library.getLibraryDilutions()) {
           SimpleDateFormat date = new SimpleDateFormat("yyyy-MM-dd");
           sb.append("<tr>");
@@ -983,7 +984,7 @@ public class LibraryControllerHelperService {
         sb.append("<th>ID</th><th>Done By</th><th>Date</th><th>Results</th><th>ID Barcode</th>");
         sb.append("</tr>");
 
-        File temploc = new File(session.getServletContext().getRealPath("/") + "temp/");
+        File temploc = getBarcodeFileLocation(session);
         for (emPCRDilution dil : requestManager.listAllEmPCRDilutionsByEmPcrId(pcrId)) {
           sb.append("<tr>");
           sb.append("<td>" + dil.getId() + "</td>");

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/PlateControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/PlateControllerHelperService.java
@@ -24,6 +24,7 @@
 package uk.ac.bbsrc.tgac.miso.spring.ajax;
 
 import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.isStringEmptyOrNull;
+import static uk.ac.bbsrc.tgac.miso.spring.ControllerHelperServiceUtils.getBarcodeFileLocation;
 
 import java.awt.image.RenderedImage;
 import java.io.File;
@@ -100,7 +101,7 @@ public class PlateControllerHelperService {
 
   public JSONObject getPlateBarcode(HttpSession session, JSONObject json) {
     Long plateId = json.getLong("plateId");
-    File temploc = new File(session.getServletContext().getRealPath("/") + "temp/");
+    File temploc = getBarcodeFileLocation(session);
     try {
       Plate<? extends List<? extends Plateable>, ? extends Plateable> plate = requestManager.getPlateById(plateId);
       barcodeFactory.setPointPixels(1.5f);

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/PoolControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/PoolControllerHelperService.java
@@ -24,6 +24,7 @@
 package uk.ac.bbsrc.tgac.miso.spring.ajax;
 
 import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.isStringEmptyOrNull;
+import static uk.ac.bbsrc.tgac.miso.spring.ControllerHelperServiceUtils.getBarcodeFileLocation;
 
 import java.awt.image.RenderedImage;
 import java.io.File;
@@ -324,7 +325,7 @@ public class PoolControllerHelperService {
 
   public JSONObject getPoolBarcode(HttpSession session, JSONObject json) {
     Long poolId = json.getLong("poolId");
-    File temploc = new File(session.getServletContext().getRealPath("/") + "temp/");
+    File temploc = getBarcodeFileLocation(session);
     try {
       Pool pool = requestManager.getPoolById(poolId);
       barcodeFactory.setPointPixels(1.5f);

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/SampleControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/SampleControllerHelperService.java
@@ -24,6 +24,7 @@
 package uk.ac.bbsrc.tgac.miso.spring.ajax;
 
 import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.isStringEmptyOrNull;
+import static uk.ac.bbsrc.tgac.miso.spring.ControllerHelperServiceUtils.getBarcodeFileLocation;
 
 import java.awt.image.RenderedImage;
 import java.io.File;
@@ -546,7 +547,7 @@ public class SampleControllerHelperService {
 
   public JSONObject getSampleBarcode(HttpSession session, JSONObject json) {
     Long sampleId = json.getLong("sampleId");
-    File temploc = new File(session.getServletContext().getRealPath("/") + "temp/");
+    File temploc = getBarcodeFileLocation(session);
     try {
       Sample sample = requestManager.getSampleById(sampleId);
       barcodeFactory.setPointPixels(1.5f);


### PR DESCRIPTION
This will hopefully solve the issue where prod is creating a folder called `ROOTtemp` at the same level as `ROOT` and saving the barcodes there.