### PR TITLE
GLT-1078 check for selected samples right before changing page

### DIFF
--- a/miso-web/src/main/webapp/scripts/sample_ajax.js
+++ b/miso-web/src/main/webapp/scripts/sample_ajax.js
@@ -1245,6 +1245,16 @@ Sample.ui = {
       jQuery('#errors').css('display', 'block');
       return false;
     }
+    // do another check for which samples have been selected
+    Sample.selectedIdsArray = Sample.ui.getSelectedIds();
+    if (Sample.selectedIdsArray.length === 0) {
+      alert("Please select one or more Samples.");
+      return false;
+    }
+    if (Sample.ui.getUniqueCategoriesForSelected().length !== 1) {
+      Sample.ui.displayMultipleCategoriesError();
+      return false;
+    }
     window.location="sample/bulk/create/" + Sample.selectedIdsArray.join(',') + "&scid=" + selectedClassId;
   },
   


### PR DESCRIPTION
fixes bug where users could select more samples after selecting the sample class for child samples, but those additional selections wouldn't be carried over to the propagate page.