### PR TITLE
Fix library report

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/MisoRequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/MisoRequestManager.java
@@ -28,6 +28,7 @@ import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -2947,6 +2948,11 @@ public class MisoRequestManager implements RequestManager {
   @Override
   public List<Run> getRunsByPool(Pool pool) throws IOException {
     return runStore.listByPoolId(pool.getId());
+  }
+
+  @Override
+  public List<Library> getLibrariesByCreationDate(Date from, Date to) throws IOException {
+    return libraryStore.searchByCreationDate(from, to);
   }
 
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/RequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/RequestManager.java
@@ -25,6 +25,7 @@ package uk.ac.bbsrc.tgac.miso.core.manager;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -377,6 +378,7 @@ public interface RequestManager {
 
   public Collection<SampleQC> listAllSampleQCsBySampleId(long sampleId) throws IOException;
 
+  @Deprecated // massively detremental to performance.
   public Collection<Library> listAllLibraries() throws IOException;
 
   public Collection<Library> listAllLibrariesWithLimit(long limit) throws IOException;
@@ -484,7 +486,7 @@ public interface RequestManager {
 
   /**
    * PlatformTypes with existing sequencers.
-   * 
+   *
    * @throws IOException
    */
   public Collection<PlatformType> listActivePlatformTypes() throws IOException;
@@ -644,6 +646,8 @@ public interface RequestManager {
   public Long getNumPoolsBySearch(PlatformType platform, String querystr) throws IOException;
 
   public int countLibraries() throws IOException;
+
+  public List<Library> getLibrariesByCreationDate(Date from, Date to) throws IOException;
 
   public List<Library> getLibrariesByPageSizeSearch(int offset, int limit, String querystr, String sortDir, String sortCol)
       throws IOException;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/UserAuthMisoRequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/UserAuthMisoRequestManager.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -2620,5 +2621,16 @@ public class UserAuthMisoRequestManager implements RequestManager {
         authorizedRuns.add(run);
     }
     return authorizedRuns;
+  }
+
+  @Override
+  public List<Library> getLibrariesByCreationDate(Date from, Date to) throws IOException {
+    List<Library> libraries = backingManager.getLibrariesByCreationDate(from, to);
+    List<Library> authorizedLibs = new ArrayList<>();
+    for (Library lib : libraries) {
+      if (readCheck(lib))
+        authorizedLibs.add(lib);
+    }
+    return authorizedLibs;
   }
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/LibraryStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/LibraryStore.java
@@ -25,6 +25,7 @@ package uk.ac.bbsrc.tgac.miso.core.store;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +39,7 @@ import uk.ac.bbsrc.tgac.miso.core.service.naming.NamingSchemeAware;
 
 /**
  * Defines a DAO interface for storing Libraries
- * 
+ *
  * @author Rob Davey
  * @since 0.0.2
  */
@@ -46,7 +47,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get a Library given a ID barcode
-   * 
+   *
    * @param barcode of type String
    * @return Library
    * @throws IOException when
@@ -55,7 +56,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all Libraries that match a search criteria
-   * 
+   *
    * @param query of type String
    * @return Collection<Library>
    * @throws IOException when
@@ -64,7 +65,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get all Library with a given Library alias
-   * 
+   *
    * @param alias of type String
    * @return all libraries with the given alias
    * @throws IOException
@@ -73,7 +74,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all Libraries generated from a Sample given a parent Sample ID
-   * 
+   *
    * @param sampleId of type long
    * @return Collection<Library>
    * @throws IOException when
@@ -82,7 +83,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all Libraries that are related to a Project given a Project ID
-   * 
+   *
    * @param projectId of type long
    * @return Collection<Library>
    * @throws IOException when
@@ -91,7 +92,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all Libraries associated with ids from the given id list
-   * 
+   *
    * @return Collection<Library>
    * @throws IOException when the objects cannot be retrieved or read
    */
@@ -99,7 +100,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get a LibraryType given a LibraryType ID
-   * 
+   *
    * @param libraryTypeId of type long
    * @return LibraryType
    * @throws IOException when
@@ -108,7 +109,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get a LibraryType given a LibraryType description
-   * 
+   *
    * @param description of type String
    * @return LibraryType
    * @throws IOException when
@@ -117,7 +118,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get a LibraryType given a LibraryType description and platform
-   * 
+   *
    * @param description of type String
    * @param platformType of type PlatformType
    * @return LibraryType
@@ -127,7 +128,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get a LibrarySelectionType given a LibrarySelectionType ID
-   * 
+   *
    * @param librarySelectionTypeId of type long
    * @return LibrarySelectionType
    * @throws IOException when
@@ -136,7 +137,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get a LibrarySelectionType given a LibrarySelectionType name
-   * 
+   *
    * @param name of type String
    * @return LibrarySelectionType
    * @throws IOException when
@@ -145,7 +146,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get a LibraryStrategyType given a LibraryStrategyType ID
-   * 
+   *
    * @param libraryStrategyTypeId of type long
    * @return LibraryStrategyType
    * @throws IOException when
@@ -154,7 +155,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Get a LibraryStrategyType given a LibraryStrategyType name
-   * 
+   *
    * @param name of type String
    * @return LibraryStrategyType
    * @throws IOException when
@@ -163,7 +164,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all LibraryTypes
-   * 
+   *
    * @return Collection<LibraryType>
    * @throws IOException when
    */
@@ -171,7 +172,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all LibraryTypes available to a given platform
-   * 
+   *
    * @param platformName of type String
    * @return Collection<LibraryType>
    * @throws IOException when
@@ -180,7 +181,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all LibrarySelectionTypes
-   * 
+   *
    * @return Collection<LibrarySelectionType>
    * @throws IOException when
    */
@@ -188,7 +189,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all LibraryStrategyTypes
-   * 
+   *
    * @return Collection<LibraryStrategyType>
    * @throws IOException when
    */
@@ -196,7 +197,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all libraries related to a given LibraryDilution given a LibraryDilution ID
-   * 
+   *
    * @param dilutionId of type long
    * @return Collection<Library>
    * @throws IOException when
@@ -205,7 +206,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all persisted objects
-   * 
+   *
    * @return Collection<Library>
    * @throws IOException when the objects cannot be retrieved
    */
@@ -213,7 +214,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * Return the Library associated with a given positionId
-   * 
+   *
    * @param positionId of type long
    * @return Boxable
    */
@@ -221,7 +222,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
 
   /**
    * List all libraries associated with an identificationBarcode from given list of identificationBarcodes (from scan)
-   * 
+   *
    * @param barcodeList
    * @return Collection<Library>
    * @throws IOException when the objects cannot be retrieved
@@ -235,7 +236,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
   public Map<String, Integer> getLibraryColumnSizes() throws IOException;
 
   /**
-   * 
+   *
    * @param offset of type int
    * @param resultsPerPage of type int
    * @param querystr of type String
@@ -246,7 +247,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
   List<Library> listBySearchOffsetAndNumResults(int offset, int limit, String querystr, String sortDir, String sortCol) throws IOException;
 
   /**
-   * 
+   *
    * @param offset of type int
    * @param limit of type int
    * @param sortDir of type String
@@ -256,7 +257,7 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
   List<Library> listByOffsetAndNumResults(int offset, int limit, String sortDir, String sortCol) throws IOException;
 
   /**
-   * 
+   *
    * @param querystr of type String
    * @return a count of how many libraries match the querystr
    * @throws IOException
@@ -264,4 +265,6 @@ public interface LibraryStore extends Store<Library>, Remover<Library>, NamingSc
   long countLibrariesBySearch(String querystr) throws IOException;
 
   Library getAdjacentLibrary(long libraryId, boolean before) throws IOException;
+
+  List<Library> searchByCreationDate(Date from, Date to) throws IOException;
 }

--- a/miso-web/src/main/resources/external/miso.properties
+++ b/miso-web/src/main/resources/external/miso.properties
@@ -57,7 +57,7 @@ miso.alerting.saveSystemAlerts:true
 
 ## configs for caching
 # precache objects at MISO startup. This will greatly increase startup time, but will improve MISO performance for users at the outset
-miso.db.caching.precache.enabled:true
+miso.db.caching.precache.enabled:false
 
 ##config for the NCBI taxon lookup service
 # sometimes MISO may be behind a firewall, or not able to access the internet. set this to false in these instances.

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/FlexReportingControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/FlexReportingControllerHelperService.java
@@ -689,10 +689,13 @@ public class FlexReportingControllerHelperService {
     JSONArray jsonArray = new JSONArray();
     try {
       Collection<Library> libraries = null;
+      DateFormat df = new SimpleDateFormat("dd/MM/yyyy");
+      Date startDate = df.parse(from);
+      Date endDate = df.parse(to);
       if (!isStringEmptyOrNull(searchStr)) {
         libraries = requestManager.listAllLibrariesBySearch(searchStr);
       } else {
-        libraries = requestManager.listAllLibraries();
+        libraries = requestManager.getLibrariesByCreationDate(startDate, endDate);
       }
 
       for (Library library : libraries) {
@@ -701,9 +704,6 @@ public class FlexReportingControllerHelperService {
 
           if (!isStringEmptyOrNull(from) && !isStringEmptyOrNull(to) && library.getCreationDate() != null) {
 
-            DateFormat df = new SimpleDateFormat("dd/MM/yyyy");
-            Date startDate = df.parse(from);
-            Date endDate = df.parse(to);
             Date receivedDate = library.getCreationDate();
             if ((receivedDate.after(startDate) && receivedDate.before(endDate)) || receivedDate.equals(startDate)
                 || receivedDate.equals(endDate)) {


### PR DESCRIPTION
So creating the library report never seemed to end as it was trying to list every single library in the database.  We have ~26,000, so along with the mapping that was taking a while.
I changed it so it queries based on the created date of the library.  It always did this anyway but the logic was in the controller to sift though all 26K libraries, now it is in the DAO.