### PR TITLE
GLT-1060 correct handling of nonstandardalias on editLibrary JSP

### DIFF
--- a/miso-web/src/main/webapp/pages/editLibrary.jsp
+++ b/miso-web/src/main/webapp/pages/editLibrary.jsp
@@ -210,7 +210,7 @@
     </c:choose>
 
     <span id="aliasCounter" class="counter"></span>
-    <c:if test="${detailedSample && library.hasNonStandardAlias()}">
+    <c:if test="${detailedSample && library.libraryAdditionalInfo.hasNonStandardAlias()}">
       <ul class="parsley-errors-list filled" id="nonStandardAlias">
         <li class="parsley-custom-error-message">
         Double-check this alias -- it will be saved even if it is duplicated or does not follow the naming standard!


### PR DESCRIPTION
The method is on the LibraryAdditionalInfo object, not on the Library object.