### PR TITLE
GLT-479 Added configuration for Active Directory authentication

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/UserImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/UserImpl.java
@@ -44,6 +44,7 @@ import org.springframework.security.core.authority.GrantedAuthorityImpl;
 import com.eaglegenomics.simlims.core.Group;
 import com.eaglegenomics.simlims.core.User;
 
+import uk.ac.bbsrc.tgac.miso.core.security.MisoAuthority;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 
 /**
@@ -157,15 +158,15 @@ public class UserImpl implements User, Serializable, Comparable {
   public Collection<GrantedAuthority> getPermissionsAsAuthorities() {
     List<GrantedAuthority> auths = new ArrayList<GrantedAuthority>();
     if (isAdmin()) {
-      auths.add(new GrantedAuthorityImpl("ROLE_ADMIN"));
+      auths.add(MisoAuthority.ROLE_ADMIN);
     }
 
     if (isInternal()) {
-      auths.add(new GrantedAuthorityImpl("ROLE_INTERNAL"));
+      auths.add(MisoAuthority.ROLE_INTERNAL);
     }
 
     if (isExternal()) {
-      auths.add(new GrantedAuthorityImpl("ROLE_EXTERNAL"));
+      auths.add(MisoAuthority.ROLE_EXTERNAL);
     }
 
     return auths;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/LDAPSecurityManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/LDAPSecurityManager.java
@@ -50,6 +50,9 @@ public class LDAPSecurityManager extends LocalSecurityManager implements MisoSec
   /** Field log */
   protected static final Logger log = LoggerFactory.getLogger(LDAPSecurityManager.class);
 
+  private static final String SECURITY_METHOD = "security.method";
+  private static final String ACTIVE_DIRECTORY = "ad";
+
   @Autowired
   private LdapUserDetailsManager ldapUserManager;
 
@@ -146,12 +149,21 @@ public class LDAPSecurityManager extends LocalSecurityManager implements MisoSec
       }
       return jdbcUser.getUserId();
     } else {
-      if (!isStringEmptyOrNull(user.getPassword())) {
+      if (!isStringEmptyOrNull(user.getPassword()) || isActiveDirectoryAuthentication()) {
         log.info("Creating " + user.getLoginName() + " in LIMS");
         return super.saveUser(user);
       }
       throw new IOException("Cannot create new user with no password");
     }
+  }
+
+  /**
+   * Active Directory does not return a password.
+   * 
+   * @return True if authentication method is Active Directory
+   */
+  private boolean isActiveDirectoryAuthentication() {
+    return System.getProperty(SECURITY_METHOD).equals(ACTIVE_DIRECTORY);
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/MisoAuthority.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/MisoAuthority.java
@@ -1,0 +1,17 @@
+package uk.ac.bbsrc.tgac.miso.core.security;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public enum MisoAuthority implements GrantedAuthority {
+  /** Administrator */
+  ROLE_ADMIN,
+  /** Regular User */
+  ROLE_INTERNAL,
+  /** External collaborator */
+  ROLE_EXTERNAL;
+
+  @Override
+  public String getAuthority() {
+    return name();
+  }
+}

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/ad/ActiveDirectoryAuthoritiesMapper.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/security/ad/ActiveDirectoryAuthoritiesMapper.java
@@ -1,0 +1,39 @@
+package uk.ac.bbsrc.tgac.miso.core.security.ad;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+
+import uk.ac.bbsrc.tgac.miso.core.security.MisoAuthority;
+
+/**
+ * When using active directory some roles may have a prefix required by the AD administrator. The class will map these prefixed roles to the
+ * actual MISO roles.
+ */
+public class ActiveDirectoryAuthoritiesMapper implements GrantedAuthoritiesMapper {
+
+  @Value("${security.ad.stripRolePrefix}")
+  private String rolePrefix = "";
+
+  @Override
+  public Collection<? extends GrantedAuthority> mapAuthorities(Collection<? extends GrantedAuthority> authorities) {
+    Set<MisoAuthority> roles = EnumSet.noneOf(MisoAuthority.class);
+
+    for (GrantedAuthority a : authorities) {
+      if ((rolePrefix + MisoAuthority.ROLE_ADMIN).equals(a.getAuthority())) {
+        roles.add(MisoAuthority.ROLE_ADMIN);
+      } else if ((rolePrefix + MisoAuthority.ROLE_INTERNAL).equals(a.getAuthority())) {
+        roles.add(MisoAuthority.ROLE_INTERNAL);
+      } else if ((rolePrefix + MisoAuthority.ROLE_EXTERNAL).equals(a.getAuthority())) {
+        roles.add(MisoAuthority.ROLE_EXTERNAL);
+      }
+    }
+
+    return roles;
+  }
+
+}

--- a/docs/_posts/2016-01-11-admin-manual.md
+++ b/docs/_posts/2016-01-11-admin-manual.md
@@ -181,6 +181,33 @@ The default configuration should work properly.
 For using LDAP, set the security method to `ldap`. Additional settings are
 needed for LDAP in the `security.properties`. Talk to your LDAP administrator.
 
+To use Active Directory, a specific kind of LDAP, set the security method to
+`ad`. Three additional settings are needed for Active Directory in the 
+`security.properties` file.
+
+| Property                    | Purpose                                                    |
+|-----------------------------|------------------------------------------------------------|
+|`security.ad.emailDomain`    | Domain added to username for lookup (e.g. ad.oicr.on.ca)   |
+|`security.ad.url`            | Url for Active Directory server (e.g. ldap://ad.oicr.on.ca)|
+|`security.ad.stripRolePrefix`| Prefix to be removed from group (e.g. MISO_)               |
+
+The search for a user is done against `userPrincipalName` which takes the form of
+an email address. To login the user will type their username and to do the lookup
+their username will be added to the domain specified in the property
+`security.ad.emailDomain`.
+
+Use the `security.ad.url` property to indicate the url for the Active Directory.
+Some valid examples are: `ad.oicr.on.ca`, `ldap://ad.oicr.on.ca:389` and
+`ldaps://ad.oicr.on.ca:636`.
+
+The groups used by MISO are `ROLE_INTERNAL` for regular users, `ROLE_EXTERNAL` for
+external collaborators and `ROLE_ADMIN` for administrators. If you find these names
+too general you may wish to add a prefix before adding these groups to your Active
+Directory. For example `MISO_ROLE_INTERNAL` gives a clearer indication as to what 
+the group is used for. In this case you will need to set the property
+`security.ad.stripRolePrefix` to the value `MISO_` to allow MISO to ignore the
+prefix.
+
 If using JDBC, once running, you should change the passwords of the `admin` and
 `notification` accounts.
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditUserController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditUserController.java
@@ -37,7 +37,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -49,17 +48,18 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.servlet.ModelAndView;
 
-import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
-import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
-import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
-import uk.ac.bbsrc.tgac.miso.core.security.PasswordCodecService;
-
 import com.eaglegenomics.simlims.core.Activity;
 import com.eaglegenomics.simlims.core.Group;
 import com.eaglegenomics.simlims.core.Protocol;
 import com.eaglegenomics.simlims.core.User;
 import com.eaglegenomics.simlims.core.manager.ProtocolManager;
 import com.eaglegenomics.simlims.core.manager.SecurityManager;
+
+import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
+import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
+import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
+import uk.ac.bbsrc.tgac.miso.core.security.MisoAuthority;
+import uk.ac.bbsrc.tgac.miso.core.security.PasswordCodecService;
 
 @Controller
 @SessionAttributes("user")
@@ -77,10 +77,10 @@ public class EditUserController {
 
   @Autowired
   private DataObjectFactory dataObjectFactory;
-  
+
   @Autowired
   private RequestManager requestManager;
-  
+
   public void setRequestManager(RequestManager requestManager) {
     this.requestManager = requestManager;
   }
@@ -199,12 +199,11 @@ public class EditUserController {
     try {
       if (user.getUserId() == UserImpl.UNSAVED_ID) {
         // new user. don't require a password to be set initially
-        if (!isStringEmptyOrNull(request.getParameter("newpassword"))
-            && !isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
+        if (!isStringEmptyOrNull(request.getParameter("newpassword")) && !isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
           if (request.getParameter("newpassword").equals(request.getParameter("confirmpassword"))) {
-            if (!isStringEmptyOrNull(request.getParameter("newpassword")) && !isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
-              if (SecurityContextHolder.getContext().getAuthentication().getAuthorities()
-                  .contains(new GrantedAuthorityImpl("ROLE_ADMIN"))) {
+            if (!isStringEmptyOrNull(request.getParameter("newpassword"))
+                && !isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
+              if (SecurityContextHolder.getContext().getAuthentication().getAuthorities().contains(MisoAuthority.ROLE_ADMIN)) {
                 // auth'ed user is the account holder or an admin
                 log.info("Admin '" + SecurityContextHolder.getContext().getAuthentication().getName()
                     + "' attempting user password change for user '" + user.getLoginName() + "'");
@@ -220,18 +219,17 @@ public class EditUserController {
           }
         }
       } else {
-        if (!isStringEmptyOrNull(request.getParameter("password"))
-            && !isStringEmptyOrNull(request.getParameter("newpassword"))) {
+        if (!isStringEmptyOrNull(request.getParameter("password")) && !isStringEmptyOrNull(request.getParameter("newpassword"))) {
           if (!isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
             if (request.getParameter("newpassword").equals(request.getParameter("confirmpassword"))) {
-              if (!isStringEmptyOrNull(request.getParameter("newpassword")) && !isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
+              if (!isStringEmptyOrNull(request.getParameter("newpassword"))
+                  && !isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
                 if (SecurityContextHolder.getContext().getAuthentication().getName().equals(user.getLoginName())) {
                   if (passwordCodecService.getEncoder().isPasswordValid(user.getPassword(), request.getParameter("password"), null)) {
                     log.debug("User '" + user.getLoginName() + "' attempting own password change");
                     user.setPassword(request.getParameter("newpassword"));
                   }
-                } else if (SecurityContextHolder.getContext().getAuthentication().getAuthorities()
-                    .contains(new GrantedAuthorityImpl("ROLE_ADMIN"))) {
+                } else if (SecurityContextHolder.getContext().getAuthentication().getAuthorities().contains(MisoAuthority.ROLE_ADMIN)) {
                   // auth'ed user is the account holder or an admin
                   log.info("Admin '" + SecurityContextHolder.getContext().getAuthentication().getName()
                       + "' attempting user password change for user '" + user.getLoginName() + "'");
@@ -267,11 +265,11 @@ public class EditUserController {
   public String processSubmit(@ModelAttribute("user") User user, ModelMap model, SessionStatus session, HttpServletRequest request)
       throws IOException {
     try {
-      if (!isStringEmptyOrNull(request.getParameter("password"))
-          && !isStringEmptyOrNull(request.getParameter("newpassword"))) {
+      if (!isStringEmptyOrNull(request.getParameter("password")) && !isStringEmptyOrNull(request.getParameter("newpassword"))) {
         if (!isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
           if (request.getParameter("newpassword").equals(request.getParameter("confirmpassword"))) {
-            if (!isStringEmptyOrNull(request.getParameter("newpassword")) && !isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
+            if (!isStringEmptyOrNull(request.getParameter("newpassword"))
+                && !isStringEmptyOrNull(request.getParameter("confirmpassword"))) {
               if (SecurityContextHolder.getContext().getAuthentication().getName().equals(user.getLoginName())) {
                 if (passwordCodecService.getEncoder().isPasswordValid(user.getPassword(), request.getParameter("password"), null)) {
                   log.debug("User '" + user.getLoginName() + "' attempting own password change");

--- a/miso-web/src/main/webapp/WEB-INF/ad-security-config.xml
+++ b/miso-web/src/main/webapp/WEB-INF/ad-security-config.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oauth="http://www.springframework.org/schema/security/oauth"
+  xmlns:security="http://www.springframework.org/schema/security"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+                           http://www.springframework.org/schema/security/oauth http://www.springframework.org/schema/security/spring-security-oauth-1.0.xsd
+                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd"
+  default-autowire="byName">
+
+  <!-- *** Declare Active Directory specific beans -->
+
+  <bean id="ldapActiveDirectoryAuthProvider" class="org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider">
+    <constructor-arg value="${security.ad.emailDomain}" /> <!-- Domain name added to username during directory search for user -->
+    <constructor-arg value="${security.ad.url}" /> <!-- Directory url -->
+    <property name="authoritiesMapper" ref="grantedAuthoritiesMapper" />
+    <property name="convertSubErrorCodesToExceptions" value="true" />
+    <property name="userDetailsContextMapper">
+      <!-- Retrieve user as InetOrgPerson as this has details need to populate db User table. Otherwise will be sparse LdapUserDetail. -->
+      <bean class="org.springframework.security.ldap.userdetails.InetOrgPersonContextMapper" />
+    </property>
+  </bean>
+
+  <!-- Map group names with prefix to expected MISO group names. Removes prefix during Spring authentication. -->
+  <bean id="grantedAuthoritiesMapper" class="uk.ac.bbsrc.tgac.miso.core.security.ad.ActiveDirectoryAuthoritiesMapper" />
+
+  <!-- Load as bean to inject group name prefix. Removes prefix when populating database. -->
+  <bean class="uk.ac.bbsrc.tgac.miso.core.security.util.LimsSecurityUtils" />
+
+  <!-- *** Import existing ldap configuration. This one is used with openldap. -->
+
+  <import resource="ldap-security-config.xml" />
+
+  <!-- *** Override the general ldap authentication manager with the Active Directory authentication manager. -->
+  
+  <security:authentication-manager alias="authenticationManager">
+    <security:authentication-provider ref="ldapActiveDirectoryAuthProvider" />
+  </security:authentication-manager>
+
+</beans>

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/DashboardHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/DashboardHelperService.java
@@ -39,7 +39,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.ldap.userdetails.InetOrgPerson;
@@ -62,6 +61,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import uk.ac.bbsrc.tgac.miso.core.event.Alert;
 import uk.ac.bbsrc.tgac.miso.core.event.type.AlertLevel;
 import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
+import uk.ac.bbsrc.tgac.miso.core.security.MisoAuthority;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 
 /**
@@ -98,14 +98,14 @@ public class DashboardHelperService {
               u.setPassword(details.getPassword());
               u.setActive(true);
 
-              if (details.getAuthorities().contains(new GrantedAuthorityImpl("ROLE_ADMIN"))) {
+              if (details.getAuthorities().contains(MisoAuthority.ROLE_ADMIN)) {
                 u.setAdmin(true);
               }
 
-              if (details.getAuthorities().contains(new GrantedAuthorityImpl("ROLE_INTERNAL"))) {
+              if (details.getAuthorities().contains(MisoAuthority.ROLE_INTERNAL)) {
                 u.setInternal(true);
                 u.setRoles(new String[] { "ROLE_INTERNAL" });
-              } else if (details.getAuthorities().contains(new GrantedAuthorityImpl("ROLE_EXTERNAL"))) {
+              } else if (details.getAuthorities().contains(MisoAuthority.ROLE_EXTERNAL)) {
                 u.setExternal(true);
                 u.setRoles(new String[] { "ROLE_EXTERNAL" });
               } else {
@@ -176,7 +176,6 @@ public class DashboardHelperService {
       return JSONUtils.SimpleJSONError("Failed: " + e.getMessage());
     }
   }
-
 
   public JSONObject searchPool(HttpSession session, JSONObject json) {
     String searchStr = json.getString("str");

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/manager/MisoJdbcUserDetailsManager.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/manager/MisoJdbcUserDetailsManager.java
@@ -36,6 +36,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.GrantedAuthorityImpl;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
 
+import uk.ac.bbsrc.tgac.miso.core.security.MisoAuthority;
+
 /**
  * uk.ac.bbsrc.tgac.miso.sqlstore.manager
  * <p/>
@@ -73,9 +75,9 @@ public class MisoJdbcUserDetailsManager extends JdbcUserDetailsManager {
             }
 
             try {
-              if (rs.getBoolean("admin")) roleList.add(new GrantedAuthorityImpl("ROLE_ADMIN"));
-              if (rs.getBoolean("external")) roleList.add(new GrantedAuthorityImpl("ROLE_EXTERNAL"));
-              if (rs.getBoolean("internal")) roleList.add(new GrantedAuthorityImpl("ROLE_INTERNAL"));
+              if (rs.getBoolean("admin")) roleList.add(MisoAuthority.ROLE_ADMIN);
+              if (rs.getBoolean("external")) roleList.add(MisoAuthority.ROLE_EXTERNAL);
+              if (rs.getBoolean("internal")) roleList.add(MisoAuthority.ROLE_INTERNAL);
             } catch (SQLException e) {
               log.error("Couldn't retrieve a user property to convert to a role", e);
             }


### PR DESCRIPTION
Active directory does not return a password. Provide a fake password in this case
it is a requirement of the User service.
Created a separate Active directory configuration file that overrode one bean from the
general ldap configuration file.