### PR TITLE
Add uniqueness contraints to boxPositionId columns (GLT-1121)

### DIFF
--- a/sqlstore/src/main/resources/db/migration/V8001__box_position_unique.sql
+++ b/sqlstore/src/main/resources/db/migration/V8001__box_position_unique.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Library ADD CONSTRAINT library_boxPositionId_unique UNIQUE (boxPositionId);
+ALTER TABLE Pool ADD CONSTRAINT pool_boxPositionId_unique UNIQUE (boxPositionId);
+ALTER TABLE Sample ADD CONSTRAINT sample_boxPositionId_unique UNIQUE (boxPositionId);


### PR DESCRIPTION
This is to reduce the presentation of a race condition where concurrent
sample/library creation leads to duplicate boxPositionIds. This neither fixes
the underlying race condition in `nextval` nor ensures that there isn't a race
between a sample and a library.