### PR TITLE
Change Status to use runAlias consistently

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Status.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Status.java
@@ -125,9 +125,9 @@ public interface Status extends Securable {
 
   public void setInstrumentName(String instrumentName);
 
-  public String getRunName();
+  public String getRunAlias();
 
-  public void setRunName(String runName);
+  public void setRunAlias(String runName);
 
   public Date getLastUpdated();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StatusImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/StatusImpl.java
@@ -72,8 +72,8 @@ public class StatusImpl implements Status, Serializable {
   @Column(nullable = false)
   private String instrumentName;
   private byte[] xml;
-  @Column(nullable = false)
-  private String runName;
+  @Column(name = "runName", nullable = false)
+  private String runAlias;
   @Column(nullable = false)
   @Temporal(TemporalType.TIMESTAMP)
   private Date lastUpdated;
@@ -93,7 +93,7 @@ public class StatusImpl implements Status, Serializable {
    *          of type String
    */
   public StatusImpl(String runName) {
-    setRunName(runName);
+    setRunAlias(runName);
     setHealth(HealthType.Unknown);
     setStartDate(new Date());
   }
@@ -167,13 +167,13 @@ public class StatusImpl implements Status, Serializable {
   }
 
   @Override
-  public String getRunName() {
-    return runName;
+  public String getRunAlias() {
+    return runAlias;
   }
 
   @Override
-  public void setRunName(String runName) {
-    this.runName = runName;
+  public void setRunAlias(String runAlias) {
+    this.runAlias = runAlias;
   }
 
   @Override
@@ -205,7 +205,7 @@ public class StatusImpl implements Status, Serializable {
     // If not saved, then compare resolved actual objects. Otherwise
     // just compare IDs.
     if (getId().equals(StatusImpl.UNSAVED_ID) || them.getId().equals(StatusImpl.UNSAVED_ID)) {
-      return getRunName().equals(them.getRunName());
+      return getRunAlias().equals(them.getRunAlias());
     } else {
       return getId().equals(them.getId()) && getHealth().equals(them.getHealth()) && getStartDate().equals(them.getStartDate())
           && getCompletionDate().equals(them.getCompletionDate());
@@ -219,7 +219,7 @@ public class StatusImpl implements Status, Serializable {
     } else {
       final int PRIME = 31;
       int result = 1;
-      result = (result * PRIME) + (getRunName() == null ? 0 : getRunName().hashCode());
+      result = (result * PRIME) + (getRunAlias() == null ? 0 : getRunAlias().hashCode());
       return result;
     }
   }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/illumina/IlluminaStatus.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/illumina/IlluminaStatus.java
@@ -78,13 +78,13 @@ public class IlluminaStatus extends StatusImpl {
           setStartDate(new SimpleDateFormat("yyMMdd").parse(m.group(1)));
           setInstrumentName(m.group(2));
         }
-        setRunName(runName);
+        setRunAlias(runName);
         setHealth(HealthType.Unknown);
       } else {
         String runStarted = statusDoc.getElementsByTagName("RunStarted").item(0).getTextContent();
         setStartDate(new SimpleDateFormat("EEEE, MMMMM dd, yyyy h:mm aaa").parse(runStarted));
         setInstrumentName(statusDoc.getElementsByTagName("InstrumentName").item(0).getTextContent());
-        setRunName(statusDoc.getElementsByTagName("RunName").item(0).getTextContent());
+        setRunAlias(statusDoc.getElementsByTagName("RunName").item(0).getTextContent());
         setHealth(HealthType.Unknown);
       }
       setXml(statusXml);

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/solid/SolidStatus.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/solid/SolidStatus.java
@@ -80,7 +80,7 @@ public class SolidStatus extends StatusImpl {
           setStartDate(new SimpleDateFormat("yyyyMMdd").parse(m.group(2)));
           setInstrumentName(m.group(1));
         }
-        setRunName(runName);
+        setRunAlias(runName);
         setHealth(HealthType.Unknown);
       } else {
         String runName = statusDoc.getElementsByTagName("name").item(3).getTextContent();
@@ -110,7 +110,7 @@ public class SolidStatus extends StatusImpl {
           }
         }
 
-        setRunName(runName);
+        setRunAlias(runName);
         setHealth(HealthType.Unknown);
 
         setXml(statusXml);

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/MisoRequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/MisoRequestManager.java
@@ -1089,12 +1089,12 @@ public class MisoRequestManager implements RequestManager {
         run.getStatus().setLastUpdated(new Date());
 
         run.setName(generateTemporaryName());
-        run.getStatus().setRunName(run.getName());
+        run.getStatus().setRunAlias(run.getName());
         run.setId(runStore.save(run));
         try {
           String name = namingScheme.generateNameFor(run);
           run.setName(name);
-          run.getStatus().setRunName(run.getAlias());
+          run.getStatus().setRunAlias(run.getAlias());
 
           validateNameOrThrow(run, namingScheme);
           return runStore.save(run);
@@ -1113,7 +1113,7 @@ public class MisoRequestManager implements RequestManager {
         managed.getStatus().setStartDate(run.getStatus().getStartDate());
         managed.getStatus().setCompletionDate(run.getStatus().getCompletionDate());
         managed.getStatus().setInstrumentName(run.getStatus().getInstrumentName());
-        managed.getStatus().setRunName(managed.getName());
+        managed.getStatus().setRunAlias(managed.getAlias());
         managed.getStatus().setXml(run.getStatus().getXml());
         for (RunQC runQc : run.getRunQCs()) {
           if (!managed.getRunQCs().contains(runQc)) {
@@ -1356,7 +1356,7 @@ public class MisoRequestManager implements RequestManager {
         original.setHealth(status.getHealth());
         original.setCompletionDate(status.getCompletionDate());
         original.setXml(status.getXml());
-        original.setRunName(status.getRunName());
+        original.setRunAlias(status.getRunAlias());
         status = original;
       }
       return statusStore.save(status);
@@ -1551,7 +1551,7 @@ public class MisoRequestManager implements RequestManager {
   @Override
   public Status getStatusByRunName(String runName) throws IOException {
     if (statusStore != null) {
-      return statusStore.getByRunName(runName);
+      return statusStore.getByRunAlias(runName);
     } else {
       throw new IOException("No statusStore available. Check that it has been declared in the Spring config.");
     }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/integration/strategy/interrogator/IlluminaSequencerInterrogationStrategy.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/integration/strategy/interrogator/IlluminaSequencerInterrogationStrategy.java
@@ -102,7 +102,7 @@ public class IlluminaSequencerInterrogationStrategy implements SequencerInterrog
             String runStarted = statusDoc.getElementsByTagName("RunStarted").item(0).getTextContent();
             status.setStartDate(new SimpleDateFormat("EEEE, MMMMM dd, yyyy h:mm aaa").parse(runStarted));
             status.setInstrumentName(statusDoc.getElementsByTagName("InstrumentName").item(0).getTextContent());
-            status.setRunName(statusDoc.getElementsByTagName("RunName").item(0).getTextContent());
+            status.setRunAlias(statusDoc.getElementsByTagName("RunName").item(0).getTextContent());
             s.add(status);
           } catch (ParserConfigurationException e) {
             log.error("list all statuses", e);
@@ -126,7 +126,7 @@ public class IlluminaSequencerInterrogationStrategy implements SequencerInterrog
     String regex = ".*/([\\d]+_" + name + "_[\\d]+_[A-z0-9_]*)/.*";
     Pattern p = Pattern.compile(regex);
     for (Status s : listAllStatus(sr)) {
-      Matcher m = p.matcher(s.getRunName());
+      Matcher m = p.matcher(s.getRunAlias());
       if (m.matches()) {
         sts.add(s);
       }
@@ -215,7 +215,7 @@ public class IlluminaSequencerInterrogationStrategy implements SequencerInterrog
             String runStarted = statusDoc.getElementsByTagName("RunStarted").item(0).getTextContent();
             status.setStartDate(new SimpleDateFormat("EEEE, MMMMM dd, yyyy h:mm aaa").parse(runStarted));
             status.setInstrumentName(statusDoc.getElementsByTagName("InstrumentName").item(0).getTextContent());
-            status.setRunName(runName);
+            status.setRunAlias(runName);
             return status;
           }
         }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/integration/strategy/interrogator/LS454SequencerInterrogationStrategy.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/service/integration/strategy/interrogator/LS454SequencerInterrogationStrategy.java
@@ -109,7 +109,7 @@ public class LS454SequencerInterrogationStrategy implements SequencerInterrogati
             for (int i = 0; i < n.getChildNodes().getLength(); i++) {
               Node child = n.getChildNodes().item(i);
               if (child instanceof Element && ((Element) child).getTagName().equals("id")) {
-                status.setRunName(child.getTextContent());
+                status.setRunAlias(child.getTextContent());
               }
             }
             s.add(status);
@@ -218,7 +218,7 @@ public class LS454SequencerInterrogationStrategy implements SequencerInterrogati
             for (int i = 0; i < n.getChildNodes().getLength(); i++) {
               Node child = n.getChildNodes().item(i);
               if (child instanceof Element && ((Element) child).getTagName().equals("id")) {
-                status.setRunName(child.getTextContent());
+                status.setRunAlias(child.getTextContent());
               }
             }
             return status;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/StatusStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/StatusStore.java
@@ -43,7 +43,7 @@ public interface StatusStore extends Store<Status> {
    * @return
    * @throws IOException
    */
-  public Status getByRunName(String runName) throws IOException;
+  public Status getByRunAlias(String runName) throws IOException;
 
   /**
    * List all Statuses for a given sequencer machine name

--- a/demo-notification-client/src/main/java/uk/ac/bbsrc/tgac/miso/notification/demo/service/mechanism/DemoIlluminaConsumerMechanism.java
+++ b/demo-notification-client/src/main/java/uk/ac/bbsrc/tgac/miso/notification/demo/service/mechanism/DemoIlluminaConsumerMechanism.java
@@ -81,7 +81,7 @@ public class DemoIlluminaConsumerMechanism implements NotificationMessageConsume
       sb.append("Processing " + runName);
       log.debug("Processing " + runName);
       Status is = new IlluminaStatus();
-      is.setRunName(runName);
+      is.setRunAlias(runName);
 
       Run r = new IlluminaRun();
       r.setPlatformRunId(0);

--- a/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/IlluminaNotificationMessageConsumerMechanism.java
+++ b/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/IlluminaNotificationMessageConsumerMechanism.java
@@ -127,7 +127,7 @@ public class IlluminaNotificationMessageConsumerMechanism
       sb.append("Processing " + runName);
       log.debug("Processing " + runName);
       Status is = new IlluminaStatus();
-      is.setRunName(runName);
+      is.setRunAlias(runName);
       Run r = null;
 
       Matcher m = p.matcher(runName);
@@ -187,7 +187,7 @@ public class IlluminaNotificationMessageConsumerMechanism
             }
 
             if (r.getSequencerReference() == null) {
-              log.error("Cannot save " + is.getRunName() + ": no sequencer reference available.");
+              log.error("Cannot save " + is.getRunAlias() + ": no sequencer reference available.");
             } else {
               log.debug("Setting sequencer reference: " + sr.getName());
 
@@ -417,7 +417,7 @@ public class IlluminaNotificationMessageConsumerMechanism
             runsToSave.add(r);
           }
         } else {
-          log.warn("\\_ Run not saved. Saving status: " + is.getRunName());
+          log.warn("\\_ Run not saved. Saving status: " + is.getRunAlias());
           requestManager.saveStatus(is);
         }
       } catch (IOException ioe) {

--- a/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/LS454NotificationMessageConsumerMechanism.java
+++ b/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/LS454NotificationMessageConsumerMechanism.java
@@ -139,7 +139,7 @@ public class LS454NotificationMessageConsumerMechanism
         if (!runLog.startsWith("ERROR")) {
           Status is = new LS454Status(runLog);
           is.setHealth(ht);
-          is.setRunName(runName);
+          is.setRunAlias(runName);
 
           Run r = null;
           Matcher m = p.matcher(runName);
@@ -156,7 +156,7 @@ public class LS454NotificationMessageConsumerMechanism
           try {
             if (attemptRunPopulation) {
               if (r == null) {
-                log.debug("\\_ Saving new run and status: " + is.getRunName());
+                log.debug("\\_ Saving new run and status: " + is.getRunAlias());
                 r = new LS454Run();
                 r.setAlias(run.getString("runName"));
                 r.setDescription(m.group(3));
@@ -193,10 +193,10 @@ public class LS454NotificationMessageConsumerMechanism
                   r.setSequencerReference(sr);
                   runsToSave.add(r);
                 } else {
-                  log.error("\\_ Cannot save " + is.getRunName() + ": no sequencer reference available.");
+                  log.error("\\_ Cannot save " + is.getRunAlias() + ": no sequencer reference available.");
                 }
               } else {
-                log.debug("\\_ Updating existing run and status: " + is.getRunName());
+                log.debug("\\_ Updating existing run and status: " + is.getRunAlias());
 
                 r.setAlias(runName);
 
@@ -252,7 +252,7 @@ public class LS454NotificationMessageConsumerMechanism
 
                 // update status if run isn't completed or failed
                 if (!r.getStatus().getHealth().equals(HealthType.Completed) && !r.getStatus().getHealth().equals(HealthType.Failed)) {
-                  log.debug("Saving previously saved status: " + is.getRunName() + " (" + r.getStatus().getHealth().getKey() + " -> "
+                  log.debug("Saving previously saved status: " + is.getRunAlias() + " (" + r.getStatus().getHealth().getKey() + " -> "
                       + is.getHealth().getKey() + ")");
                   r.setStatus(is);
                 }

--- a/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/PacBioNotificationMessageConsumerMechanism.java
+++ b/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/PacBioNotificationMessageConsumerMechanism.java
@@ -137,7 +137,7 @@ public class PacBioNotificationMessageConsumerMechanism
           if (!status.startsWith("ERROR")) {
             Status is = new PacBioStatus(status);
             is.setHealth(ht);
-            is.setRunName(runName);
+            is.setRunAlias(runName);
 
             Run r = null;
 
@@ -153,7 +153,7 @@ public class PacBioNotificationMessageConsumerMechanism
 
             if (attemptRunPopulation) {
               if (r == null) {
-                log.info("\\_ Saving new run and status: " + is.getRunName());
+                log.info("\\_ Saving new run and status: " + is.getRunAlias());
                 r = new PacBioRun(status);
                 r.setAlias(run.getString("runName"));
                 r.setDescription(m.group(1));
@@ -190,10 +190,10 @@ public class PacBioNotificationMessageConsumerMechanism
 
                   r.setSequencerReference(sr);
                 } else {
-                  log.error("\\_ Cannot save " + is.getRunName() + ": no sequencer reference available.");
+                  log.error("\\_ Cannot save " + is.getRunAlias() + ": no sequencer reference available.");
                 }
               } else {
-                log.info("\\_ Updating existing run and status: " + is.getRunName());
+                log.info("\\_ Updating existing run and status: " + is.getRunAlias());
 
                 r.setAlias(runName);
 
@@ -240,7 +240,7 @@ public class PacBioNotificationMessageConsumerMechanism
 
                   // update status if run isn't completed or failed
                   if (!r.getStatus().getHealth().equals(HealthType.Completed) && !r.getStatus().getHealth().equals(HealthType.Failed)) {
-                    log.info("Saving previously saved status: " + is.getRunName() + " (" + r.getStatus().getHealth().getKey() + " -> "
+                    log.info("Saving previously saved status: " + is.getRunAlias() + " (" + r.getStatus().getHealth().getKey() + " -> "
                         + is.getHealth().getKey() + ")");
                     r.setStatus(is);
                   }
@@ -315,7 +315,7 @@ public class PacBioNotificationMessageConsumerMechanism
                 runsToSave.add(r);
               }
             } else {
-              log.warn("\\_ Run not saved. Saving status: " + is.getRunName());
+              log.warn("\\_ Run not saved. Saving status: " + is.getRunAlias());
               requestManager.saveStatus(is);
             }
           }

--- a/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/SolidNotificationMessageConsumerMechanism.java
+++ b/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/SolidNotificationMessageConsumerMechanism.java
@@ -119,7 +119,7 @@ public class SolidNotificationMessageConsumerMechanism
         String xml = run.getString("status");
         Status is = new SolidStatus(xml);
         is.setHealth(ht);
-        is.setRunName(runName);
+        is.setRunAlias(runName);
 
         Run r = null;
         Matcher m = p.matcher(runName);
@@ -135,7 +135,7 @@ public class SolidNotificationMessageConsumerMechanism
         try {
           if (attemptRunPopulation) {
             if (r == null) {
-              log.debug("Saving new run and status: " + is.getRunName());
+              log.debug("Saving new run and status: " + is.getRunAlias());
               r = new SolidRun(xml);
               r.getStatus().setHealth(ht);
               if (run.has("fullPath")) {
@@ -188,7 +188,7 @@ public class SolidNotificationMessageConsumerMechanism
                 }
               }
             } else {
-              log.debug("Updating existing run and status: " + is.getRunName());
+              log.debug("Updating existing run and status: " + is.getRunAlias());
 
               r.setAlias(runName);
               r.setPlatformType(PlatformType.SOLID);
@@ -250,7 +250,7 @@ public class SolidNotificationMessageConsumerMechanism
 
                 // update status if run isn't completed or failed
                 if (!r.getStatus().getHealth().equals(HealthType.Completed) && !r.getStatus().getHealth().equals(HealthType.Failed)) {
-                  log.debug("Saving previously saved status: " + is.getRunName() + " (" + r.getStatus().getHealth().getKey() + " -> "
+                  log.debug("Saving previously saved status: " + is.getRunAlias() + " (" + r.getStatus().getHealth().getKey() + " -> "
                       + is.getHealth().getKey() + ")");
                   r.setStatus(is);
                 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateStatusDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateStatusDao.java
@@ -67,10 +67,10 @@ public class HibernateStatusDao implements StatusStore {
   }
 
   @Override
-  public Status getByRunName(String runName) throws IOException {
-    runName = DbUtils.convertStringToSearchQuery(runName);
+  public Status getByRunAlias(String runAlias) throws IOException {
+    runAlias = DbUtils.convertStringToSearchQuery(runAlias);
     Criteria criteria = currentSession().createCriteria(StatusImpl.class);
-    criteria.add(Restrictions.ilike("runName", runName));
+    criteria.add(Restrictions.ilike("runAlias", runAlias));
     criteria.setMaxResults(1);
     return (Status) criteria.uniqueResult();
   }

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLRunDAOTest.java
@@ -118,7 +118,7 @@ public class SQLRunDAOTest extends AbstractDAOTest {
     when(sequencerReferenceDAO.get(Matchers.anyLong())).thenReturn(emptySR);
     emptyStatus.setHealth(HealthType.Unknown);
     emptyStatus.setInstrumentName("srName");
-    emptyStatus.setRunName("runName");
+    emptyStatus.setRunAlias("runName");
     emptyStatus.setLastUpdated(new Date());
     emptyStatus.setStartDate(new Date());
     when(statusDao.get(Matchers.anyLong())).thenReturn(emptyStatus);

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLStatusDAOTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/sqlstore/SQLStatusDAOTest.java
@@ -72,7 +72,7 @@ public class SQLStatusDAOTest extends AbstractDAOTest {
     status.setStartDate(start);
     status.setLastUpdated(lastModified);
     status.setInstrumentName(instrument);
-    status.setRunName(runName);
+    status.setRunAlias(runName);
     status.setXml(xml);
 
     long id = dao.save(status);
@@ -86,7 +86,7 @@ public class SQLStatusDAOTest extends AbstractDAOTest {
     assertEquals(format.format(start), format.format(rtn.getStartDate()));
     assertEquals(instrument, rtn.getInstrumentName());
     assertNotSame(format.format(lastModified), rtn.getLastUpdated().toString());
-    assertEquals(runName, rtn.getRunName());
+    assertEquals(runName, rtn.getRunAlias());
     // TODO: Better xml assertion.
     assertNotNull(rtn.getXml());
 
@@ -152,7 +152,7 @@ public class SQLStatusDAOTest extends AbstractDAOTest {
     assertEquals(start, format.format(status.getStartDate()));
     assertEquals(instrument, status.getInstrumentName());
     assertTrue(status.getLastUpdated().after(calendar.getTime()));
-    assertEquals(runName, status.getRunName());
+    assertEquals(runName, status.getRunAlias());
     // TODO assert xml is still the same. Converting back isn't straightforward.
     // "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!--Illumina RTA Status Report-->\n<Status>\n <Software>Illumina RTA
     // 1.12.4.2</Software>\n <RunName>120323_h1179_0070_BC0JHTACXX</RunName>\n <InstrumentName>H1179</InstrumentName>\n <RunStarted>Tuesday,
@@ -165,13 +165,13 @@ public class SQLStatusDAOTest extends AbstractDAOTest {
   }
 
   /**
-   * Test method for {@link uk.ac.bbsrc.tgac.miso.sqlstore.SQLStatusDAO#getByRunName(java.lang.String)}.
+   * Test method for {@link uk.ac.bbsrc.tgac.miso.sqlstore.SQLStatusDAO#getByRunAlias(java.lang.String)}.
    * 
    * @throws IOException
    */
   @Test
   public void testGetByRunName() throws IOException {
-    Status status = dao.getByRunName("120412_h1179_0073_BC075RACXX");
+    Status status = dao.getByRunAlias("120412_h1179_0073_BC075RACXX");
     assertNotNull(status);
   }
 


### PR DESCRIPTION
The notification server and Status use the term runName to refer to the thing MISO calls Run.alias . This updates the getters and setters on Status to use the term run.alias to avoid confusion. (Note that the notification server still uses the term runName, because this is the term that the sequencers and possibly the SRA use.)