### PR TITLE
GLT-1317: added check for parent sample when migrating library

### DIFF
--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/DefaultMigrationTarget.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/DefaultMigrationTarget.java
@@ -345,6 +345,9 @@ public class DefaultMigrationTarget implements MigrationTarget {
           }
         }
       }
+      if (library.getSample() == null || library.getSample().getId() == AbstractSample.UNSAVED_ID) {
+        throw new IOException("Library does not have a parent sample set");
+      }
       library.inheritPermissions(library.getSample().getProject());
       valueTypeLookup.resolveAll(library);
       library.setLastModifier(migrationUser);


### PR DESCRIPTION
There is a bug where libraries which should have ghost aliquots are saving without the sample linked. This PR causes the save to fail as it should