### PR TITLE
GLT-1130 don't obliterate poolables when saving pool

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractPool.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractPool.java
@@ -27,6 +27,7 @@ import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.nullifyStringIfBlank;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -82,7 +83,7 @@ public abstract class AbstractPool<P extends Poolable<?, ?>> extends AbstractBox
   private String name;
   private String description;
 
-  private final Collection<P> pooledElements = new HashSet<P>();
+  private Collection<P> pooledElements = new HashSet<P>();
   private Collection<Experiment> experiments = new HashSet<Experiment>();
   private Date creationDate;
   private Double concentration;
@@ -164,22 +165,14 @@ public abstract class AbstractPool<P extends Poolable<?, ?>> extends AbstractBox
     pooledElements.add(poolable);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   @JsonDeserialize(using = PooledElementDeserializer.class)
   public <T extends Poolable> void setPoolableElements(Collection<T> poolables) {
-    this.pooledElements.clear();
-    if (poolables != null && !poolables.isEmpty()) {
-      for (T poolable : poolables) {
-        if (poolable != null) {
-          if (poolable instanceof Poolable) {
-            this.pooledElements.add((P) poolable);
-          } else {
-            log.error(poolable.getClass().getName());
-          }
-        } else {
-          log.error("Null poolable");
-        }
-      }
+    if (poolables == null) {
+      this.pooledElements = Collections.emptySet();
+    } else {
+      this.pooledElements = (Collection<P>) poolables;
     }
   }
 

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLPoolDAOTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -591,6 +592,7 @@ public class SQLPoolDAOTest extends AbstractDAOTest {
     User user = new UserImpl();
     user.setUserId(1L);
     oldPool.setLastModifier(user);
+    oldPool.setPoolableElements(null);
     Mockito.when(namingScheme.validateField(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
 
     assertEquals(1L, dao.save(oldPool));


### PR DESCRIPTION
(note: this work is based off GLT-1127, and will be rebased when #442 is merged)