### PR TITLE
fixup Watcher cascades

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractPool.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractPool.java
@@ -119,8 +119,7 @@ public abstract class AbstractPool extends AbstractBoxable implements Pool {
   // listeners
   private final Set<MisoListener> listeners = new HashSet<>();
 
-  // Cascade all operations except delete
-  @ManyToMany(targetEntity = UserImpl.class, cascade = { CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })
+  @ManyToMany(targetEntity = UserImpl.class)
   @JoinTable(name = "Pool_Watcher", joinColumns = { @JoinColumn(name = "poolId") }, inverseJoinColumns = { @JoinColumn(name = "userId") })
   private Set<User> watchUsers = new HashSet<>();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractProject.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractProject.java
@@ -30,7 +30,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -116,8 +115,7 @@ public abstract class AbstractProject implements Project {
   private final Set<MisoListener> listeners = new HashSet<>();
   private Date lastUpdated;
 
-  // Cascade all operations except delete
-  @ManyToMany(targetEntity = UserImpl.class, cascade = { CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })
+  @ManyToMany(targetEntity = UserImpl.class)
   @JoinTable(name = "Project_Watcher", joinColumns = { @JoinColumn(name = "projectId") },
       inverseJoinColumns = { @JoinColumn(name = "userId") })
   private Set<User> watchUsers = new HashSet<>();

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractRun.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractRun.java
@@ -130,8 +130,7 @@ public abstract class AbstractRun implements Run {
   @Transient
   private final Set<MisoListener> listeners = new HashSet<>();
 
-  // Cascade all operations except delete
-  @ManyToMany(targetEntity = UserImpl.class, cascade = { CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })
+  @ManyToMany(targetEntity = UserImpl.class)
   @JoinTable(name = "Run_Watcher", joinColumns = { @JoinColumn(name = "runId") }, inverseJoinColumns = { @JoinColumn(name = "userId") })
   private Set<User> watchUsers = new HashSet<>();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/ProjectOverview.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/ProjectOverview.java
@@ -31,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -108,8 +107,7 @@ public class ProjectOverview implements Watchable, Alertable, Nameable, Serializ
   private boolean primaryAnalysisCompleted;
   private final Set<MisoListener> listeners = new HashSet<>();
 
-  // Cascade all operations except delete
-  @ManyToMany(targetEntity = UserImpl.class, cascade = { CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })
+  @ManyToMany(targetEntity = UserImpl.class)
   @JoinTable(name = "ProjectOverview_Watcher", joinColumns = { @JoinColumn(name = "overviewId") },
       inverseJoinColumns = { @JoinColumn(name = "userId") })
   private Set<User> watchUsers = new HashSet<>();


### PR DESCRIPTION
I had thought that the cascade was required to manage the bridge table, but it is not. The cascade affects the referenced object(s) only. In this case, changes to the watched entity should never affect the watching User