### PR TITLE
GLT-1042 add ctrl-v message to HOT pages

### DIFF
--- a/miso-web/src/main/webapp/pages/bulkEditDilutions.jsp
+++ b/miso-web/src/main/webapp/pages/bulkEditDilutions.jsp
@@ -60,6 +60,9 @@
   <br/>
 
  <div id="HOTbulkForm" data-detailed-sample="${detailedSample}">
+   <div id="ctrlV" class="note">
+     <p>Paste values using Ctrl + V in Windows or Linux, or Command-V (&#8984;-V) on a Mac.</p>
+   </div>
  
    <div id="saveSuccesses"  class="parsley-success hidden">
      <p id="successMessages"></p>

--- a/miso-web/src/main/webapp/pages/bulkEditLibraries.jsp
+++ b/miso-web/src/main/webapp/pages/bulkEditLibraries.jsp
@@ -63,6 +63,10 @@
    <div id="nonStandardAliasNote" class="table-note hidden">
       <p>Aliases highlighted in yellow are non-standard, and any value you give them will be saved.</p>
     </div>
+
+   <div id="ctrlV" class="note">
+     <p>Paste values using Ctrl + V in Windows or Linux, or Command-V (&#8984;-V) on a Mac.</p>
+   </div>
  
    <div id="saveSuccesses"  class="parsley-success hidden">
      <p id="successMessages"></p>

--- a/miso-web/src/main/webapp/pages/bulkEditSamples.jsp
+++ b/miso-web/src/main/webapp/pages/bulkEditSamples.jsp
@@ -66,6 +66,10 @@
 	    <p>Aliases highlighted in yellow are non-standard, and any value you enter will be saved.</p>
 	    <br/>
 	  </div>
+
+      <div id="ctrlV" class="note">
+        <p>Paste values using Ctrl + V in Windows or Linux, or Command-V (&#8984;-V) on a Mac.</p>
+      </div>
 	
 		<div id="saveSuccesses"  class="parsley-success hidden">
 	    <p id="successMessages"></p>
@@ -104,6 +108,15 @@
         Sample.hot.newSamplesJSON = Sample.hot.modifySamplesForPropagate(Sample.hot.samplesJSON);
         var targetSampleCategory = Sample.hot.getCategoryFromClassId(Sample.hot.newSamplesJSON[0].sampleClassId);
         Sample.hot.makeHOT(Sample.hot.newSamplesJSON, 'propagate', sourceSampleCategory, targetSampleCategory);
+        Hot.hotTable.updateSettings({
+          cells: function (row, col, prop) {
+            var cellProperties = {};
+            if (prop == 'sampleClassAlias') {
+              cellProperties.readOnly = false;
+            }
+            return cellProperties;
+          }
+        });
       };
 
 	    // get SampleOptions and make the appropriate table

--- a/miso-web/src/main/webapp/pages/editSample.jsp
+++ b/miso-web/src/main/webapp/pages/editSample.jsp
@@ -739,6 +739,9 @@
   <br/>
 
   <div id="HOTbulkForm" data-detailed-sample="${detailedSample}">
+    <div id="ctrlV" class="note">
+      <p>Paste values using Ctrl + V in Windows or Linux, or Command-V (&#8984;-V) on a Mac.</p>
+    </div>
     <div class="floatleft">
 	    <div>Project:<select id="projectSelect"></select></div>
 	    <div id="subpSelectOptions"></div>


### PR DESCRIPTION
Right-click to paste does not work, so make it very obvious to users what they need to do to paste data.