### PR TITLE
Change interceptor design to avoid multiple Hibernate sesions

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractBox.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractBox.java
@@ -29,7 +29,7 @@ public abstract class AbstractBox implements Box {
 
   public static final Long UNSAVED_ID = 0L;
 
-  @ManyToOne(cascade = CascadeType.ALL)
+  @ManyToOne(cascade = CascadeType.PERSIST)
   @JoinColumn(name = "securityProfile_profileId")
   private SecurityProfile securityProfile;
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Box.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Box.java
@@ -147,14 +147,6 @@ public interface Box extends SecurableByProfile, Barcodable, Locatable, Deletabl
   public void removeBoxable(String position);
 
   /**
-   * Removes a given Boxable item from the Box
-   * 
-   * @param Boxable
-   *          boxable
-   */
-  public void removeBoxable(Boxable boxable);
-
-  /**
    * Removes ALL Boxable items from the Box
    * 
    */

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/BoxImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/BoxImpl.java
@@ -86,9 +86,7 @@ public class BoxImpl extends AbstractBox implements Serializable {
     if (!position.matches("[A-Z][0-9][0-9]")) throw new IllegalArgumentException("Position must match [A-Z][0-9][0-9]");
     if (BoxUtils.fromRowChar(position.charAt(0)) >= getSize().getRows()) throw new IndexOutOfBoundsException("Row letter too large!");
     int col = BoxUtils.tryParseInt(position.substring(1, 3));
-    if (col <= 0 || col > getSize().getColumns()) throw new IndexOutOfBoundsException("Column value too large!"); // columns are
-                                                                                                                  // zero-indexed in
-                                                                                                                  // database
+    if (col <= 0 || col > getSize().getColumns()) throw new IndexOutOfBoundsException("Column value too large!");
   }
   
   @Override
@@ -142,12 +140,7 @@ public class BoxImpl extends AbstractBox implements Serializable {
   @Override
   public void removeBoxable(String position) {
     validate(position);
-    removeBoxable(getBoxable(position));
-  }
-
-  @Override
-  public void removeBoxable(Boxable boxable) {
-    boxableItems.values().remove(boxable);
+    boxableItems.remove(position);
   }
 
   @Override

--- a/miso-web/src/main/webapp/WEB-INF/db-config.xml
+++ b/miso-web/src/main/webapp/WEB-INF/db-config.xml
@@ -33,6 +33,7 @@
 
 
   <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+    <property name="entityInterceptor" ref="collectionLoggingInterceptor"/>
     <property name="dataSource" ref="dataSource" />
     <property name="annotatedClasses">
       <list>
@@ -135,6 +136,8 @@
       </props>
     </property>
   </bean>
+
+  <bean id="collectionLoggingInterceptor" name="collectionLoggingInterceptor" class="uk.ac.bbsrc.tgac.miso.persistence.impl.CollectionLoggingInterceptor" />
 
   <tx:annotation-driven/>
   <bean id="jpaDialect"

--- a/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/BoxControllerHelperService.java
+++ b/spring/src/main/java/uk/ac/bbsrc/tgac/miso/spring/ajax/BoxControllerHelperService.java
@@ -362,7 +362,7 @@ public class BoxControllerHelperService {
         .SimpleJSONError(boxable.getName() + " (" + boxable.getAlias() + ") has been discarded, and can not be added to the box.");
 
     // if the selected item is already in the box, remove it here and add it to the correct position in next step
-    if (box.boxableExists(boxable)) box.removeBoxable(boxable);
+    if (box.boxableExists(boxable)) box.removeBoxable(boxable.getBoxPosition());
 
     // if an item already exists at this position, its location will be set to unknown.
     box.setBoxable(position, boxable);
@@ -414,7 +414,7 @@ public class BoxControllerHelperService {
     String position = json.getString("position");
     if (!box.isValidPosition(position)) return JSONUtils.SimpleJSONError("Invalid position given!");
 
-    box.removeBoxable(box.getBoxable(position));
+    box.removeBoxable(position);
 
     try {
       box.setLastModifier(authorizationManager.getCurrentUser());

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/CollectionLoggingInterceptor.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/CollectionLoggingInterceptor.java
@@ -1,0 +1,182 @@
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.hibernate.EmptyInterceptor;
+import org.hibernate.type.Type;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+
+import uk.ac.bbsrc.tgac.miso.core.data.Box;
+import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
+import uk.ac.bbsrc.tgac.miso.core.data.ChangeLog;
+import uk.ac.bbsrc.tgac.miso.core.data.Dilution;
+import uk.ac.bbsrc.tgac.miso.core.data.Pool;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.changelog.BoxChangeLog;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.changelog.PoolChangeLog;
+import uk.ac.bbsrc.tgac.miso.core.store.ChangeLogStore;
+
+/**
+ * When “collection” entities (pools, boxes) mutate write custom change log entries
+ *
+ */
+final class CollectionLoggingInterceptor extends EmptyInterceptor implements BeanFactoryAware {
+
+  private interface MoveCallback {
+    public void invoke(String position, String name);
+  }
+
+  private final Queue<ChangeLog> changeLogQueue = new ConcurrentLinkedQueue<>();
+
+  private ChangeLogStore changeLogStore;
+
+  private BeanFactory factory;
+
+  private void appendSet(StringBuilder target, Set<String> items, String prefix) {
+    if (items.isEmpty()) return;
+    target.append(" ");
+    target.append(prefix);
+    target.append(": ");
+    boolean first = true;
+    for (String item : items) {
+      if (first) {
+        first = false;
+      } else {
+        target.append(", ");
+      }
+      target.append(item);
+    }
+  }
+
+  private Set<String> extractBoxables(Object boxableMap, MoveCallback callback) {
+    Set<String> names = new TreeSet<>();
+    @SuppressWarnings("unchecked")
+    Map<String, Boxable> boxables = (Map<String, Boxable>) boxableMap;
+    for (Entry<String, Boxable> entry : boxables.entrySet()) {
+      String name = entry.getValue().getName() + "::" + entry.getValue().getAlias();
+      names.add(name);
+      callback.invoke(entry.getKey(), name);
+    }
+    return names;
+  }
+
+  private Set<String> extractDilutionNames(Object dilutionSet) {
+    @SuppressWarnings("unchecked")
+    Set<Dilution> dilutions = (Set<Dilution>) dilutionSet;
+    Set<String> original = new HashSet<>();
+    for (Dilution dilution : dilutions) {
+      original.add(dilution.getName());
+    }
+    return original;
+  }
+
+  @Override
+  public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState, Object[] previousState, String[] propertyNames,
+      Type[] types) {
+    if (entity instanceof Box) {
+      Box box = (Box) entity;
+      for (int i = 0; i < propertyNames.length; i++) {
+        if (propertyNames[i].equals("boxables")) {
+          final Map<String, String> positions = new HashMap<>();
+          final Set<String> moved = new TreeSet<>();
+
+          Set<String> originalNames = extractBoxables(previousState[i], new MoveCallback() {
+            @Override
+            public void invoke(String position, String name) {
+              positions.put(name, position);
+            }
+          });
+
+          Set<String> newNames = extractBoxables(currentState[i], new MoveCallback() {
+            @Override
+            public void invoke(String position, String name) {
+              if (positions.containsKey(name) && !positions.get(name).equals(position)) {
+                moved.add(name);
+              }
+            }
+          });
+
+          Set<String> added = new TreeSet<>(newNames);
+          added.removeAll(originalNames);
+          Set<String> removed = new TreeSet<>(originalNames);
+          removed.removeAll(newNames);
+          if (!added.isEmpty() && !removed.isEmpty() && !moved.isEmpty()) {
+            StringBuilder message = new StringBuilder();
+            message.append("Items");
+            appendSet(message, added, "added");
+            appendSet(message, removed, "removed");
+            appendSet(message, moved, "moved");
+
+            BoxChangeLog changeLog = new BoxChangeLog();
+            changeLog.setBox(box);
+            changeLog.setTime(new Date());
+            changeLog.setColumnsChanged("contents");
+            changeLog.setSummary(message.toString());
+            changeLog.setUser(box.getLastModifier());
+            changeLogQueue.add(changeLog);
+          }
+        }
+      }
+    } else if (entity instanceof Pool) {
+      Pool pool = (Pool) entity;
+      for (int i = 0; i < propertyNames.length; i++) {
+        if (!propertyNames[i].equals("pooledElements")) continue;
+        Set<String> original = extractDilutionNames(previousState[i]);
+        Set<String> updated = extractDilutionNames(currentState[i]);
+
+        Set<String> added = new TreeSet<>(updated);
+        added.removeAll(original);
+        Set<String> removed = new TreeSet<>(original);
+        removed.removeAll(updated);
+
+        if (!added.isEmpty() || !removed.isEmpty()) {
+          StringBuilder message = new StringBuilder();
+          message.append("Items");
+          appendSet(message, added, "added");
+          appendSet(message, removed, "removed");
+
+          PoolChangeLog changeLog = new PoolChangeLog();
+          changeLog.setPool(pool);
+          changeLog.setColumnsChanged("contents");
+          changeLog.setSummary(message.toString());
+          changeLog.setTime(new Date());
+          changeLog.setUser(pool.getLastModifier());
+          changeLogQueue.add(changeLog);
+        }
+
+      }
+    }
+    return super.onFlushDirty(entity, id, currentState, previousState, propertyNames, types);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public void postFlush(Iterator entities) {
+    super.postFlush(entities);
+    if (changeLogStore == null) {
+      changeLogStore = factory.getBean(ChangeLogStore.class);
+    }
+    ChangeLog log;
+    while ((log = changeLogQueue.poll()) != null) {
+      changeLogStore.create(log);
+    }
+  }
+
+  @Override
+  public void setBeanFactory(BeanFactory factory) throws BeansException {
+    this.factory = factory;
+
+  }
+
+}

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateBoxDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateBoxDao.java
@@ -1,27 +1,16 @@
 package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Queue;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.hibernate.Criteria;
-import org.hibernate.EmptyInterceptor;
-import org.hibernate.Interceptor;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.type.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,99 +23,17 @@ import uk.ac.bbsrc.tgac.miso.core.data.Box;
 import uk.ac.bbsrc.tgac.miso.core.data.BoxSize;
 import uk.ac.bbsrc.tgac.miso.core.data.BoxUse;
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
-import uk.ac.bbsrc.tgac.miso.core.data.ChangeLog;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.BoxImpl;
 import uk.ac.bbsrc.tgac.miso.core.store.BoxStore;
-import uk.ac.bbsrc.tgac.miso.core.store.ChangeLogStore;
 import uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils;
 
 @Transactional(rollbackFor = Exception.class)
 @Repository
 public class HibernateBoxDao implements BoxStore {
-  private static class ChangeLogEntry {
-    public Box box;
-    public String summary;
-  }
 
   private static final Logger log = LoggerFactory.getLogger(HibernateBoxDao.class);
 
   private static String TABLE_NAME = "Box";
-
-  private final Queue<ChangeLogEntry> changeLogQueue = new ConcurrentLinkedQueue<>();
-
-  @Autowired
-  private ChangeLogStore changeLogStore;
-
-  private final Interceptor interceptor = new EmptyInterceptor() {
-
-    @Override
-    public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState, Object[] previousState, String[] propertyNames,
-        Type[] types) {
-      if (entity instanceof Box) {
-        for (int i = 0; i < propertyNames.length; i++) {
-          if (propertyNames[i].equals("boxables")) {
-            Map<String, String> positions = new HashMap<>();
-            Set<String> moved = new TreeSet<>();
-            Set<String> originalNames = new HashSet<>();
-            @SuppressWarnings("unchecked")
-            Map<String, Boxable> originalBoxables = (Map<String, Boxable>) previousState[i];
-            for (Entry<String, Boxable> entry : originalBoxables.entrySet()) {
-              String name = entry.getValue().getName() + "::" + entry.getValue().getAlias();
-              originalNames.add(name);
-              positions.put(name, entry.getKey());
-            }
-
-            Set<String> newNames = new HashSet<>();
-            @SuppressWarnings("unchecked")
-            Map<String, Boxable> newBoxables = (Map<String, Boxable>) currentState[i];
-            for (Entry<String, Boxable> entry : newBoxables.entrySet()) {
-              String name = entry.getValue().getName() + "::" + entry.getValue().getAlias();
-              newNames.add(name);
-              if (positions.containsKey(name) && !positions.get(name).equals(entry.getKey())) {
-                moved.add(name);
-              }
-            }
-
-            Set<String> added = new TreeSet<>(newNames);
-            added.removeAll(originalNames);
-            Set<String> removed = new TreeSet<>(originalNames);
-            removed.removeAll(newNames);
-            if (!added.isEmpty() && !removed.isEmpty() && !moved.isEmpty()) {
-              StringBuilder message = new StringBuilder();
-              message.append(((Box) entity).getLastModifier().getFullName());
-              if (!added.isEmpty()) {
-                message.append(" added:");
-                for (String name : added) {
-                  message.append(" ");
-                  message.append(name);
-                }
-              }
-              if (!removed.isEmpty()) {
-                message.append(" removed:");
-                for (String name : removed) {
-                  message.append(" ");
-                  message.append(name);
-                }
-              }
-              if (!moved.isEmpty()) {
-                message.append(" moved:");
-                for (String name : moved) {
-                  message.append(" ");
-                  message.append(name);
-                }
-              }
-              ChangeLogEntry changeLog = new ChangeLogEntry();
-              changeLog.box = (Box) entity;
-              changeLog.summary = message.toString();
-              changeLogQueue.add(changeLog);
-            }
-          }
-        }
-      }
-      return super.onFlushDirty(entity, id, currentState, previousState, propertyNames, types);
-    }
-
-  };
 
   @Autowired
   private SessionFactory sessionFactory;
@@ -141,7 +48,7 @@ public class HibernateBoxDao implements BoxStore {
   }
 
   private Session currentSession() {
-    return getSessionFactory().withOptions().interceptor(interceptor).openSession();
+    return getSessionFactory().getCurrentSession();
   }
 
   @Override
@@ -192,10 +99,6 @@ public class HibernateBoxDao implements BoxStore {
     Criteria criteria = currentSession().createCriteria(BoxImpl.class);
     criteria.add(Restrictions.eq("identificationBarcode", barcode));
     return (Box) criteria.uniqueResult();
-  }
-
-  public ChangeLogStore getChangeLogStore() {
-    return changeLogStore;
   }
 
   public JdbcTemplate getJdbcTemplate() {
@@ -270,7 +173,7 @@ public class HibernateBoxDao implements BoxStore {
   @Override
   public void removeBoxableFromBox(Boxable boxable) throws IOException {
     Box box = get(boxable.getBox().getId());
-    box.removeBoxable(boxable);
+    box.removeBoxable(boxable.getBoxPosition());
     currentSession().save(box);
   }
 
@@ -281,18 +184,8 @@ public class HibernateBoxDao implements BoxStore {
     } else {
       currentSession().update(box);
       currentSession().flush();
-      ChangeLogEntry log;
-      while ((log = changeLogQueue.poll()) != null) {
-        ChangeLog changeLog = box.createChangeLog(log.summary, "contents", log.box.getLastModifier());
-        changeLogStore.create(changeLog);
-      }
-
       return box.getId();
     }
-  }
-
-  public void setChangeLogStore(ChangeLogStore changeLogStore) {
-    this.changeLogStore = changeLogStore;
   }
 
   public void setJdbcTemplate(JdbcTemplate template) {

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLBoxDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLBoxDAOTest.java
@@ -160,10 +160,13 @@ public class SQLBoxDAOTest extends AbstractDAOTest {
   public void testEmptySingleTube() throws Exception {
 
     Box box = dao.get(1);
+    int count = box.getBoxables().size();
 
-    assertTrue("precondition failed", box.getBoxables().values().size() > 0);
+    assertTrue("precondition failed", box.getBoxables().size() > 0);
+    assertTrue(box.getBoxables().containsKey("B02"));
     dao.discardSingleTube(box, "B02");
-    assertTrue(box.getBoxables().values().size() == 0);
+    Box fetchedBox = dao.get(1);
+    assertEquals(count - 1, fetchedBox.getBoxables().size());
 
   }
 
@@ -171,10 +174,11 @@ public class SQLBoxDAOTest extends AbstractDAOTest {
   public void testRemoveBoxableFromBox() throws Exception {
     Box box = dao.get(1);
     Boxable item = box.getBoxables().values().iterator().next();
+    assertNotNull(item);
 
     dao.removeBoxableFromBox(item);
     Box again = dao.get(1);
-    assertFalse(again.getBoxables().values().contains(item));
+    assertFalse(again.getBoxables().containsValue(item));
   }
 
   @Test

--- a/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
+++ b/sqlstore/src/test/resources/db/test_migration/V9000__miso_test_data.test.sql
@@ -476,7 +476,7 @@ VALUES
 DELETE FROM BoxPosition;
 INSERT INTO `BoxPosition` (`boxId`, `position`, `targetType`, `targetId`)
 VALUES
-('1', 'A01', 'S', 1),
+('1', 'B02', 'S', 1),
 ('2', 'A02', 'S', 2);
 
 DELETE FROM Submission;


### PR DESCRIPTION
The original interceptor design to log changes to pools and boxes created
multiple Hibernate sessions. This attaches the interceptor to the Hibernate
session factory.