### PR TITLE
GLT-1038 set null if attribute string is blank

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
@@ -23,6 +23,8 @@
 
 package uk.ac.bbsrc.tgac.miso.core.data;
 
+import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.nullifyStringIfBlank;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -203,7 +205,7 @@ public abstract class AbstractLibrary extends AbstractBoxable implements Library
 
   @Override
   public void setIdentificationBarcode(String identificationBarcode) {
-    this.identificationBarcode = identificationBarcode;
+    this.identificationBarcode = nullifyStringIfBlank(identificationBarcode);
   }
 
   @Override
@@ -213,7 +215,7 @@ public abstract class AbstractLibrary extends AbstractBoxable implements Library
 
   @Override
   public void setLocationBarcode(String locationBarcode) {
-    this.locationBarcode = locationBarcode;
+    this.locationBarcode = nullifyStringIfBlank(locationBarcode);
   }
 
   @CoverageIgnore
@@ -333,7 +335,7 @@ public abstract class AbstractLibrary extends AbstractBoxable implements Library
 
   @Override
   public void setPlatformName(String platformName) {
-    this.platformName = platformName;
+    this.platformName = nullifyStringIfBlank(platformName);
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractPool.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractPool.java
@@ -23,6 +23,8 @@
 
 package uk.ac.bbsrc.tgac.miso.core.data;
 
+import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.nullifyStringIfBlank;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -255,7 +257,7 @@ public abstract class AbstractPool<P extends Poolable<?, ?>> extends AbstractBox
 
   @Override
   public void setIdentificationBarcode(String identificationBarcode) {
-    this.identificationBarcode = identificationBarcode;
+    this.identificationBarcode = nullifyStringIfBlank(identificationBarcode);
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
@@ -23,13 +23,12 @@
 
 package uk.ac.bbsrc.tgac.miso.core.data;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.nullifyStringIfBlank;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.TreeSet;
 
 import javax.persistence.GeneratedValue;
@@ -43,8 +42,6 @@ import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Transient;
 
 import org.codehaus.jackson.annotate.JsonManagedReference;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -53,7 +50,6 @@ import com.eaglegenomics.simlims.core.Note;
 import com.eaglegenomics.simlims.core.SecurityProfile;
 import com.eaglegenomics.simlims.core.User;
 
-import uk.ac.bbsrc.tgac.miso.core.data.impl.IdentityImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleDerivedInfo;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
@@ -61,7 +57,6 @@ import uk.ac.bbsrc.tgac.miso.core.exception.MalformedLibraryException;
 import uk.ac.bbsrc.tgac.miso.core.exception.MalformedSampleException;
 import uk.ac.bbsrc.tgac.miso.core.exception.MalformedSampleQcException;
 import uk.ac.bbsrc.tgac.miso.core.security.SecurableByProfile;
-import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 
 /**
  * Skeleton implementation of a Sample
@@ -124,7 +119,6 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
   @OneToOne(targetEntity = SampleDerivedInfo.class)
   @PrimaryKeyJoinColumn
   private SampleDerivedInfo derivedInfo;
-
 
   @Override
   public User getLastModifier() {
@@ -203,7 +197,7 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
 
   @Override
   public void setTaxonIdentifier(String taxonIdentifier) {
-    this.taxonIdentifier = taxonIdentifier;
+    this.taxonIdentifier = nullifyStringIfBlank(taxonIdentifier);
   }
 
   @Override
@@ -223,7 +217,7 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
 
   @Override
   public void setIdentificationBarcode(String identificationBarcode) {
-    this.identificationBarcode = identificationBarcode;
+    this.identificationBarcode = nullifyStringIfBlank(identificationBarcode);
   }
 
   @Override
@@ -233,7 +227,7 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
 
   @Override
   public void setLocationBarcode(String locationBarcode) {
-    this.locationBarcode = locationBarcode;
+    this.locationBarcode = nullifyStringIfBlank(locationBarcode);
   }
 
   @Override
@@ -288,7 +282,7 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
 
   @Override
   public void setSampleType(String sampleType) {
-    this.sampleType = sampleType;
+    this.sampleType = nullifyStringIfBlank(sampleType);
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAdditionalInfoImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleAdditionalInfoImpl.java
@@ -1,5 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.core.data.impl;
 
+import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.nullifyStringIfBlank;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -161,7 +163,7 @@ public class SampleAdditionalInfoImpl extends SampleImpl implements SampleAdditi
 
   @Override
   public void setGroupId(String groupId) {
-    this.groupId = groupId;
+    this.groupId = nullifyStringIfBlank(groupId);
   }
 
   @Override
@@ -171,7 +173,7 @@ public class SampleAdditionalInfoImpl extends SampleImpl implements SampleAdditi
 
   @Override
   public void setGroupDescription(String groupDescription) {
-    this.groupDescription = groupDescription;
+    this.groupDescription = nullifyStringIfBlank(groupDescription);
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleTissueImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SampleTissueImpl.java
@@ -1,5 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.core.data.impl;
 
+import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.nullifyStringIfBlank;
+
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
@@ -88,7 +90,7 @@ public class SampleTissueImpl extends SampleAdditionalInfoImpl implements Sample
 
   @Override
   public void setExternalInstituteIdentifier(String externalInstituteIdentifier) {
-    this.externalInstituteIdentifier = externalInstituteIdentifier;
+    this.externalInstituteIdentifier = nullifyStringIfBlank(externalInstituteIdentifier);
   }
 
   @Override
@@ -103,7 +105,7 @@ public class SampleTissueImpl extends SampleAdditionalInfoImpl implements Sample
 
   @Override
   public void setRegion(String region) {
-    this.region = region;
+    this.region = nullifyStringIfBlank(region);
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtils.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtils.java
@@ -156,13 +156,15 @@ public class LimsUtils {
     return s == null || "".equals(s.trim());
   }
 
+  public static String nullifyStringIfBlank(String s) {
+    return (isStringBlankOrNull(s) ? null : s);
+  }
+
   /**
    * Join a collection, akin to Perl's join(), using a given delimiter to produce a single String
    * 
-   * @param s
-   *          of type Collection
-   * @param delimiter
-   *          of type String
+   * @param s of type Collection
+   * @param delimiter of type String
    * @return String
    * @throws IllegalArgumentException
    */
@@ -184,10 +186,8 @@ public class LimsUtils {
   /**
    * Join an Array, akin to Perl's join(), using a given delimiter to produce a single String
    * 
-   * @param s
-   *          of type Object[]
-   * @param delimiter
-   *          of type String
+   * @param s of type Object[]
+   * @param delimiter of type String
    * @return String
    */
   public static String join(Object[] s, String delimiter) {
@@ -244,10 +244,8 @@ public class LimsUtils {
   /**
    * Computes the relative complement of two sets, i.e. those elements that are in A but not in B
    * 
-   * @param needles
-   *          of type Set
-   * @param haystack
-   *          of type Set
+   * @param needles of type Set
+   * @param haystack of type Set
    * @return Set
    */
   public static Set relativeComplement(Set needles, Set haystack) {
@@ -266,12 +264,9 @@ public class LimsUtils {
    * <p/>
    * If an exception occurs, null is returned.
    * 
-   * @param c
-   *          of type Class
-   * @param needles
-   *          of type Set
-   * @param haystack
-   *          of type Set
+   * @param c of type Class
+   * @param needles of type Set
+   * @param haystack of type Set
    * @return Set
    */
   public static Set relativeComplementByProperty(Class c, String methodName, Set needles, Set haystack) {
@@ -445,13 +440,10 @@ public class LimsUtils {
    * Checks that a directory exists. This method will attempt to create the directory if it doesn't exist and if the attemptMkdir flag is
    * true
    * 
-   * @param path
-   *          of type File
-   * @param attemptMkdir
-   *          of type boolean
+   * @param path of type File
+   * @param attemptMkdir of type boolean
    * @return boolean true if the directory exists/was created, false if not
-   * @throws IOException
-   *           when the directory exist check/creation could not be completed
+   * @throws IOException when the directory exist check/creation could not be completed
    */
   public static boolean checkDirectory(File path, boolean attemptMkdir) throws IOException {
     boolean storageOk;
@@ -482,11 +474,9 @@ public class LimsUtils {
   /**
    * Similar to checkDirectory, but for single files.
    * 
-   * @param path
-   *          of type File
+   * @param path of type File
    * @return boolean true if the file exists, false if not
-   * @throws IOException
-   *           when the file doesn't exist
+   * @throws IOException when the file doesn't exist
    */
   public static boolean checkFile(File path) throws IOException {
     boolean storageOk = path.exists();
@@ -502,11 +492,9 @@ public class LimsUtils {
   /**
    * Helper method to parse and store output from a given process' stdout and stderr
    * 
-   * @param process
-   *          of type Process
+   * @param process of type Process
    * @return Map<String, String>
-   * @throws IOException
-   *           when
+   * @throws IOException when
    */
   public static Map<String, String> checkPipes(Process process) throws IOException {
     HashMap<String, String> r = new HashMap<String, String>();
@@ -538,11 +526,9 @@ public class LimsUtils {
   /**
    * Reads the contents of an InputStream into a String
    * 
-   * @param in
-   *          of type InputStream
+   * @param in of type InputStream
    * @return String
-   * @throws IOException
-   *           when
+   * @throws IOException when
    */
   public static String inputStreamToString(InputStream in) throws IOException {
     StringBuilder sb = new StringBuilder();
@@ -557,11 +543,9 @@ public class LimsUtils {
   /**
    * Reads the contents of an File into a String
    * 
-   * @param f
-   *          of type File
+   * @param f of type File
    * @return String
-   * @throws IOException
-   *           when
+   * @throws IOException when
    */
   public static String fileToString(File f) throws IOException {
     StringBuilder sb = new StringBuilder();
@@ -583,11 +567,9 @@ public class LimsUtils {
   /**
    * Reads the contents of an InputStream into a byte[]
    * 
-   * @param in
-   *          of type InputStream
+   * @param in of type InputStream
    * @return byte[]
-   * @throws IOException
-   *           when
+   * @throws IOException when
    */
   public static byte[] inputStreamToByteArray(InputStream in) throws IOException {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
@@ -603,11 +585,9 @@ public class LimsUtils {
   /**
    * Process stdout from a given Process and concat it to a single String
    * 
-   * @param p
-   *          of type Process
+   * @param p of type Process
    * @return String
-   * @throws IOException
-   *           when
+   * @throws IOException when
    */
   private static String processStdOut(Process p) throws IOException {
     return inputStreamToString(p.getInputStream());
@@ -616,11 +596,9 @@ public class LimsUtils {
   /**
    * Process stderr from a given Process and concat it to a single String
    * 
-   * @param p
-   *          of type Process
+   * @param p of type Process
    * @return String
-   * @throws IOException
-   *           when
+   * @throws IOException when
    */
   private static String processStdErr(Process p) throws IOException {
     return inputStreamToString(p.getErrorStream());
@@ -805,7 +783,9 @@ public class LimsUtils {
     if (!isDetailedSample(child) || !isDetailedSample(parent)) {
       return false;
     }
-    return isValidRelationship(relations, ((SampleAdditionalInfo) parent).getSampleClass(),
+    return isValidRelationship(
+        relations,
+        ((SampleAdditionalInfo) parent).getSampleClass(),
         ((SampleAdditionalInfo) child).getSampleClass());
   }
 
@@ -896,7 +876,7 @@ public class LimsUtils {
     if (!isDetailedSample(sample)) return false;
     return sample instanceof SampleTissue;
   }
-  
+
   public static boolean isTissueProcessingSample(Sample sample) {
     if (!isDetailedSample(sample)) return false;
     return sample instanceof SampleTissueProcessing;

--- a/core/src/test/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtilsTest.java
+++ b/core/src/test/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtilsTest.java
@@ -1,5 +1,6 @@
 package uk.ac.bbsrc.tgac.miso.core.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -15,15 +16,26 @@ public class LimsUtilsTest {
   public void testValidateRelationshipForSimpleSample() throws Exception {
     Sample child = new SampleImpl(); // Simple sample has no SampleAdditionalInfo.
     Sample parent = null; // Simple sample has no parent.
-    assertTrue("Simple sample with a null parent and null SampleAdditionalInfo is a valid relationship",
+    assertTrue(
+        "Simple sample with a null parent and null SampleAdditionalInfo is a valid relationship",
         LimsUtils.isValidRelationship(null, parent, child));
   }
 
   @Test
   public void testInstanceOfSampleTissueProcessing() throws Exception {
     SampleCVSlide cvSlide = new SampleCVSlideImpl();
-    assertTrue("CV Slide is a type of Tissue Processing",
-        LimsUtils.isTissueProcessingSample(cvSlide));
+    assertTrue("CV Slide is a type of Tissue Processing", LimsUtils.isTissueProcessingSample(cvSlide));
   }
 
+  @Test
+  public void testNullifyStringIfBlankIsBlank() throws Exception {
+    String nullString = null;
+    assertEquals(nullString, LimsUtils.nullifyStringIfBlank("     "));
+  }
+
+  @Test
+  public void testNullifyStringIfBlankNotBlank() throws Exception {
+    String notNullString = "not null";
+    assertEquals(notNullString, LimsUtils.nullifyStringIfBlank("not null"));
+  }
 }


### PR DESCRIPTION
When Samples and Libraries are created through the Edit Sample/Edit Library page, empty fields were saved to the database as empty strings. This fix checks if the value being set is a blank string and if it is, the value is set to null.