### PR TITLE
Remove experiments link

### DIFF
--- a/miso-web/src/main/webapp/pages/adminsub.jsp
+++ b/miso-web/src/main/webapp/pages/adminsub.jsp
@@ -47,7 +47,7 @@
         <li><a href="<c:url value="/miso/sequencers"/>">Sequencers</a></li>
         <li><a href="<c:url value="/miso/kitdescriptors"/>">Kits</a></li>
         <li><a href="<c:url value="/miso/indices"/>">Indices</a></li>
-        <li><a href="<c:url value="/miso/experiments"/>">Experiments</a></li>
+        <%-- <li><a href="<c:url value="/miso/experiments"/>">Experiments</a></li> --%>
         <li><a href="<c:url value="/miso/studies"/>">Studies</a></li>
         <li><a href="<c:url value="/miso/printers"/>">Printers</a></li>
     </ul>


### PR DESCRIPTION
I commented out the link to the experiments page in the left hand navigation menu until we solve the back end issues surrounding the listAll methods.