### PR TITLE
GLT-1085: fix siblingNumber generation

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/naming/NameGenerator.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/naming/NameGenerator.java
@@ -2,6 +2,8 @@ package uk.ac.bbsrc.tgac.miso.core.service.naming;
 
 import net.sourceforge.fluxion.spi.Spi;
 
+import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
+
 /**
  * uk.ac.bbsrc.tgac.miso.core.service.naming
  * <p/>
@@ -15,7 +17,7 @@ import net.sourceforge.fluxion.spi.Spi;
 public interface NameGenerator<T> {
   public String getGeneratorName();
 
-  public String generateName(T t);
+  public String generateName(T t) throws MisoNamingException;
 
   public Class<T> nameGeneratorFor();
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/naming/SiblingNumberGenerator.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/naming/SiblingNumberGenerator.java
@@ -9,7 +9,7 @@ public interface SiblingNumberGenerator {
    * be appended to the end of the partialAlias to form the complete alias
    * 
    * @param partialAlias the Sample alias being generated, missing only a siblingNumber
-   * @return the next siblingNumber that may be used for a new sample based on the provided partialAlias
+   * @return the lowest useable siblingNumber where the alias formed by {@code (partialAlias + siblingNumber)} does not yet exist
    * @throws IOException
    */
   public int getNextSiblingNumber(String partialAlias) throws IOException;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/naming/SiblingNumberGenerator.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/naming/SiblingNumberGenerator.java
@@ -1,0 +1,17 @@
+package uk.ac.bbsrc.tgac.miso.core.service.naming;
+
+import java.io.IOException;
+
+public interface SiblingNumberGenerator {
+
+  /**
+   * Determines the next available siblingNumber to use for this sample name. Assumes that siblingNumber will
+   * be appended to the end of the partialAlias to form the complete alias
+   * 
+   * @param partialAlias the Sample alias being generated, missing only a siblingNumber
+   * @return the next siblingNumber that may be used for a new sample based on the provided partialAlias
+   * @throws IOException
+   */
+  public int getNextSiblingNumber(String partialAlias) throws IOException;
+
+}

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
@@ -231,13 +231,6 @@ public class DefaultSampleService implements SampleService {
     } else {
       validateAliasUniqueness(sample.getAlias());
     }
-    if (isStockSample(sample) || isAliquotSample(sample) || isTissueProcessingSample(sample)) {
-      DetailedSample detailed = (DetailedSample) sample;
-      if (detailed.getParent() != null && detailed.getSiblingNumber() == null) {
-        int siblingNumber = sampleDao.getNextSiblingNumber(detailed.getParent(), detailed.getSampleClass());
-        detailed.setSiblingNumber(siblingNumber);
-      }
-    }
     return save(sample).getId();
   }
 

--- a/miso-web/src/main/resources/external/miso.properties
+++ b/miso-web/src/main/resources/external/miso.properties
@@ -58,8 +58,6 @@ miso.alerting.saveSystemAlerts:true
 ## configs for caching
 # precache objects at MISO startup. This will greatly increase startup time, but will improve MISO performance for users at the outset
 miso.db.caching.precache.enabled:true
-# enable cache checking at the DAO RowMapper level. Disabling this can have large performance detriments!
-miso.db.caching.mappers.enabled:true
 
 ##config for the NCBI taxon lookup service
 # sometimes MISO may be behind a firewall, or not able to access the internet. set this to false in these instances.

--- a/miso-web/src/main/resources/internal/miso.properties
+++ b/miso-web/src/main/resources/internal/miso.properties
@@ -48,8 +48,6 @@ miso.alerting.saveSystemAlerts:true
 ## configs for caching
 # precache objects at MISO startup which will improve MISO performance for users at the outset. Disabling this will greatly decrease startup time, but will have large performance detriments.
 miso.db.caching.precache.enabled:true
-# enable cache checking at the DAO RowMapper level. Disabling this can have large performance detriments!
-miso.db.caching.mappers.enabled:true
 
 ##config for the NCBI taxon lookup service
 # sometimes MISO may be behind a firewall, or not able to access the internet. set this to false in these instances.

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/SampleDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/SampleDao.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
-import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
 import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
 import uk.ac.bbsrc.tgac.miso.core.store.SampleStore;
 
@@ -24,8 +23,6 @@ public interface SampleDao extends SampleStore {
   void deleteSample(Sample sample);
 
   void update(Sample sample) throws IOException;
-
-  int getNextSiblingNumber(Sample parent, SampleClass childClass) throws IOException;
 
   /**
    * Determines whether an alias exists already

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
@@ -125,13 +125,14 @@ public class HibernateSampleDao implements SampleDao, SiblingNumberGenerator {
 
   @Override
   public int getNextSiblingNumber(String partialAlias) throws IOException {
+    // Find highest existing siblingNumber matching this partialAlias
     Query query = currentSession().createQuery("select max(siblingNumber) from DetailedSampleImpl as ds"
             + " where alias IN (concat(:alias, ds.siblingNumber), concat(:alias, '0', ds.siblingNumber))");
     query.setString("alias", partialAlias);
     Number result = ((Number) query.uniqueResult());
     int next = result == null ? 0 : result.intValue();
 
-    // verify uniqueness and fix siblingNumbers for existing samples if necessary
+    // Increment and verify uniqueness. If alias is used, fix siblingNumber for existing sample. Repeat until unique
     Query verifyQuery = null;
     do {
       next++;

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDao.java
@@ -36,15 +36,16 @@ import com.eaglegenomics.simlims.core.store.SecurityStore;
 
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
+
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
 import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
-import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.IdentityImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.MisoNamingScheme;
+import uk.ac.bbsrc.tgac.miso.core.service.naming.SiblingNumberGenerator;
 import uk.ac.bbsrc.tgac.miso.core.store.ChangeLogStore;
 import uk.ac.bbsrc.tgac.miso.core.store.LibraryStore;
 import uk.ac.bbsrc.tgac.miso.core.store.NoteStore;
@@ -63,7 +64,7 @@ import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
  * “transient” in the Sample class.
  */
 @Transactional(rollbackFor = Exception.class)
-public class HibernateSampleDao implements SampleDao {
+public class HibernateSampleDao implements SampleDao, SiblingNumberGenerator {
 
   protected static final Logger log = LoggerFactory.getLogger(HibernateSampleDao.class);
 
@@ -123,13 +124,23 @@ public class HibernateSampleDao implements SampleDao {
   }
 
   @Override
-  public int getNextSiblingNumber(Sample parent, SampleClass childClass) throws IOException {
-    Query query = currentSession().createQuery(
-        "select max(siblingNumber) " + "from DetailedSampleImpl " + "where parentId = :parentId " + "and sampleClassId = :sampleClassId");
-    query.setLong("parentId", parent.getId());
-    query.setLong("sampleClassId", childClass.getId());
+  public int getNextSiblingNumber(String partialAlias) throws IOException {
+    Query query = currentSession().createQuery("select max(siblingNumber) from DetailedSampleImpl as ds"
+            + " where alias IN (concat(:alias, ds.siblingNumber), concat(:alias, '0', ds.siblingNumber))");
+    query.setString("alias", partialAlias);
     Number result = ((Number) query.uniqueResult());
-    return result == null ? 1 : result.intValue() + 1;
+    int next = result == null ? 0 : result.intValue();
+
+    // verify uniqueness and fix siblingNumbers for existing samples if necessary
+    Query verifyQuery = null;
+    do {
+      next++;
+      verifyQuery = currentSession().createQuery("update DetailedSampleImpl ds set ds.siblingNumber = :siblingNumber"
+          + " where alias IN (concat(:alias, :siblingNumber), concat(:alias, '0', :siblingNumber))");
+      verifyQuery.setString("alias", partialAlias).setString("siblingNumber", String.valueOf(next));
+    } while (verifyQuery.executeUpdate() > 0);
+
+    return next;
   }
 
   @Override

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLSampleDAOTest.java
@@ -1,11 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.sqlstore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -390,6 +386,20 @@ public class SQLSampleDAOTest extends AbstractDAOTest {
     max++;
     Map<String, Object> rs = new HashMap<>();
     rs.put("Auto_increment", max);
+  }
+
+  @Test
+  public void getNextSiblingNumberTest() throws Exception {
+    // sibling numbers are missing. getNextSiblingNumber should fix these and return first truly available number
+    DetailedSample s1 = (DetailedSample) dao.get(16L);
+    DetailedSample s2 = (DetailedSample) dao.get(17L);
+    assertNull(s1.getSiblingNumber());
+    assertNull(s2.getSiblingNumber());
+    assertEquals(3, dao.getNextSiblingNumber("TEST_0001_TISSUE_"));
+    sessionFactory.getCurrentSession().refresh(s1);
+    sessionFactory.getCurrentSession().refresh(s2);
+    assertEquals(new Integer(1), s1.getSiblingNumber());
+    assertEquals(new Integer(2), s2.getSiblingNumber());
   }
 
 }

--- a/sqlstore/src/test/resources/db-test-context.xml
+++ b/sqlstore/src/test/resources/db-test-context.xml
@@ -77,7 +77,7 @@
     </property>
     <property name="hibernateProperties">
       <props>
-        <prop key="hibernate.dialect">org.hibernate.dialect.MySQL5InnoDBDialect</prop>
+        <prop key="hibernate.dialect">org.hibernate.dialect.H2Dialect</prop>
         <prop key="hibernate.show_sql">true</prop>
       </props>
     </property>


### PR DESCRIPTION
also removes the option `miso.db.caching.mappers.enabled` which was never actually used for anything, and will not be useful with the switch-over to Hibernate