### PR TITLE
always show date of receipt and sci. name for bulk create/update

### DIFF
--- a/miso-web/src/main/webapp/scripts/sample_hot.js
+++ b/miso-web/src/main/webapp/scripts/sample_hot.js
@@ -681,7 +681,7 @@ Sample.hot = {
         },
         allowEmpty: true,
         extraneous: true,
-        include: !isDetailed || show['Tissue']
+        include: true
       },
       {
         header: 'Matrix Barcode',
@@ -706,7 +706,7 @@ Sample.hot = {
         validator: Hot.requiredText,
         renderer: Hot.requiredTextRenderer,
         extraneous: true,
-        include: !isDetailed || show['Tissue']
+        include: true
       },
 
       // Parent columns


### PR DESCRIPTION
So users can bulk update if receiving non-tissue, or if they need to bulk update scientific name for detailed samples.