### PR TITLE
update Edit Sample (bulk) for required tissue in hierarchy

### DIFF
--- a/miso-dto/src/test/java/uk/ac/bbsrc/tgac/miso/dto/DtosTestSuite.java
+++ b/miso-dto/src/test/java/uk/ac/bbsrc/tgac/miso/dto/DtosTestSuite.java
@@ -1,0 +1,96 @@
+package uk.ac.bbsrc.tgac.miso.dto;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import uk.ac.bbsrc.tgac.miso.core.data.Identity;
+import uk.ac.bbsrc.tgac.miso.core.data.Sample;
+import uk.ac.bbsrc.tgac.miso.core.data.SampleAdditionalInfo;
+import uk.ac.bbsrc.tgac.miso.core.data.SampleAnalyte;
+import uk.ac.bbsrc.tgac.miso.core.data.SampleTissue;
+import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
+
+public class DtosTestSuite {
+  
+  
+  
+  @Test
+  public void testToAnalyteWithNewParents() {
+    SampleAnalyteDto dto = new SampleAnalyteDto();
+    dto.setRootSampleClassId(1L);
+    dto.setParentSampleClassId(2L);
+    dto.setSampleClassId(3L);
+    dto.setExternalName("externalName");
+    dto.setTissueOriginId(4L);
+    dto.setTissueTypeId(5L);
+    
+    Sample sample = Dtos.to(dto);
+    assertNotNull(sample);
+    assertTrue(LimsUtils.isAnalyteSample(sample));
+    SampleAnalyte analyte = (SampleAnalyte) sample;
+    assertNotNull(analyte.getSampleClass());
+    assertEquals(Long.valueOf(3L), analyte.getSampleClass().getId());
+    
+    assertNotNull(analyte.getParent());
+    assertTrue(LimsUtils.isTissueSample(analyte.getParent()));
+    SampleTissue tissue = (SampleTissue) analyte.getParent();
+    assertNotNull(tissue.getSampleClass());
+    assertEquals(Long.valueOf(2L), tissue.getSampleClass().getId());
+    assertNotNull(tissue.getTissueOrigin());
+    assertEquals(Long.valueOf(4L), tissue.getTissueOrigin().getId());
+    assertNotNull(tissue.getTissueType());
+    assertEquals(Long.valueOf(5L), tissue.getTissueType().getId());
+    
+    assertNotNull(tissue.getParent());
+    assertTrue(LimsUtils.isIdentitySample(tissue.getParent()));
+    Identity identity = (Identity) tissue.getParent();
+    assertEquals("externalName", identity.getExternalName());
+  }
+  
+  @Test
+  public void testToAnalyteWithExistingParent() {
+    SampleAnalyteDto dto = new SampleAnalyteDto();
+    dto.setRootSampleClassId(1L);
+    dto.setParentSampleClassId(2L);
+    dto.setSampleClassId(3L);
+    dto.setExternalName("externalName");
+    dto.setTissueOriginId(4L);
+    dto.setTissueTypeId(5L);
+    dto.setParentId(6L); // known ID should cause other parent details to be ignored
+    
+    Sample sample = Dtos.to(dto);
+    assertNotNull(sample);
+    assertTrue(LimsUtils.isAnalyteSample(sample));
+    SampleAnalyte analyte = (SampleAnalyte) sample;
+    assertNotNull(analyte.getSampleClass());
+    assertEquals(Long.valueOf(3L), analyte.getSampleClass().getId());
+    
+    assertNotNull(analyte.getParent());
+    assertTrue(LimsUtils.isDetailedSample(analyte.getParent()));
+    SampleAdditionalInfo parent = (SampleAdditionalInfo) analyte.getParent();
+    assertEquals(6L, parent.getId());
+    
+    assertNull(parent.getParent());
+  }
+  
+  @Test
+  public void testToTissueWithParent() {
+    SampleTissueDto dto = new SampleTissueDto();
+    dto.setRootSampleClassId(1L);
+    dto.setExternalName("externalName");
+    dto.setSampleClassId(2L);
+    dto.setTissueOriginId(3L);
+    dto.setTissueTypeId(4L);
+    
+    Sample sample = Dtos.to(dto);
+    assertNotNull(sample);
+    assertTrue(LimsUtils.isTissueSample(sample));
+    SampleTissue tissue = (SampleTissue) sample;
+    assertNotNull(tissue.getParent());
+    assertTrue(LimsUtils.isIdentitySample(tissue.getParent()));
+    Identity identity = (Identity) tissue.getParent();
+    assertEquals("externalName", identity.getExternalName());
+  }
+
+}

--- a/miso-web/src/main/webapp/scripts/sample_hot.js
+++ b/miso-web/src/main/webapp/scripts/sample_hot.js
@@ -199,16 +199,61 @@ Sample.hot = {
    */
   addClassSelect: function () {
     var select = [];
-    var classes = Hot.sortByProperty(Hot.sampleOptions.sampleClassesDtos, 'id');
     select.push('<select id="classDropdown">');
     select.push('<option value="">Select class</option>');
-    for (var i=0; i<classes.length; i++) {
-      if (classes[i].alias == "Identity") continue;
-      select.push('<option value="'+ classes[i].id +'">'+ classes[i].alias +'</option>');
+    var classOptions = Sample.hot.getNewSampleClassOptions();
+    for (var i=0; i<classOptions.length; i++) {
+      select.push('<option value="'+ classOptions[i].id +'">'+ classOptions[i].alias +'</option>');
     }
     select.push('</select>');
     document.getElementById('classOptions').innerHTML = select.join('');
     document.getElementById('classDropdown').addEventListener('change', Sample.hot.enableTableButton);
+  },
+  
+  /**
+   * Returns true if a new sample of the provided SampleClass can be created without an existing parent
+   */
+  canCreateNew: function (sampleClass) {
+    return sampleClass.sampleCategory === "Tissue" || (sampleClass.sampleCategory === "Analyte" && sampleClass.stock === true);
+  },
+  
+  /**
+   * Returns the SampleClasses which may be created without an existing parent
+   */
+  getNewSampleClassOptions: function () {
+    var classes = Hot.sortByProperty(Hot.sampleOptions.sampleClassesDtos, 'id');
+    var options = [];
+    for (var i=0; i<classes.length; i++) {
+      if (Sample.hot.canCreateNew(classes[i])) {
+        options.push(classes[i]);
+      }
+    }
+    return options;
+  },
+  
+  /**
+   * Returns the alias of each SampleClass which may be created without an existing parent
+   */
+  getNewSampleClassOptionsAliasOnly: function () {
+    var classes = Hot.sortByProperty(Hot.sampleOptions.sampleClassesDtos, 'id');
+    var options = [];
+    for (var i=0; i<classes.length; i++) {
+      if (Sample.hot.canCreateNew(classes[i])) {
+        options.push(classes[i].alias);
+      }
+    }
+    return options;
+  },
+  
+  getTissueClassesAliasOnly: function () {
+    var classes = Hot.sortByProperty(Hot.sampleOptions.sampleClassesDtos, 'id');
+    var options = [];
+    for (var i=0; i<classes.length; i++) {
+      if (classes[i].sampleCategory === 'Tissue') {
+        options.push(classes[i].alias);
+      }
+    }
+    return options;
   },
   
   /**
@@ -614,11 +659,7 @@ Sample.hot = {
       ];
       
       var tissueCols = [
-        {
-          header: 'Cellularity',
-          data: 'cellularity',
-          type: 'text'
-        }                 
+        
       ];
        
       var analyteCols = [
@@ -670,94 +711,112 @@ Sample.hot = {
         }
       ];  
       
-      // attach either the external name column & cols required to create sample alias, 
-      //   or the parentAlias column (depending on what kind of parent is required)
-      (function () {
-        var parentIdentityCols = [
-          {
-            header: 'External Name',
-            data: 'externalName',
-            type: 'text',
-            validator: requiredText
-          },{
-            header: 'Sex',
-            data: 'donorSex',
-            type: 'dropdown',
-            trimDropdown: false,
-            source: Sample.hot.getDonorSexes(),
-            validator: permitEmpty
-          },{
-            header: 'Tissue Origin',
-            data: 'tissueOriginAlias',
-            type: 'dropdown',
-            trimDropdown: false,
-            source: Sample.hot.getTissueOrigins(),
-            validator: validateTissueOrigins
-          },{
-            header: 'Tissue Type',
-            data: 'tissueTypeAlias',
-            type: 'dropdown',
-            trimDropdown: false,
-            source: Sample.hot.getTissueTypes(),
-            validator: validateTissueTypes
-          },{
-            header: 'Passage #',
-            data: 'passageNumber',
-            type: 'text',
-            validator: validateNumber
-          },{
-            header: 'Times Received',
-            data: 'timesReceived',
-            type: 'numeric',
-            validator: requiredText
-          },{
-            header: 'Tube Number',
-            data: 'tubeNumber',
-            type: 'numeric',
-            validator: requiredText
-          },{
-            header: 'Sample Class',
-            data: 'sampleClassAlias',
-            type: 'dropdown',
-            trimDropdown: false,
-            source: Sample.hot.getValidClassesForParent(Sample.hot.getRootSampleClassId())
-          },{
-            header: 'Lab',
-            data: 'labComposite',
-            type: 'dropdown',
-            trimDropdown: false,
-            source: Sample.hot.getLabs(),
-            validator: permitEmpty
-          },{
-            header: 'Ext. Inst. Identifier',
-            data: 'externalInstituteIdentifier',
-            type: 'text'
-          }
-        ];
-        var parentSampleCols = [
-          {
-            header: 'Parent Alias',
-            data: 'parentAlias',
-            type: 'text',
-            readOnly: true
-          },{
-            header: 'Parent Sample Class',
-            data: 'parentSampleClassAlias',
-            type: 'dropdown',
-            trimDropdown: false,
-            source: Sample.hot.getSampleClasses(),
-            readOnly: true
-          },{
-            header: 'Sample Class',
-            data: 'sampleClassAlias',
-            type: 'dropdown',
-            trimDropdown: false,
-            source: Sample.hot.getSampleClasses()
-          }
-        ];
-        var parentColumn = (idColBoolean ? parentIdentityCols : parentSampleCols);
-        additionalCols = Hot.concatArrays(parentColumn, additionalCols);
-      }()); 
+      // fields required to create a tissue parent and identify or create an identity parent 
+      // for the tissue. Used when receiving new samples
+      var parentIdentityCols = [
+        {
+          header: 'External Name',
+          data: 'externalName',
+          type: 'text',
+          validator: requiredText
+        },{
+          header: 'Sex',
+          data: 'donorSex',
+          type: 'dropdown',
+          trimDropdown: false,
+          source: Sample.hot.getDonorSexes(),
+          validator: permitEmpty
+        }
+      ];
+      
+      if (sampleCategory === 'Analyte') {
+        parentIdentityCols.push({
+          header: 'Tissue Class',
+          data: 'parentSampleClassAlias',
+          type: 'dropdown',
+          trimDropdown: false,
+          source: Sample.hot.getTissueClassesAliasOnly(),
+          validator: validateTissueClasses
+        });
+      }
+      
+      parentIdentityCols.push({
+        header: 'Tissue Origin',
+        data: 'tissueOriginAlias',
+        type: 'dropdown',
+        trimDropdown: false,
+        source: Sample.hot.getTissueOrigins(),
+        validator: validateTissueOrigins
+      },{
+        header: 'Tissue Type',
+        data: 'tissueTypeAlias',
+        type: 'dropdown',
+        trimDropdown: false,
+        source: Sample.hot.getTissueTypes(),
+        validator: validateTissueTypes
+      },{
+        header: 'Passage #',
+        data: 'passageNumber',
+        type: 'text',
+        validator: validateNumber
+      },{
+        header: 'Times Received',
+        data: 'timesReceived',
+        type: 'numeric',
+        validator: requiredText
+      },{
+        header: 'Tube Number',
+        data: 'tubeNumber',
+        type: 'numeric',
+        validator: requiredText
+      },{
+        header: 'Cellularity',
+        data: 'cellularity',
+        type: 'text'
+      },{
+        header: 'Sample Class',
+        data: 'sampleClassAlias',
+        type: 'dropdown',
+        trimDropdown: false,
+        source: Sample.hot.getNewSampleClassOptionsAliasOnly()
+      },{
+        header: 'Lab',
+        data: 'labComposite',
+        type: 'dropdown',
+        trimDropdown: false,
+        source: Sample.hot.getLabs(),
+        validator: permitEmpty
+      },{
+        header: 'Ext. Inst. Identifier',
+        data: 'externalInstituteIdentifier',
+        type: 'text'
+      });
+      
+      // fields used when propagating
+      var parentSampleCols = [
+        {
+          header: 'Parent Alias',
+          data: 'parentAlias',
+          type: 'text',
+          readOnly: true
+        },{
+          header: 'Parent Sample Class',
+          data: 'parentSampleClassAlias',
+          type: 'dropdown',
+          trimDropdown: false,
+          source: Sample.hot.getSampleClasses(),
+          readOnly: true
+        },{
+          header: 'Sample Class',
+          data: 'sampleClassAlias',
+          type: 'dropdown',
+          trimDropdown: false,
+          source: Sample.hot.getSampleClasses()
+        }
+      ];
+      var parentColumn = (idColBoolean ? parentIdentityCols : parentSampleCols);
+      additionalCols = Hot.concatArrays(parentColumn, additionalCols);
+      
       return Hot.concatArrays(additionalCols, getSampleCategoryCols(sampleCategory, tissueCols, analyteCols));
     }
     
@@ -853,6 +912,14 @@ Sample.hot = {
     
     function validateSampleTypes (value, callback) {
       if (Sample.hot.getSampleTypes().indexOf(value) == -1) {
+        return callback(false);
+      } else {
+        return callback(true);
+      }
+    }
+    
+    function validateTissueClasses (value, callback) {
+      if (Sample.hot.getTissueClassesAliasOnly().indexOf(value) == -1) {
         return callback(false);
       } else {
         return callback(true);
@@ -1039,6 +1106,9 @@ Sample.hot = {
       if (obj.tubeId && obj.tubeId.length) {
         sample.tubeId = obj.tubeId;
       }
+      if (obj.parentSampleClassAlias && obj.parentSampleClassAlias.length) {
+        sample.parentSampleClassId = Hot.getIdFromAlias(obj.parentSampleClassAlias, Hot.sampleOptions.sampleClassesDtos);
+      }
       break;
     case 'Tissue':
       if (obj.cellularity && obj.cellularity.length) {
@@ -1186,21 +1256,6 @@ Sample.hot = {
     
     Hot.hotTable.validateCells(function (isValid) { 
       if (isValid) {
-        // check for sampleValidRelationship with RootSampleClass as parent
-        var parentClassId = Sample.hot.getRootSampleClassId();
-        // TODO: update this to check each be the cell, not the dropdown
-        var childClassId = document.getElementById('classDropdown').value;
-        var validRelationship = Sample.hot.findMatchingRelationship(parentClassId, childClassId);
-        if (validRelationship.length === 0) {
-          Hot.messages.failed.push(Sample.hot.makeErrorMessageForInvalidRelationship(parentClassId, childClassId) 
-                  +  " Please copy your data, select another child class and save again.");
-          Hot.addErrors(Hot.messages);
-          document.getElementById('classDropdown').removeAttribute('disabled');
-          document.getElementById('classDropdown').classList.remove('disabled');
-          document.getElementById('classDropdown').classList.add('invalid');
-          return false;
-        }
-
         // send it through the parser to get a sampleData array that isn't merely a reference to Hot.hotTable.getSourceData()
         var sampleData = JSON.parse(JSON.parse(JSON.stringify(Hot.hotTable.getSourceData())));
         


### PR DESCRIPTION
Creating stock analyte on the bulk create sample page works again, and causes a parent tissue to be created in addition to the identity. All create and propagate methods should function correctly again