### PR TITLE
Switch to RollingFileAppender and reduce ehcache log level

### DIFF
--- a/miso-web/src/main/webapp/WEB-INF/log4j.miso.properties
+++ b/miso-web/src/main/webapp/WEB-INF/log4j.miso.properties
@@ -25,32 +25,37 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%p [%c{1}]: %m%n
 
-log4j.appender.daoFileAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.daoFileAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.daoFileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.daoFileAppender.MaxFileSize=100MB
+log4j.appender.daoFileAppender.MaxBackupIndex=4
 log4j.appender.daoFileAppender.File=${miso.baseDirectory}log/dao_update.log
 log4j.appender.daoFileAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.daoFileAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %p: %m%n
 
-log4j.appender.notificationFileAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.notificationFileAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.notificationFileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.notificationFileAppender.MaxBackupIndex=4
+log4j.appender.notificationFileAppender.MaxFileSize=100MB
 log4j.appender.notificationFileAppender.File=${miso.baseDirectory}log/notification.log
 log4j.appender.notificationFileAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.notificationFileAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %p: %m%n
 
-log4j.appender.limsFileAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.limsFileAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.limsFileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.limsFileAppender.MaxBackupIndex=4
+log4j.appender.limsFileAppender.MaxFileSize=100MB
 log4j.appender.limsFileAppender.File=${miso.baseDirectory}log/lims_update.log
 log4j.appender.limsFileAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.limsFileAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %p: %m%n
 
-log4j.appender.cacheFileAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.cacheFileAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.cacheFileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.cacheFileAppender.MaxBackupIndex=4
+log4j.appender.cacheFileAppender.MaxFileSize=100MB
 log4j.appender.cacheFileAppender.File=${miso.baseDirectory}log/ehcache.log
 log4j.appender.cacheFileAppender.layout = org.apache.log4j.PatternLayout
 log4j.appender.cacheFileAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %p: %m%n
 
-log4j.appender.debugFileAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.debugFileAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.debugFileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.debugFileAppender.MaxBackupIndex=4
+log4j.appender.debugFileAppender.MaxFileSize=100MB
 log4j.appender.debugFileAppender.File=${miso.baseDirectory}log/miso_debug.log
 log4j.appender.debugFileAppender.layout = org.apache.log4j.PatternLayout
 log4j.appender.debugFileAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %p: %m%n
@@ -58,17 +63,18 @@ log4j.appender.debugFileAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss
 #log4j.rootLogger=INFO, stdout
 log4j.rootLogger=INFO, debugFileAppender
 
-log4j.logger.net.sf.ehcache=DEBUG, cacheFileAppender
+log4j.logger.net.sf.ehcache=ERROR, cacheFileAppender
 log4j.additivity.net.sf.ehcache=false
-log4j.logger.net.sf.ehcache.config=DEBUG, cacheFileAppender
+log4j.logger.net.sf.ehcache.config=ERROR, cacheFileAppender
 log4j.additivity.net.sf.ehcache.config=false
-log4j.logger.net.sf.ehcache.distribution=DEBUG, cacheFileAppender
+log4j.logger.net.sf.ehcache.distribution=ERROR, cacheFileAppender
 log4j.additivity.net.sf.ehcache.distribution=false
-log4j.logger.net.sf.ehcache.code=DEBUG, cacheFileAppender
+log4j.logger.net.sf.ehcache.code=ERROR, cacheFileAppender
 log4j.additivity.net.sf.ehcache.code=false
 
-net.sf.ehcache.pool.sizeof=INFO, cacheFileAppender
-log4j.category.com.googlecode.ehcache.annotations=INFO, cacheFileAppender
+log4j.logger.net.sf.ehcache.pool.sizeof=ERROR, cacheFileAppender
+log4j.additivity.net.sf.ehcache.pool.sizeof=false
+log4j.category.com.googlecode.ehcache.annotations=ERROR, cacheFileAppender
 log4j.additivity.com.googlecode.ehcache.annotations=false
 
 log4j.logger.requestFileLogger=DEBUG, daoFileAppender


### PR DESCRIPTION
While date-based searching is nice, there's not automatic way to expire old
logs and log files can grow to an unbounded size. In particular, production
`ehcache.log` files can be large (over 1G) and tend to consume more prod disk
than they are worth. This will limit each log to 500GB and automaticall remove
old logs.