### PR TITLE
GLT-1250 Migrate ReferenceGenome by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ core/test_file.txt
 notification-server/metrixDaemon.log
 
 # Ignore Eclipse Web Standard Tools settings files.
-.settings/org.eclipse.wst.common.component
-.settings/org.eclipse.wst.common.project.facet.core.prefs.xml
-.settings/org.eclipse.wst.common.project.facet.core.xml
-.settings/org.eclipse.wst.validation.prefs
+org.eclipse.wst.common.component
+org.eclipse.wst.common.project.facet.core.prefs.xml
+org.eclipse.wst.common.project.facet.core.xml
+org.eclipse.wst.validation.prefs

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractProject.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractProject.java
@@ -36,7 +36,9 @@ import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToOne;
 import javax.persistence.Transient;
 
 import org.apache.commons.lang.BooleanUtils;
@@ -53,6 +55,7 @@ import com.eaglegenomics.simlims.core.SecurityProfile;
 import com.eaglegenomics.simlims.core.User;
 
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectOverview;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.ReferenceGenomeImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.type.ProgressType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.ProgressTypeUserType;
 import uk.ac.bbsrc.tgac.miso.core.event.listener.MisoListener;
@@ -87,33 +90,34 @@ public abstract class AbstractProject implements Project {
   private long projectId = AbstractProject.UNSAVED_ID;
 
   @Transient
-  private Collection<Request> requests = new HashSet<Request>();
+  private Collection<Request> requests = new HashSet<>();
 
   @Transient
-  private Collection<Sample> samples = new HashSet<Sample>();
+  private Collection<Sample> samples = new HashSet<>();
   @Transient
-  private Collection<Run> runs = new HashSet<Run>();
+  private Collection<Run> runs = new HashSet<>();
   @Transient
-  private Collection<Study> studies = new HashSet<Study>();
+  private Collection<Study> studies = new HashSet<>();
   @Transient
-  private Collection<ProjectOverview> overviews = new HashSet<ProjectOverview>();
+  private Collection<ProjectOverview> overviews = new HashSet<>();
   @Transient
-  private Collection<String> issueKeys = new HashSet<String>();
+  private Collection<String> issueKeys = new HashSet<>();
 
   @Column
   @Type(type = "progressTypeUserType")
   private ProgressType progress;
 
-  @Column
-  private Long referenceGenomeId;
+  @OneToOne(targetEntity = ReferenceGenomeImpl.class)
+  @JoinColumn(name = "referenceGenomeId", referencedColumnName = "referenceGenomeId", nullable = false)
+  private ReferenceGenome referenceGenome;
 
   @Transient
   private SecurityProfile securityProfile = null;
   @Transient
-  private final Set<MisoListener> listeners = new HashSet<MisoListener>();
+  private final Set<MisoListener> listeners = new HashSet<>();
   private Date lastUpdated;
   @Transient
-  private Set<User> watchers = new HashSet<User>();
+  private Set<User> watchers = new HashSet<>();
 
   @Override
   public Date getCreationDate() {
@@ -454,13 +458,13 @@ public abstract class AbstractProject implements Project {
   }
 
   @Override
-  public Long getReferenceGenomeId() {
-    return referenceGenomeId;
+  public ReferenceGenome getReferenceGenome() {
+    return referenceGenome;
   }
 
   @Override
-  public void setReferenceGenomeId(Long referenceGenomeId) {
-    this.referenceGenomeId = referenceGenomeId;
+  public void setReferenceGenome(ReferenceGenome referenceGenome) {
+    this.referenceGenome = referenceGenome;
   }
 
   @Override
@@ -469,7 +473,7 @@ public abstract class AbstractProject implements Project {
         .append(alias)
         .append(description)
         .append(progress)
-        .append(referenceGenomeId)
+        .append(referenceGenome)
         .append(shortName)
         .toHashCode();
   }
@@ -484,7 +488,7 @@ public abstract class AbstractProject implements Project {
         .append(alias, other.alias)
         .append(description, other.description)
         .append(progress, other.progress)
-        .append(referenceGenomeId, other.referenceGenomeId)
+        .append(referenceGenome, other.referenceGenome)
         .append(shortName, other.shortName)
         .isEquals();
   }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Project.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Project.java
@@ -200,7 +200,7 @@ public interface Project extends com.eaglegenomics.simlims.core.Project, Compara
 
   void setLastUpdated(Date lastUpdated);
 
-  Long getReferenceGenomeId();
+  public ReferenceGenome getReferenceGenome();
 
-  void setReferenceGenomeId(Long referenceGenome);
+  public void setReferenceGenome(ReferenceGenome referenceGenome);
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/ReferenceGenomeImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/ReferenceGenomeImpl.java
@@ -7,6 +7,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 
 @Entity
@@ -43,6 +46,24 @@ public class ReferenceGenomeImpl implements ReferenceGenome {
   @Override
   public String toString() {
     return "ReferenceGenomeImpl [referenceGenomeId=" + referenceGenomeId + ", alias=" + alias + "]";
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(9, 335)
+        .append(alias)
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    ReferenceGenomeImpl other = (ReferenceGenomeImpl) obj;
+    return new EqualsBuilder()
+        .append(alias, other.alias)
+        .isEquals();
   }
 
 }

--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/DefaultMigrationTarget.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/DefaultMigrationTarget.java
@@ -156,6 +156,7 @@ public class DefaultMigrationTarget implements MigrationTarget {
     log.info("Migrating projects...");
     for (Project project : projects) {
       project.setSecurityProfile(new SecurityProfile(migrationUser));
+      valueTypeLookup.resolveAll(project);
       // Make sure there's a study
       if (project.getStudies() == null) project.setStudies(new HashSet<Study>());
       if (project.getStudies().isEmpty()) {
@@ -278,7 +279,7 @@ public class DefaultMigrationTarget implements MigrationTarget {
     subproject.setParentProject(project);
     subproject.setDescription(subproject.getAlias());
     subproject.setPriority(Boolean.FALSE);
-    subproject.setReferenceGenomeId(project.getReferenceGenomeId());
+    subproject.setReferenceGenomeId(project.getReferenceGenome().getId());
     subproject.setCreatedBy(migrationUser);
     subproject.setCreationDate(timeStamp);
     subproject.setUpdatedBy(migrationUser);

--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/ValueTypeLookup.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/ValueTypeLookup.java
@@ -6,6 +6,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import uk.ac.bbsrc.tgac.miso.core.data.DetailedQcStatus;
 import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.Index;
@@ -17,6 +19,8 @@ import uk.ac.bbsrc.tgac.miso.core.data.LibraryDesign;
 import uk.ac.bbsrc.tgac.miso.core.data.LibraryDesignCode;
 import uk.ac.bbsrc.tgac.miso.core.data.LibraryQC;
 import uk.ac.bbsrc.tgac.miso.core.data.Platform;
+import uk.ac.bbsrc.tgac.miso.core.data.Project;
+import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleAliquot;
@@ -84,6 +88,7 @@ public class ValueTypeLookup {
   private Map<String, Subproject> subprojectByAlias;
   private Map<Long, DetailedQcStatus> detailedQcStatusById;
   private Map<String, DetailedQcStatus> detailedQcStatusByDescription;
+  private Map<String, ReferenceGenome> referenceGenomeByAlias;
   
   /**
    * Create a ValueTypeLookup loaded with data from the provided MisoServiceManager
@@ -110,6 +115,7 @@ public class ValueTypeLookup {
     setSequencers(misoServiceManager.getSequencerReferenceDao().listAll());
     setSubprojects(misoServiceManager.getSubprojectDao().getSubproject());
     setDetailedQcStatuses(misoServiceManager.getDetailedQcStatusDao().getDetailedQcStatus());
+    setReferenceGenomes(misoServiceManager.getReferenceGenomeService().listAllReferenceGenomeTypes());
   }
 
   private void setSampleClasses(Collection<SampleClass> sampleClasses) {
@@ -343,6 +349,14 @@ public class ValueTypeLookup {
     this.detailedQcStatusByDescription = mapByDesc;
   }
   
+  private void setReferenceGenomes(Collection<ReferenceGenome> referenceGenomes) {
+    Map<String, ReferenceGenome> mapByAlias = new UniqueKeyHashMap<>();
+    for (ReferenceGenome referenceGenome : referenceGenomes) {
+      mapByAlias.put(referenceGenome.getAlias(), referenceGenome);
+    }
+    this.referenceGenomeByAlias = mapByAlias;
+  }
+
   /**
    * Attempts to find an existing SampleClass
    * 
@@ -350,7 +364,8 @@ public class ValueTypeLookup {
    * SampleClass
    * @return the existing SampleClass if a matching one is found; null otherwise
    */
-  public SampleClass resolve(SampleClass sampleClass) {
+  @VisibleForTesting
+  SampleClass resolve(SampleClass sampleClass) {
     if (sampleClass == null) return null;
     if (sampleClass.getId() != null) return sampleClassById.get(sampleClass.getId());
     if (sampleClass.getAlias() != null) return sampleClassByAlias.get(sampleClass.getAlias());
@@ -367,7 +382,8 @@ public class ValueTypeLookup {
    * @param tissueType a partially-formed TissueType, which must have its ID or alias set in order for this method to resolve the TissueType
    * @return the existing TissueType if a matching one is found; null otherwise
    */
-  public TissueType resolve(TissueType tissueType) {
+  @VisibleForTesting
+  TissueType resolve(TissueType tissueType) {
     if (tissueType == null) return null;
     if (tissueType.getId() != null) return tissueTypeById.get(tissueType.getId());
     if (tissueType.getAlias() != null) return tissueTypeByAlias.get(tissueType.getAlias());
@@ -385,7 +401,8 @@ public class ValueTypeLookup {
    * TissueMaterial
    * @return the existing TissueMaterial if a matching one is found; null otherwise
    */
-  public TissueMaterial resolve(TissueMaterial tissueMaterial) {
+  @VisibleForTesting
+  TissueMaterial resolve(TissueMaterial tissueMaterial) {
     if (tissueMaterial == null) return null;
     if (tissueMaterial.getId() != null) return tissueMaterialById.get(tissueMaterial.getId());
     if (tissueMaterial.getAlias() != null) return tissueMaterialByAlias.get(tissueMaterial.getAlias());
@@ -402,7 +419,8 @@ public class ValueTypeLookup {
    * @param kit a partially-formed KitDescriptor, which must have its ID or name set in order for this method to resolve the KitDescriptor
    * @return the existing KitDescriptor if a matching one is found; null otherwise
    */
-  public KitDescriptor resolve(KitDescriptor kit) {
+  @VisibleForTesting
+  KitDescriptor resolve(KitDescriptor kit) {
     if (kit == null) return null;
     if (kit.getId() != KitDescriptor.UNSAVED_ID) return kitById.get(kit.getId());
     if (kit.getName() != null) return kitByName.get(kit.getName());
@@ -420,7 +438,8 @@ public class ValueTypeLookup {
    * SamplePurpose
    * @return the existing SamplePurpose if a matching one is found; null otherwise
    */
-  public SamplePurpose resolve(SamplePurpose samplePurpose) {
+  @VisibleForTesting
+  SamplePurpose resolve(SamplePurpose samplePurpose) {
     if (samplePurpose == null) return null;
     if (samplePurpose.getId() != null) return samplePurposeById.get(samplePurpose.getId());
     if (samplePurpose.getAlias() != null) return samplePurposeByAlias.get(samplePurpose.getAlias());
@@ -439,7 +458,8 @@ public class ValueTypeLookup {
    * Institute is first resolved by ID or alias
    * @return the existing Lab if a matching one is found; null otherwise
    */
-  public Lab resolve(Lab lab) {
+  @VisibleForTesting
+  Lab resolve(Lab lab) {
     if (lab == null) return null;
     if (lab.getId() != null) return labsById.get(lab.getId());
     if (lab.getInstitute() != null) {
@@ -471,7 +491,8 @@ public class ValueTypeLookup {
    * resolve the TissueOrigin
    * @return the existing TissueOrigin if a matching one is found; null otherwise
    */
-  public TissueOrigin resolve(TissueOrigin tissueOrigin) {
+  @VisibleForTesting
+  TissueOrigin resolve(TissueOrigin tissueOrigin) {
     if (tissueOrigin == null) return null;
     if (tissueOrigin.getId() != null) return tissueOriginsById.get(tissueOrigin.getId());
     if (tissueOrigin.getAlias() != null) {
@@ -493,7 +514,8 @@ public class ValueTypeLookup {
    * resolve the LibrarySelectionType
    * @return the existing LibrarySelectionType if a matching one is found; null otherwise
    */
-  public LibrarySelectionType resolve(LibrarySelectionType librarySelectionType) {
+  @VisibleForTesting
+  LibrarySelectionType resolve(LibrarySelectionType librarySelectionType) {
     if (librarySelectionType == null) return null;
     if (librarySelectionType.getId() != LibrarySelectionType.UNSAVED_ID) {
       return librarySelectionsById.get(librarySelectionType.getId());
@@ -513,7 +535,8 @@ public class ValueTypeLookup {
    * resolve the LibraryStrategyType
    * @return the existing LibraryStrategyType if a matching one is found; null otherwise
    */
-  public LibraryStrategyType resolve(LibraryStrategyType libraryStrategyType) {
+  @VisibleForTesting
+  LibraryStrategyType resolve(LibraryStrategyType libraryStrategyType) {
     if (libraryStrategyType == null) return null;
     if (libraryStrategyType.getId() != LibrarySelectionType.UNSAVED_ID) {
       return libraryStrategiesById.get(libraryStrategyType.getId());
@@ -533,7 +556,8 @@ public class ValueTypeLookup {
    * resolve the LibraryType
    * @return the existing LibraryType if a matching one is found; null otherwise
    */
-  public LibraryType resolve(LibraryType libraryType) {
+  @VisibleForTesting
+  LibraryType resolve(LibraryType libraryType) {
     if (libraryType == null) return null;
     if (libraryType.getId() != LibraryType.UNSAVED_ID) return libraryTypeById.get(libraryType.getId());
     if (libraryType.getDescription() != null && libraryType.getPlatformType() != null) {
@@ -555,7 +579,8 @@ public class ValueTypeLookup {
    * LibraryDesign
    * @return the existing LibraryDesign if a matching one is found; null otherwise
    */
-  public LibraryDesign resolve(LibraryDesign libraryDesign) {
+  @VisibleForTesting
+  LibraryDesign resolve(LibraryDesign libraryDesign) {
     if (libraryDesign == null) return null;
     if (libraryDesign.getId() != null) return libraryDesignById.get(libraryDesign.getId());
     if (libraryDesign.getSampleClass() != null && libraryDesign.getSampleClass().getAlias() != null && libraryDesign.getName() != null) {
@@ -573,7 +598,8 @@ public class ValueTypeLookup {
    *          LibraryDesignCode
    * @return the existing LibraryDesignCode if a matching one is found; null otherwise
    */
-  public LibraryDesignCode resolve(LibraryDesignCode libraryDesignCode) {
+  @VisibleForTesting
+  LibraryDesignCode resolve(LibraryDesignCode libraryDesignCode) {
     if (libraryDesignCode == null) return null;
     if (libraryDesignCode.getId() != null) return libraryDesignCodeById.get(libraryDesignCode.getId());
     if (libraryDesignCode.getCode() != null) return libraryDesignCodeByCode.get(libraryDesignCode.getCode());
@@ -587,7 +613,8 @@ public class ValueTypeLookup {
    * resolve the Index
    * @return the existing Index if a matching one is found; null otherwise
    */
-  public Index resolve(Index index) {
+  @VisibleForTesting
+  Index resolve(Index index) {
     if (index == null) return null;
     if (index.getId() != Index.UNSAVED_ID) return indexById.get(index.getId());
     if (index.getFamily() != null && index.getFamily().getName() != null && index.getSequence() != null) {
@@ -643,7 +670,8 @@ public class ValueTypeLookup {
    * resolve the SequencerReference
    * @return the existing SequencerReference if a matching one is found; null otherwise
    */
-  public SequencerReference resolve(SequencerReference sequencer) {
+  @VisibleForTesting
+  SequencerReference resolve(SequencerReference sequencer) {
     if (sequencer == null) return null;
     if (sequencer.getId() != Index.UNSAVED_ID) return sequencerById.get(sequencer.getId());
     if (sequencer.getName() != null) return sequencerByName.get(sequencer.getName());
@@ -661,7 +689,8 @@ public class ValueTypeLookup {
    * alias set in order for this method to resolve the Subproject
    * @return the existing Subproject if a matching one is found; null otherwise
    */
-  public Subproject resolve(Subproject subproject) {
+  @VisibleForTesting
+  Subproject resolve(Subproject subproject) {
     if (subproject == null) return null;
     if (subproject.getId() != null) return subprojectById.get(subproject.getId());
     if (subproject.getAlias() != null) return subprojectByAlias.get(subproject.getAlias());
@@ -680,7 +709,8 @@ public class ValueTypeLookup {
    *          the DetailedQcStatus
    * @return the existing DetailedQcStatus if a matching one is found; null otherwise
    */
-  public DetailedQcStatus resolve(DetailedQcStatus detailedQcStatus) {
+  @VisibleForTesting
+  DetailedQcStatus resolve(DetailedQcStatus detailedQcStatus) {
     if (detailedQcStatus == null) return null;
     if (detailedQcStatus.getId() != null) return detailedQcStatusById.get(detailedQcStatus.getId());
     if (detailedQcStatus.getDescription() != null) return detailedQcStatusByDescription.get(detailedQcStatus.getDescription());
@@ -898,6 +928,25 @@ public class ValueTypeLookup {
         }
       }
     }
+  }
+
+  public void resolveAll(Project project) {
+    ReferenceGenome referenceGenome = resolve(project.getReferenceGenome());
+    project.setReferenceGenome(referenceGenome);
+  }
+
+  /**
+   * Attempts to find an existing ReferenceGenome by alias
+   * 
+   * @param referenceGenome a partially-formed ReferenceGenome, which must have its alias set in order for this method to resolve the
+   *          ReferenceGenome. (This resolve method does not support lookup by id.)
+   * @return the existing ReferenceGenome if a matching one is found; null otherwise
+   */
+  @VisibleForTesting
+  ReferenceGenome resolve(ReferenceGenome referenceGenome) {
+    if (referenceGenome == null) return null;
+    if (referenceGenome.getAlias() != null) return referenceGenomeByAlias.get(referenceGenome.getAlias());
+    return null;
   }
 
 }

--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/source/LoadGeneratorSource.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/source/LoadGeneratorSource.java
@@ -19,6 +19,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.LibraryAdditionalInfo;
 import uk.ac.bbsrc.tgac.miso.core.data.Platform;
 import uk.ac.bbsrc.tgac.miso.core.data.Pool;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
+import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleAliquot;
@@ -39,6 +40,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.PartitionImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PlatformImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.ReferenceGenomeImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.RunImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleAliquotImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleClassImpl;
@@ -168,7 +170,7 @@ public class LoadGeneratorSource implements MigrationSource {
         project.setProgress(ProgressType.ACTIVE);
         project.setCreationDate(now);
         project.setLastUpdated(now);
-        project.setReferenceGenomeId(1L);
+        project.setReferenceGenome(createReferenceGenome());
         projects.add(project);
       }
       this.projects = projects;
@@ -497,6 +499,12 @@ public class LoadGeneratorSource implements MigrationSource {
     containers.add(container);
     run.setSequencerPartitionContainers(containers);
     return run;
+  }
+
+  private ReferenceGenome createReferenceGenome() {
+    ReferenceGenome referenceGenome = new ReferenceGenomeImpl();
+    referenceGenome.setAlias("Human hg19");
+    return referenceGenome;
   }
 
   @Override

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/ReferenceGenomeService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/ReferenceGenomeService.java
@@ -2,12 +2,13 @@ package uk.ac.bbsrc.tgac.miso.service;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Set;
 
 import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
-import uk.ac.bbsrc.tgac.miso.core.data.Subproject;
 
 public interface ReferenceGenomeService {
 
   public Collection<ReferenceGenome> listAllReferenceGenomeTypes() throws IOException;
+
+  public ReferenceGenome get(Long id) throws IOException;
+
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultReferenceGenomeService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultReferenceGenomeService.java
@@ -32,4 +32,18 @@ public class DefaultReferenceGenomeService implements ReferenceGenomeService {
     return referenceGenomeDao.listAllReferenceGenomeTypes();
   }
 
+  @Override
+  public ReferenceGenome get(Long id) throws IOException {
+    authorizationManager.throwIfUnauthenticated();
+    return referenceGenomeDao.getReferenceGenome(id);
+  }
+
+  public void setAuthorizationManager(AuthorizationManager authorizationManager) {
+    this.authorizationManager = authorizationManager;
+  }
+
+  public void setReferenceGenomeDao(ReferenceGenomeDao referenceGenomeDao) {
+    this.referenceGenomeDao = referenceGenomeDao;
+  }
+
 }

--- a/miso-service/src/test/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleServiceTestSuite.java
+++ b/miso-service/src/test/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleServiceTestSuite.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.Identity;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
+import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleStock;
@@ -33,6 +34,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.SampleTissue;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleValidRelationship;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.IdentityImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.ReferenceGenomeImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleClassImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleStockImpl;
@@ -433,10 +435,18 @@ public class DefaultSampleServiceTestSuite {
     assertEquals("Sample name should NOT be modifiable", old.getName(), result.getName());
   }
 
+  private ReferenceGenome humanReferenceGenome() {
+    ReferenceGenome referenceGenome = new ReferenceGenomeImpl();
+    referenceGenome.setAlias("hg19");
+    referenceGenome.setId(1L);
+    return referenceGenome;
+  }
+
   @Test
   public void testUniqueExternalNamePerProjectTest() throws IOException {
     Project project = new ProjectImpl();
     project.setId(1L);
+    project.setReferenceGenome(humanReferenceGenome());
     Set<Identity> idList = new HashSet<>();
     Identity id1 = new IdentityImpl();
     id1.setExternalName("String1,String2");
@@ -452,6 +462,7 @@ public class DefaultSampleServiceTestSuite {
   public void testNonUniqueExternalNamePerProjectFailTest() throws IOException {
     Project project = new ProjectImpl();
     project.setId(1L);
+    project.setReferenceGenome(humanReferenceGenome());
     Set<Identity> idList = new HashSet<>();
     Identity id1 = new IdentityImpl();
     id1.setExternalName("String1,String2");
@@ -468,6 +479,7 @@ public class DefaultSampleServiceTestSuite {
   public void testNonUniqueExternalNamePerProjectPassTest() throws IOException {
     Project project = new ProjectImpl();
     project.setId(1L);
+    project.setReferenceGenome(humanReferenceGenome());
     Set<Identity> idList = new HashSet<>();
     Identity id1 = new IdentityImpl();
     id1.setExternalName("String1,String2");

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditProjectController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditProjectController.java
@@ -60,6 +60,7 @@ import com.eaglegenomics.simlims.core.manager.SecurityManager;
 
 import net.sf.json.JSONObject;
 import net.sourceforge.fluxion.ajax.util.JSONUtils;
+
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractPool;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractProject;
 import uk.ac.bbsrc.tgac.miso.core.data.AbstractSampleQC;
@@ -136,7 +137,7 @@ public class EditProjectController {
     if (projectId != AbstractProject.UNSAVED_ID) {
       Project p = requestManager.lazyGetProjectById(projectId);
       if (p != null) {
-        Map<Integer, String> fileMap = new HashMap<Integer, String>();
+        Map<Integer, String> fileMap = new HashMap<>();
         for (String s : filesManager.getFileNames(Project.class, projectId.toString())) {
           fileMap.put(s.hashCode(), s);
         }
@@ -153,7 +154,7 @@ public class EditProjectController {
 
   @ModelAttribute("sampleQcTypesString")
   public String sampleTypesString() throws IOException {
-    List<String> types = new ArrayList<String>();
+    List<String> types = new ArrayList<>();
     for (QcType s : requestManager.listAllSampleQcTypes()) {
       types.add("\"" + s.getQcTypeId() + "\"" + ":" + "\"" + s.getName() + "\"");
     }
@@ -178,8 +179,8 @@ public class EditProjectController {
 
   @ModelAttribute("libraryQcTypesString")
   public String libraryTypesString() throws IOException {
-    List<String> types = new ArrayList<String>();
-    List<QcType> libraryQcTypes = new ArrayList<QcType>(requestManager.listAllLibraryQcTypes());
+    List<String> types = new ArrayList<>();
+    List<QcType> libraryQcTypes = new ArrayList<>(requestManager.listAllLibraryQcTypes());
     Collections.sort(libraryQcTypes);
     for (QcType s : libraryQcTypes) {
       types.add("\"" + s.getQcTypeId() + "\"" + ":" + "\"" + s.getName() + "\"");
@@ -188,12 +189,12 @@ public class EditProjectController {
   }
 
   public Collection<Run> populateProjectRuns(long projectId) throws IOException {
-    List<Run> runs = new ArrayList<Run>(requestManager.listAllRunsByProjectId(projectId));
+    List<Run> runs = new ArrayList<>(requestManager.listAllRunsByProjectId(projectId));
     try {
       Collections.sort(runs, new AliasComparator(Run.class));
       for (Run r : runs) {
         RunImpl ri = (RunImpl) r;
-        ri.setSequencerPartitionContainers(new ArrayList<SequencerPartitionContainer<SequencerPoolPartition>>(
+        ri.setSequencerPartitionContainers(new ArrayList<>(
             requestManager.listSequencerPartitionContainersByRunId(r.getId())));
       }
       return runs;
@@ -203,7 +204,7 @@ public class EditProjectController {
   }
 
   public Collection<Library> populateProjectLibraries(long projectId) throws IOException {
-    List<Library> libraries = new ArrayList<Library>(requestManager.listAllLibrariesByProjectId(projectId));
+    List<Library> libraries = new ArrayList<>(requestManager.listAllLibrariesByProjectId(projectId));
     try {
       Collections.sort(libraries, new AliasComparator(Library.class));
       for (Library l : libraries) {
@@ -223,7 +224,7 @@ public class EditProjectController {
   }
 
   public Collection<LibraryDilution> populateProjectLibraryDilutions(Collection<Library> projectLibraries) throws IOException {
-    List<LibraryDilution> dilutions = new ArrayList<LibraryDilution>();
+    List<LibraryDilution> dilutions = new ArrayList<>();
     for (Library l : projectLibraries) {
       dilutions.addAll(requestManager.listAllLibraryDilutionsByLibraryId(l.getId()));
     }
@@ -232,13 +233,13 @@ public class EditProjectController {
   }
 
   public Collection<LibraryDilution> populateProjectLibraryDilutions(long projectId) throws IOException {
-    List<LibraryDilution> dilutions = new ArrayList<LibraryDilution>(requestManager.listAllLibraryDilutionsByProjectId(projectId));
+    List<LibraryDilution> dilutions = new ArrayList<>(requestManager.listAllLibraryDilutionsByProjectId(projectId));
     Collections.sort(dilutions);
     return dilutions;
   }
 
   public Collection<Pool> populateProjectPools(long projectId) throws IOException {
-    List<Pool> pools = new ArrayList<Pool>(requestManager.listPoolsByProjectId(projectId));
+    List<Pool> pools = new ArrayList<>(requestManager.listPoolsByProjectId(projectId));
     Collections.sort(pools);
     return pools;
   }
@@ -257,13 +258,13 @@ public class EditProjectController {
   }
 
   public Collection<emPCR> populateProjectEmPCRs(long projectId) throws IOException {
-    List<emPCR> pcrs = new ArrayList<emPCR>(requestManager.listAllEmPCRsByProjectId(projectId));
+    List<emPCR> pcrs = new ArrayList<>(requestManager.listAllEmPCRsByProjectId(projectId));
     Collections.sort(pcrs);
     return pcrs;
   }
 
   public Collection<emPCRDilution> populateProjectEmPcrDilutions(Collection<emPCR> projectEmPCRs) throws IOException {
-    List<emPCRDilution> dilutions = new ArrayList<emPCRDilution>();
+    List<emPCRDilution> dilutions = new ArrayList<>();
     for (emPCR e : projectEmPCRs) {
       dilutions.addAll(requestManager.listAllEmPCRDilutionsByEmPcrId(e.getId()));
     }
@@ -272,7 +273,7 @@ public class EditProjectController {
   }
 
   public Collection<emPCRDilution> populateProjectEmPcrDilutions(long projectId) throws IOException {
-    List<emPCRDilution> dilutions = new ArrayList<emPCRDilution>(requestManager.listAllEmPCRDilutionsByProjectId(projectId));
+    List<emPCRDilution> dilutions = new ArrayList<>(requestManager.listAllEmPCRDilutionsByProjectId(projectId));
     Collections.sort(dilutions);
     return dilutions;
   }
@@ -422,7 +423,7 @@ public class EditProjectController {
       model.put("accessibleGroups", LimsSecurityUtils.getAccessibleGroups(user, project, securityManager.listAllGroups()));
       model.put("overviews", project.getOverviews());
 
-      Map<Long, String> overviewMap = new HashMap<Long, String>();
+      Map<Long, String> overviewMap = new HashMap<>();
       for (ProjectOverview po : project.getOverviews()) {
         if (po.getWatchers().contains(user)) {
           overviewMap.put(po.getId(), user.getLoginName());

--- a/miso-web/src/main/webapp/pages/editProject.jsp
+++ b/miso-web/src/main/webapp/pages/editProject.jsp
@@ -130,7 +130,7 @@
   <tr>
     <td>Reference Genome :*</td>
     <td>
-        <form:select id="referenceGenome" path="referenceGenomeId">
+        <form:select id="referenceGenome" path="referenceGenome">
             <form:options items="${referenceGenome}" itemValue="id" itemLabel="alias"/>
         </form:select>
     </td>

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/LimsBindingInitializer.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/LimsBindingInitializer.java
@@ -70,6 +70,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.LibraryDesignCode;
 import uk.ac.bbsrc.tgac.miso.core.data.Platform;
 import uk.ac.bbsrc.tgac.miso.core.data.Pool;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
+import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 import uk.ac.bbsrc.tgac.miso.core.data.Run;
 import uk.ac.bbsrc.tgac.miso.core.data.Sample;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerPartitionContainer;
@@ -92,6 +93,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.BoxStore;
 import uk.ac.bbsrc.tgac.miso.core.store.LibraryDesignCodeDao;
 import uk.ac.bbsrc.tgac.miso.core.store.LibraryDesignDao;
 import uk.ac.bbsrc.tgac.miso.persistence.SequencingParametersDao;
+import uk.ac.bbsrc.tgac.miso.service.ReferenceGenomeService;
 
 /**
  * Class that binds all the MISO model datatypes to the Spring form path types
@@ -117,6 +119,9 @@ public class LimsBindingInitializer extends org.springframework.web.bind.support
 
   @Autowired
   private BoxStore sqlBoxDAO;
+
+  @Autowired
+  private ReferenceGenomeService referenceGenomeService;
 
   @Autowired
   private IndexService indexService;
@@ -673,8 +678,17 @@ public class LimsBindingInitializer extends org.springframework.web.bind.support
       }
     }.register(binder).register(binder, Set.class, "kitDescriptors");
 
+    new BindingConverterById<ReferenceGenome>(ReferenceGenome.class) {
+
+      @Override
+      public ReferenceGenome resolveById(long id) throws Exception {
+        return referenceGenomeService.get(id);
+      }
+    }.register(binder).register(binder, Set.class, "referenceGenomes");
+
     new BindingConverterByPrefixDispatch<>(Dilution.class).add(ldiResolver).add(ediResolver).register(binder, Set.class,
         "poolableElements");
+
 
     binder.registerCustomEditor(LibraryDesign.class, new PropertyEditorSupport() {
       @Override

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/ReferenceGenomeDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/ReferenceGenomeDao.java
@@ -6,7 +6,8 @@ import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 
 public interface ReferenceGenomeDao {
 
-
   Collection<ReferenceGenome> listAllReferenceGenomeTypes();
+
+  ReferenceGenome getReferenceGenome(Long id);
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateReferenceGenomeDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateReferenceGenomeDao.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.ReferenceGenomeImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.ReferenceGenomeDao;
 
 @Repository
@@ -28,11 +29,21 @@ public class HibernateReferenceGenomeDao implements ReferenceGenomeDao {
     return sessionFactory.getCurrentSession();
   }
 
+  public void setSessionFactory(SessionFactory sessionFactory) {
+    this.sessionFactory = sessionFactory;
+  }
+
   @Override
   public Collection<ReferenceGenome> listAllReferenceGenomeTypes() {
     Query query = currentSession().createQuery("from ReferenceGenomeImpl");
+    @SuppressWarnings("unchecked")
     List<ReferenceGenome> records = query.list();
     return records;
+  }
+
+  @Override
+  public ReferenceGenome getReferenceGenome(Long id) {
+    return (ReferenceGenome) currentSession().get(ReferenceGenomeImpl.class, id);
   }
 
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLProjectDAO.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLProjectDAO.java
@@ -213,6 +213,10 @@ public class SQLProjectDAO implements ProjectStore {
   @Autowired
   private ReferenceGenomeDao referenceGenomeDao;
 
+  public void setReferenceGenomeDao(ReferenceGenomeDao referenceGenomeDao) {
+    this.referenceGenomeDao = referenceGenomeDao;
+  }
+
   @CoverageIgnore
   public void setDataObjectFactory(DataObjectFactory dataObjectFactory) {
     this.dataObjectFactory = dataObjectFactory;
@@ -311,7 +315,7 @@ public class SQLProjectDAO implements ProjectStore {
     params.addValue("creationDate", project.getCreationDate());
     params.addValue("securityProfile_profileId", securityProfileId);
     params.addValue("progress", project.getProgress().getKey());
-    params.addValue("referenceGenomeId", project.getReferenceGenomeId());
+    params.addValue("referenceGenomeId", project.getReferenceGenome().getId());
 
     if (project.getId() == AbstractProject.UNSAVED_ID) {
       SimpleJdbcInsert insert = new SimpleJdbcInsert(template).withTableName(TABLE_NAME).usingGeneratedKeyColumns("projectId");
@@ -587,7 +591,7 @@ public class SQLProjectDAO implements ProjectStore {
         project.setCreationDate(rs.getDate("creationDate"));
         project.setProgress(ProgressType.get(rs.getString("progress")));
         project.setLastUpdated(rs.getTimestamp("lastUpdated"));
-        project.setReferenceGenomeId(rs.getLong("referenceGenomeId"));
+        project.setReferenceGenome(referenceGenomeDao.getReferenceGenome(rs.getLong("referenceGenomeId")));
 
         try {
           project.setSecurityProfile(securityProfileDAO.get(rs.getLong("securityProfile_profileId")));

--- a/sqlstore/src/main/resources/db/migration/V8000__ReferenceGenome.sql
+++ b/sqlstore/src/main/resources/db/migration/V8000__ReferenceGenome.sql
@@ -1,0 +1,3 @@
+--StartNoTest
+ALTER TABLE ReferenceGenome CONVERT TO CHARACTER SET utf8;
+--EndNoTest

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/AllTestsSuite.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/AllTestsSuite.java
@@ -55,6 +55,7 @@ import org.junit.runners.Suite;
     SQLPrintJobDAOTest.class, //
     SQLPrintServiceDAOTest.class, //
     SQLProjectDAOTest.class, //
+    SQLReferenceGenomeDAOTest.class, //
     SQLRunDAOTest.class, //
     SQLRunQCDAOTest.class, //
     SQLSampleDAOTest.class, //

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLProjectDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLProjectDAOTest.java
@@ -31,8 +31,10 @@ import com.eaglegenomics.simlims.core.SecurityProfile;
 
 import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
 import uk.ac.bbsrc.tgac.miso.core.data.Project;
+import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.ProjectOverview;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.ReferenceGenomeImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.type.ProgressType;
 import uk.ac.bbsrc.tgac.miso.core.factory.DataObjectFactory;
 import uk.ac.bbsrc.tgac.miso.core.factory.TgacDataObjectFactory;
@@ -46,6 +48,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.core.store.StudyStore;
 import uk.ac.bbsrc.tgac.miso.core.store.WatcherStore;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
+import uk.ac.bbsrc.tgac.miso.persistence.ReferenceGenomeDao;
 
 /**
  * @author Chris Salt
@@ -95,6 +98,9 @@ public class SQLProjectDAOTest extends AbstractDAOTest {
   @Mock
   private LibraryStore libraryDAO;
 
+  @Mock
+  private ReferenceGenomeDao referenceGenomeDao;
+
   @InjectMocks
   private SQLProjectDAO projectDAO;
 
@@ -119,9 +125,14 @@ public class SQLProjectDAOTest extends AbstractDAOTest {
     when(mockAuthentication.getName()).thenReturn("some name");
     SecurityContextHolder.setContext(mockContext);
     when(securityProfileDAO.save(any(SecurityProfile.class))).thenReturn(1L);
+    
+    projectDAO.setReferenceGenomeDao(referenceGenomeDao);
 
     project.setProgress(ProgressType.ACTIVE);
-    project.setReferenceGenomeId(1L);
+    ReferenceGenome referenceGenome = new ReferenceGenomeImpl();
+    referenceGenome.setId(1L);
+    referenceGenome.setAlias("hg19");
+    project.setReferenceGenome(referenceGenome);
 
   }
 

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLReferenceGenomeDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLReferenceGenomeDAOTest.java
@@ -1,0 +1,54 @@
+package uk.ac.bbsrc.tgac.miso.sqlstore;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collection;
+
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
+import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
+import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateReferenceGenomeDao;
+
+public class SQLReferenceGenomeDAOTest extends AbstractDAOTest {
+
+  @Autowired
+  private SessionFactory sessionFactory;
+
+  @InjectMocks
+  private HibernateReferenceGenomeDao dao;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    dao.setSessionFactory(sessionFactory);
+  }
+
+  @Test
+  public void testListAllReferenceGeonomesCountIsAtLeastThree() {
+    // Three ReferenceGenomes are present in the test database.
+    Collection<ReferenceGenome> referenceGenomes = dao.listAllReferenceGenomeTypes();
+    assertThat("count of all references", referenceGenomes.size(), is(greaterThanOrEqualTo(3)));
+  }
+
+  @Test
+  public void testGetByIdTwoReturnsHumanReference() throws Exception {
+    Long idTwo = 2L; // Id 2 contains 'Human hg19' in the test database.
+    ReferenceGenome actual = dao.getReferenceGenome(idTwo);
+    assertThat("alias for reference with id 2", actual.getAlias(), is("Human hg19"));
+  }
+
+  @Test
+  public void testGetNonExistentReferenceGenomeReturnsNull() throws Exception {
+    Long idTooLargeToExistInTestData = 999999999999999999L;
+    ReferenceGenome actual = dao.getReferenceGenome(idTooLargeToExistInTestData);
+    assertThat("Non exisitent reference", actual, is(nullValue()));
+  }
+
+}

--- a/sqlstore/src/test/resources/db-test-context.xml
+++ b/sqlstore/src/test/resources/db-test-context.xml
@@ -74,6 +74,7 @@
         <value>uk.ac.bbsrc.tgac.miso.core.data.IndexFamily</value>
         <value>uk.ac.bbsrc.tgac.miso.core.data.impl.SampleDerivedInfo</value>
         <value>uk.ac.bbsrc.tgac.miso.core.data.LibraryDesignCode</value>
+        <value>uk.ac.bbsrc.tgac.miso.core.data.impl.ReferenceGenomeImpl</value>
       </list>
     </property>
     <property name="hibernateProperties">


### PR DESCRIPTION
Allowed ReferenceGenome to be retrieved by id.
Converted ReferenceGenome to charset utf8.
Project now refers to ReferenceGenome as an object and not an id.
Added project resolver to migration allowing a ReferenceGenome to be specified by name during migration.
Updated edit project UI to work with ReferenceGenome changes. Added a binding to convert by id.