### PR TITLE
Re-add plate option for sample delivery form

### DIFF
--- a/miso-web/src/main/webapp/scripts/editProject_sample.js
+++ b/miso-web/src/main/webapp/scripts/editProject_sample.js
@@ -286,7 +286,7 @@ function generateSampleDeliveryForm(tableName, projectId) {
       }
     });
 
-    jQuery("div.toolbar").html("<button type='button' onclick=\"Project.ui.processSampleDeliveryForm('"+tableName+"', " + projectId + ");\" class=\"fg-button ui-state-default ui-corner-all\">Generate Form</button>");
+    jQuery("div.toolbar").html("Plate: <input type='radio' name='plateinformationform' value='yes'/>Yes |<input type='radio' name='plateinformationform' value='no' checked='checked'/>No " + "<button type='button' onclick=\"Project.ui.processSampleDeliveryForm('"+tableName+"', " + projectId + ");\" class=\"fg-button ui-state-default ui-corner-all\">Generate Form</button>");
   }
 }
 

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/ProjectControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/ProjectControllerHelperService.java
@@ -745,6 +745,10 @@ public class ProjectControllerHelperService {
   }
 
   public JSONObject generateSampleDeliveryForm(HttpSession session, JSONObject json) {
+    Boolean plate = false;
+    if ("yes".equals(json.getString("plate"))) {
+      plate = true;
+    }
     final Long projectId = json.getLong("projectId");
     final List<Sample> samples = new ArrayList<>();
     if (json.has("samples")) {
@@ -756,7 +760,7 @@ public class ProjectControllerHelperService {
         final File f = misoFileManager.getNewFile(Project.class, projectId.toString(),
             "SampleInformationForm-" + LimsUtils.getCurrentDateAsString() + ".odt");
 
-        FormUtils.createSampleDeliveryForm(samples, f, false);
+        FormUtils.createSampleDeliveryForm(samples, f, plate);
         return JSONUtils.SimpleJSONResponse("" + f.getName().hashCode());
       } catch (final Exception e) {
         log.error("generate sample deliver form", e);


### PR DESCRIPTION
This was removed with the removal of plates.
Our lab use this, it isn't tied to any plate functionality.
Selecting this option in the radio adds a 96 well plate index (A1, B1, C1) to the generated sample delivery form, presumably for ease of use on the other end.