### PR TITLE
Fixed NPE with Library SecurityProfiles

### DIFF
--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/DefaultMigrationTarget.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/DefaultMigrationTarget.java
@@ -345,7 +345,7 @@ public class DefaultMigrationTarget implements MigrationTarget {
           }
         }
       }
-      library.inheritPermissions(library.getSample());
+      library.inheritPermissions(library.getSample().getProject());
       valueTypeLookup.resolveAll(library);
       library.setLastModifier(migrationUser);
       library.setLastUpdated(timeStamp);


### PR DESCRIPTION
In migration, Library SecurityProfile is set using its parent Sample's Project, not the Sample itself.