### PR TITLE
skip library alias validation during migration

### DIFF
--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/MisoServiceManager.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/MisoServiceManager.java
@@ -31,9 +31,9 @@ import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.factory.TgacDataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.DefaultEntityNamingScheme;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.MisoNamingScheme;
-import uk.ac.bbsrc.tgac.miso.core.service.naming.OicrLibraryNamingScheme;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.OicrSampleAliasGenerator;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.OicrSampleNamingScheme;
+import uk.ac.bbsrc.tgac.miso.migration.util.SimpleLibraryNamingScheme;
 import uk.ac.bbsrc.tgac.miso.persistence.HibernateSampleClassDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateIdentityDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateInstituteDao;
@@ -263,7 +263,7 @@ public class MisoServiceManager {
 
   private MisoNamingScheme<Library> getLibraryNamingScheme() {
     if (libraryNamingScheme == null) {
-      libraryNamingScheme = new OicrLibraryNamingScheme();
+      libraryNamingScheme = new SimpleLibraryNamingScheme();
     }
     return libraryNamingScheme;
   }

--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/util/SimpleLibraryNameGenerator.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/util/SimpleLibraryNameGenerator.java
@@ -1,0 +1,28 @@
+package uk.ac.bbsrc.tgac.miso.migration.util;
+
+import uk.ac.bbsrc.tgac.miso.core.data.Library;
+import uk.ac.bbsrc.tgac.miso.core.service.naming.NameGenerator;
+
+/**
+ * Generates values for the Library 'name' field in format "LIB" + libraryId. e.g. "LIB123"
+ */
+public class SimpleLibraryNameGenerator implements NameGenerator<Library> {
+
+  private static final String NAME_PREFIX = "LIB";
+  
+  @Override
+  public String getGeneratorName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public String generateName(Library t) {
+    return NAME_PREFIX + t.getId();
+  }
+
+  @Override
+  public Class<Library> nameGeneratorFor() {
+    return Library.class;
+  }
+
+}

--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/util/SimpleLibraryNamingScheme.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/util/SimpleLibraryNamingScheme.java
@@ -1,0 +1,85 @@
+package uk.ac.bbsrc.tgac.miso.migration.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import uk.ac.bbsrc.tgac.miso.core.data.Library;
+import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
+import uk.ac.bbsrc.tgac.miso.core.service.naming.MisoNamingScheme;
+import uk.ac.bbsrc.tgac.miso.core.service.naming.NameGenerator;
+
+/**
+ * Simple naming scheme for Libraries. By default uses SimpleLibraryNameGenerator, does not allow
+ * duplicate name or alias, and performs no validation. This configuration may be modified
+ */
+public class SimpleLibraryNamingScheme implements MisoNamingScheme<Library> {
+
+  Map<String, NameGenerator<Library>> nameGenerators = new HashMap<>();
+  Map<String, String> validationMap = new HashMap<>();
+  Map<String, Boolean> allowDuplicatesMap = new HashMap<>();
+  
+  public SimpleLibraryNamingScheme() {
+    allowDuplicatesMap.put("name", false);
+    allowDuplicatesMap.put("alias", false);
+    nameGenerators.put("name", new SimpleLibraryNameGenerator());
+  }
+  
+  @Override
+  public Class<Library> namingSchemeFor() {
+    return Library.class;
+  }
+
+  @Override
+  public String getSchemeName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public String generateNameFor(String field, Library library) throws MisoNamingException {
+    NameGenerator<Library> generator = nameGenerators.get(field);
+    if (generator == null) throw new MisoNamingException("No name generator for field " + field);
+    return generator.generateName(library);
+  }
+
+  @Override
+  public void setValidationRegex(String fieldName, String validationRegex) throws MisoNamingException {
+    validationMap.put(fieldName, validationRegex);
+  }
+
+  @Override
+  public String getValidationRegex(String fieldName) throws MisoNamingException {
+    return validationMap.get(fieldName);
+  }
+
+  @Override
+  public boolean validateField(String fieldName, String entityName) throws MisoNamingException {
+    String regex = validationMap.get(fieldName);
+    return regex == null ? true : entityName.matches(regex);
+  }
+
+  @Override
+  public void registerCustomNameGenerator(String fieldName, NameGenerator<Library> nameGenerator) {
+    nameGenerators.put(fieldName, nameGenerator);
+  }
+
+  @Override
+  public void unregisterCustomNameGenerator(String fieldName) {
+    nameGenerators.remove(fieldName);
+  }
+
+  @Override
+  public boolean allowDuplicateEntityNameFor(String fieldName) {
+    return allowDuplicatesMap.containsKey(fieldName) ? allowDuplicatesMap.get(fieldName) : false;
+  }
+
+  @Override
+  public void setAllowDuplicateEntityName(String fieldName, boolean allow) {
+    allowDuplicatesMap.put(fieldName, allow);
+  }
+
+  @Override
+  public boolean hasGeneratorFor(String fieldName) {
+    return nameGenerators.containsKey(fieldName);
+  }
+
+}

--- a/migration/src/main/resources/load-generator.properties
+++ b/migration/src/main/resources/load-generator.properties
@@ -18,7 +18,7 @@ target.db.user=username
 target.db.pass=password
 
 # NOTE: Naming schemes are not yet configurable here. This is informational only.
-# Naming schemes: OicrSampleNamingScheme, OicrLibraryNamingScheme, DefaultEntityNamingScheme
+# Naming schemes: OicrSampleNamingScheme, SimpleLibraryNamingScheme, DefaultEntityNamingScheme
 # Name generators: OicrSampleAliasGenerator
 # Barcodes: NOT auto-generated
 


### PR DESCRIPTION
During migration, library alias validation must be skipped, and names such 'LIB123' must be generated. It was not possible to configure the existing naming schemes to achieve this, so I created a very simple one to use for migration instead