### PR TITLE
GLT-1180 DB and SampleService changes

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Identity.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Identity.java
@@ -4,16 +4,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface Identity extends DetailedSample {
   
   public static final String CATEGORY_NAME = "Identity";
 
-  String getInternalName();
-
-  void setInternalName(String internalName);
-
   String getExternalName();
+
+  Set<String> getExternalNameSet();
 
   void setExternalName(String externalName);
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/DetailedSampleBuilder.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/DetailedSampleBuilder.java
@@ -16,12 +16,12 @@ import com.google.common.collect.Lists;
 
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractSample;
 import uk.ac.bbsrc.tgac.miso.core.data.ChangeLog;
+import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.core.data.Lab;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
 import uk.ac.bbsrc.tgac.miso.core.data.QcPassedDetail;
-import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleAliquot;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleCVSlide;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
@@ -87,7 +87,6 @@ public class DetailedSampleBuilder implements DetailedSample, SampleAliquot, Sam
   private Integer siblingNumber;
 
   // Identity attributes
-  private String internalName;
   private String externalName;
   private DonorSex donorSex = DonorSex.UNKNOWN;
 
@@ -523,18 +522,13 @@ public class DetailedSampleBuilder implements DetailedSample, SampleAliquot, Sam
   }
 
   @Override
-  public String getInternalName() {
-    return internalName;
-  }
-
-  @Override
-  public void setInternalName(String internalName) {
-    this.internalName = internalName;
-  }
-
-  @Override
   public String getExternalName() {
     return externalName;
+  }
+
+  @Override
+  public Set<String> getExternalNameSet() {
+    throw new UnsupportedOperationException("Method not implemented on builder");
   }
 
   @Override
@@ -832,7 +826,6 @@ public class DetailedSampleBuilder implements DetailedSample, SampleAliquot, Sam
     switch (sampleClass.getSampleCategory()) {
     case Identity.CATEGORY_NAME:
       Identity identity = new IdentityImpl();
-      identity.setInternalName(internalName);
       identity.setExternalName(externalName);
       identity.setDonorSex(donorSex);
       sample = identity;
@@ -881,7 +874,6 @@ public class DetailedSampleBuilder implements DetailedSample, SampleAliquot, Sam
         throw new NullPointerException("Missing externalName");
       }
       identity.setExternalName(externalName);
-      identity.setInternalName(internalName);
       identity.setDonorSex(donorSex);
       if (SampleTissue.CATEGORY_NAME.equals(sampleClass.getSampleCategory())) {
         sample.setParent(identity);

--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/source/LoadGeneratorSource.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/source/LoadGeneratorSource.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import org.apache.log4j.Logger;
 import org.springframework.format.datetime.DateFormatter;
 
+import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.LibraryAdditionalInfo;
@@ -17,7 +18,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.Pool;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
 import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
-import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleAliquot;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleStock;
@@ -257,7 +257,6 @@ public class LoadGeneratorSource implements MigrationSource {
     sample.setScientificName(SCIENTIFIC_NAME);
     sample.setSampleClass(sampleClass);
     sample.setExternalName(sample.getAlias());
-    sample.setInternalName(sample.getAlias());
 
     return sample;
   }

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Sets;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Box;
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
+import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.Dilution;
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.core.data.Index;
@@ -42,7 +43,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.Poolable;
 import uk.ac.bbsrc.tgac.miso.core.data.QcPassedDetail;
 import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
-import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleAliquot;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleCVSlide;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
@@ -62,6 +62,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.TissueMaterial;
 import uk.ac.bbsrc.tgac.miso.core.data.TissueOrigin;
 import uk.ac.bbsrc.tgac.miso.core.data.TissueType;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.BoxImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.DetailedSampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.IdentityImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.InstituteImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LabImpl;
@@ -71,7 +72,6 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolOrderImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.QcPassedDetailImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.DetailedSampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAliquotImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleCVSlideImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleClassImpl;
@@ -590,7 +590,6 @@ public class Dtos {
 
   private static SampleIdentityDto asIdentitySampleDto(Identity from) {
     SampleIdentityDto dto = new SampleIdentityDto();
-    dto.setInternalName(from.getInternalName());
     dto.setExternalName(from.getExternalName());
     dto.setDonorSex(from.getDonorSex().getLabel());
     return dto;
@@ -598,7 +597,6 @@ public class Dtos {
 
   private static Identity toIdentitySample(SampleIdentityDto from) {
     Identity to = new IdentityImpl();
-    to.setInternalName(from.getInternalName());
     to.setExternalName(from.getExternalName());
     if (from.getDonorSex() != null) {
       to.setDonorSex(from.getDonorSex());

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleService.java
@@ -1,7 +1,10 @@
 package uk.ac.bbsrc.tgac.miso.service;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
+
+import org.hibernate.exception.ConstraintViolationException;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
@@ -30,6 +33,7 @@ public interface SampleService {
 
   Long countBySearch(String querystr) throws IOException;
 
-  Identity getIdentityByExternalName(String externalName) throws IOException;
+  Collection<Identity> getIdentitiesByExternalName(String externalName) throws IOException;
 
+  boolean confirmExternalNameUniqueForProjectIfRequired(String externalNames, Sample sample) throws IOException, ConstraintViolationException;
 }

--- a/miso-service/src/test/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleServiceTestSuite.java
+++ b/miso-service/src/test/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleServiceTestSuite.java
@@ -11,12 +11,14 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -25,10 +27,10 @@ import com.eaglegenomics.simlims.core.SecurityProfile;
 import com.eaglegenomics.simlims.core.User;
 import com.google.common.collect.Lists;
 
+import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
-import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleStock;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleTissue;
@@ -263,6 +265,8 @@ public class DefaultSampleServiceTestSuite {
     shellParent.setExternalName(parent.getExternalName());
     shellParent.setSecurityProfile(parent.getSecurityProfile());
     shellParent.getSecurityProfile().setOwner(mockUser());
+    Long shellParentId = 88L;
+    shellParent.setId(shellParentId);
     child.setParent(shellParent);
 
     Long newId = 89L;
@@ -272,6 +276,7 @@ public class DefaultSampleServiceTestSuite {
 
     Mockito.when(sampleDao.addSample(Mockito.any(Sample.class))).thenReturn(newId);
     Mockito.when(sampleDao.getSample(newId)).thenReturn(postSave);
+    Mockito.when(sampleDao.getSample(shellParentId)).thenReturn(parent);
     mockValidRelationship(parent.getSampleClass(), child.getSampleClass());
 
     sut.create(child);
@@ -342,6 +347,7 @@ public class DefaultSampleServiceTestSuite {
 
     Identity shellIdentity = new IdentityImpl();
     shellIdentity.setExternalName(identity.getExternalName());
+    shellIdentity.setId(identity.getId());
     tissue.setParent(shellIdentity);
 
     SampleStock analyte = makeUnsavedChildStock();
@@ -437,6 +443,53 @@ public class DefaultSampleServiceTestSuite {
     assertEquals("Sample name should NOT be modifiable", old.getName(), result.getName());
   }
 
+  @Test
+  public void testUniqueExternalNamePerProjectTest() throws IOException {
+    Project project = new ProjectImpl();
+    project.setId(1L);
+    Set<Identity> idList = new HashSet<Identity>();
+    Identity id1 = new IdentityImpl();
+    id1.setExternalName("String1,String2");
+    id1.setProject(project);
+    idList.add(id1);
+    Mockito.when(sut.getIdentitiesByExternalName(Matchers.anyString())).thenReturn(idList);
+    Sample newSample = new SampleImpl();
+    newSample.setProject(project);
+    assertTrue(sut.confirmExternalNameUniqueForProjectIfRequired("String3", newSample));
+  }
+
+  @Test
+  public void testNonUniqueExternalNamePerProjectFailTest() throws IOException {
+    Project project = new ProjectImpl();
+    project.setId(1L);
+    Set<Identity> idList = new HashSet<Identity>();
+    Identity id1 = new IdentityImpl();
+    id1.setExternalName("String1,String2");
+    id1.setProject(project);
+    idList.add(id1);
+    Mockito.when(sut.getIdentitiesByExternalName(Matchers.anyString())).thenReturn(idList);
+    Sample newSample = new SampleImpl();
+    newSample.setProject(project);
+    exception.expect(ConstraintViolationException.class);
+    sut.confirmExternalNameUniqueForProjectIfRequired("String1", newSample);
+  }
+
+  @Test
+  public void testNonUniqueExternalNamePerProjectPassTest() throws IOException {
+    Project project = new ProjectImpl();
+    project.setId(1L);
+    Set<Identity> idList = new HashSet<Identity>();
+    Identity id1 = new IdentityImpl();
+    id1.setExternalName("String1,String2");
+    id1.setProject(project);
+    idList.add(id1);
+    sut.setUniqueExternalNameWithinProjectRequired(false);
+    Mockito.when(sut.getIdentitiesByExternalName(Matchers.anyString())).thenReturn(idList);
+    Sample newSample = new SampleImpl();
+    newSample.setProject(project);
+    assertTrue(sut.confirmExternalNameUniqueForProjectIfRequired("String1", newSample));
+  }
+
   private Sample makePlainSample() {
     Sample sample = new SampleImpl();
     sample.setId(77L);
@@ -448,7 +501,6 @@ public class DefaultSampleServiceTestSuite {
   private Identity makeParentIdentityWithLookup() throws IOException {
     Identity sample = makeUnsavedParentIdentity();
     Mockito.when(sampleDao.getSample(sample.getId())).thenReturn(sample);
-    Mockito.when(sampleDao.getIdentityByExternalName(sample.getExternalName())).thenReturn(sample);
     Mockito.when(sampleClassDao.listByCategory(Mockito.eq(Identity.CATEGORY_NAME))).thenReturn(Lists.newArrayList(sample.getSampleClass()));
     return sample;
   }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/SampleDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/SampleDao.java
@@ -52,6 +52,6 @@ public interface SampleDao extends SampleStore {
 
   Long countBySearch(String querystr) throws IOException;
 
-  Identity getIdentityByExternalName(String externalName) throws IOException;
+  Collection<Identity> getIdentitiesByExternalNameOrAlias(String externalName) throws IOException;
 
 }

--- a/sqlstore/src/main/resources/db/migration/V8093__identity_changes.sql
+++ b/sqlstore/src/main/resources/db/migration/V8093__identity_changes.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `Identity` DROP COLUMN internalName;
+
+CREATE TABLE `Identity_ExternalName` (
+  `sampleId` BIGINT(20) NOT NULL,
+  `externalName` VARCHAR(255) NOT NULL,
+  CONSTRAINT `Sample_sampleId` FOREIGN KEY (`sampleId`) REFERENCES `Sample` (`sampleId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- do something here to move externalNames from Identity column to this newly-created table, then...
+
+ALTER TABLE `Identity` DROP COLUMN externalName;

--- a/sqlstore/src/main/resources/db/migration/afterMigrate.sql
+++ b/sqlstore/src/main/resources/db/migration/afterMigrate.sql
@@ -217,15 +217,13 @@ FOR EACH ROW
   DECLARE log_message varchar(500) CHARACTER SET utf8;
   SET log_message = CONCAT_WS(', ',
      CASE WHEN NEW.donorSex <> OLD.donorSex THEN CONCAT('donor sex: ', OLD.donorSex, ' → ', NEW.donorSex) END,
-     CASE WHEN NEW.externalName <> OLD.externalName THEN CONCAT('external name: ', OLD.externalName, ' → ', NEW.externalName) END,
-     CASE WHEN NEW.internalName <> OLD.internalName THEN CONCAT('internal name: ', OLD.internalName, ' → ', NEW.internalName) END);
+     CASE WHEN NEW.externalName <> OLD.externalName THEN CONCAT('external name: ', OLD.externalName, ' → ', NEW.externalName) END);
   IF log_message IS NOT NULL AND log_message <> '' THEN
     INSERT INTO SampleChangeLog(sampleId, columnsChanged, userId, message) VALUES (
       NEW.sampleId,
       COALESCE(CONCAT_WS(',',
         CASE WHEN NEW.donorSex <> OLD.donorSex THEN 'donorSex' END,
-        CASE WHEN NEW.externalName <> OLD.externalName THEN 'externalName' END,
-        CASE WHEN NEW.internalName <> OLD.internalName THEN 'internalName' END
+        CASE WHEN NEW.externalName <> OLD.externalName THEN 'externalName' END
       ), ''),
       (SELECT lastModifier FROM Sample WHERE sampleId = NEW.sampleId),
       log_message

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,9 +17,8 @@ import com.eaglegenomics.simlims.core.SecurityProfile;
 import com.eaglegenomics.simlims.core.store.SecurityStore;
 
 import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
-import uk.ac.bbsrc.tgac.miso.core.data.Identity;
-import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
+import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.DefaultSampleNamingScheme;
 import uk.ac.bbsrc.tgac.miso.core.store.ChangeLogStore;
@@ -86,13 +83,6 @@ public class HibernateSampleDaoTest extends AbstractDAOTest {
     DetailedSample detailed = (DetailedSample) sample;
     assertNotNull(detailed.getParent());
     assertEquals(15L, detailed.getParent().getId());
-  }
-
-  @Test
-  public void testGetIdentityByExternalName() throws IOException {
-    Identity identity = sut.getIdentityByExternalName("EXT1");
-    assertEquals("EXT1", identity.getExternalName());
-    assertEquals("INT1", identity.getInternalName());
   }
 
 }

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleDAOTest.java
@@ -235,8 +235,7 @@ public class SQLSampleDAOTest extends AbstractDAOTest {
     assertTrue(LimsUtils.isDetailedSample(sample));
     assertTrue(LimsUtils.isIdentitySample(sample));
     Identity identity = (Identity) sample;
-    assertEquals("INT1", identity.getInternalName());
-    assertEquals("EXT1", identity.getExternalName());
+    assertEquals("EXT15,15_EXT15", identity.getExternalName());
   }
 
   @Test
@@ -329,6 +328,31 @@ public class SQLSampleDAOTest extends AbstractDAOTest {
   public void countSamplesByEmptySearch() throws IOException {
     Long numSamples = dao.countBySearch("");
     assertEquals(Long.valueOf(17L), numSamples);
+  }
+
+  @Test
+  public void testGetIdentityByExternalName() throws IOException {
+    List<Identity> identity = (List<Identity>) dao.getIdentitiesByExternalNameOrAlias("EXT15");
+    assertTrue(identity.get(0).getExternalName().contains("EXT15"));
+  }
+
+  @Test
+  public void getIdentityByAlias() throws IOException {
+    Collection<Identity> identities = dao.getIdentitiesByExternalNameOrAlias("TEST_0001_IDENTITY_1");
+    assertEquals(1, identities.size());
+    assertEquals("TEST_0001_IDENTITY_1", identities.iterator().next().getAlias());
+  }
+
+  @Test
+  public void getIdentityByNullAlias() throws IOException {
+    Collection<Identity> identities = dao.getIdentitiesByExternalNameOrAlias(null);
+    assertTrue(identities.isEmpty());
+  }
+
+  @Test
+  public void getIdentityByNonIdentityAlias() throws IOException {
+    Collection<Identity> identities = dao.getIdentitiesByExternalNameOrAlias("TEST_0001_Bn_P_nn_1-1_D_1");
+    assertTrue(identities.isEmpty());
   }
 
   private void mockAutoIncrement() throws IOException {

--- a/sqlstore/src/test/resources/db/scripts/schema_translator.groovy
+++ b/sqlstore/src/test/resources/db/scripts/schema_translator.groovy
@@ -15,7 +15,6 @@ final String basedir = "${project.basedir}"
 final File productionSchemaDir = new File(basedir + '/src/main/resources/db/migration/')
 println('Translating schema files from ' + productionSchemaDir.getAbsolutePath() + '...')
 
-// ignore V8000-series site-specific migrations as they will cause tests to fail
 final String productionScriptPattern = '^(V\\d{4}_.*|afterMigrate)\\.sql$'
 final String testSchemaDir = basedir + '/target/test-classes/db/test_migration/'
 

--- a/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
+++ b/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
@@ -370,8 +370,12 @@ VALUES (15,1,0,NULL),
 (16,2,0,15),
 (17,2,0,15);
 
-INSERT INTO `Identity`(`sampleId`, `internalName`, `externalName`)
-VALUES (15,'INT1','EXT1');
+DELETE FROM `Identity`;
+INSERT INTO `Identity` (`sampleId`, `donorSex`)
+VALUES (15, 'UNKNOWN');
+
+INSERT INTO `Identity_ExternalName`(`sampleId`,`externalName`)
+VALUES (15,'15_EXT15'),(15,'EXT15');
 
 INSERT INTO `SampleTissue`(`sampleId`)
 VALUES (16),


### PR DESCRIPTION
- remove internalName from Identity
- change externalName to Set<String>
- external names must now be unique on a per-project basis (possible to turn this requirement off during migration)
- when creating a new sample, existing identity parents are looked up by ID if available, and created anew otherwise.
