### PR TITLE
Add library QC types

### DIFF
--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/LibraryDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/LibraryDto.java
@@ -48,6 +48,9 @@ public class LibraryDto {
   private Long boxId;
   private List<LibraryQcDto> qcs;
   private Integer dnaSize;
+  private Double qcQubit;
+  private Double qcTapeStation;
+  private Double qcQPcr;
 
   public String getAlias() {
     return alias;
@@ -305,5 +308,29 @@ public class LibraryDto {
   public void writeUrls(UriComponentsBuilder uriBuilder) {
     URI baseUri = uriBuilder.build().toUri();
     writeUrls(baseUri);
+  }
+
+  public Double getQcQubit() {
+    return qcQubit;
+  }
+
+  public void setQcQubit(Double qcQubit) {
+    this.qcQubit = qcQubit;
+  }
+
+  public Double getQcTapeStation() {
+    return qcTapeStation;
+  }
+
+  public void setQcTapeStation(Double qcTapeStation) {
+    this.qcTapeStation = qcTapeStation;
+  }
+
+  public Double getQcQPcr() {
+    return qcQPcr;
+  }
+
+  public void setQcQPcr(Double qcQPcr) {
+    this.qcQPcr = qcQPcr;
   }
 }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryRestController.java
@@ -53,6 +53,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
+import uk.ac.bbsrc.tgac.miso.core.data.LibraryQC;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryQCImpl;
+import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.dto.DataTablesResponseDto;
 import uk.ac.bbsrc.tgac.miso.dto.Dtos;
 import uk.ac.bbsrc.tgac.miso.dto.LibraryDto;
@@ -73,6 +76,9 @@ public class LibraryRestController extends RestController {
 
   @Autowired
   private LibraryService libraryService;
+
+  @Autowired
+  private RequestManager requestManager;
 
   public void setLibraryService(LibraryService libraryService) {
     this.libraryService = libraryService;
@@ -134,6 +140,24 @@ public class LibraryRestController extends RestController {
       throw new RestException("No such library.", Status.NOT_FOUND);
     }
     library = Dtos.to(libraryDto);
+    if (libraryDto.getQcQubit() != null) {
+      LibraryQC qc = new LibraryQCImpl();
+      qc.setQcType(requestManager.getLibraryQcTypeByName("Qubit"));
+      qc.setResults(libraryDto.getQcQubit());
+      libraryService.addQc(library, qc);
+    }
+    if (libraryDto.getQcTapeStation() != null) {
+      LibraryQC qc = new LibraryQCImpl();
+      qc.setQcType(requestManager.getLibraryQcTypeByName("Tape Station"));
+      qc.setResults(libraryDto.getQcTapeStation());
+      libraryService.addQc(library, qc);
+    }
+    if (libraryDto.getQcQPcr() != null) {
+      LibraryQC qc = new LibraryQCImpl();
+      qc.setQcType(requestManager.getLibraryQcTypeByName("qPCR"));
+      qc.setResults(libraryDto.getQcQPcr());
+      libraryService.addQc(library, qc);
+    }
     libraryService.update(library);
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/miso-web/src/main/webapp/scripts/library_hot.js
+++ b/miso-web/src/main/webapp/scripts/library_hot.js
@@ -194,7 +194,10 @@ Library.hot = {
     volume: null,
     kitDescriptorId: null,
     kitDescriptorName: null,
-    archived: false
+    archived: false,
+    qcQubit: null,
+    qcTapeStation: null,
+    qcQPcr: null
   },
   
   /**
@@ -371,6 +374,15 @@ Library.hot = {
         include: true
       },
       {
+        header: 'Kit',
+        data: 'kitDescriptorName',
+        type: 'dropdown',
+        trimDropdown: false,
+        source: Library.hot.getKitDescriptors(),
+        renderer: Hot.requiredAutocompleteRenderer,
+        include: detailedBool
+      },
+      {
         header: 'QC Passed?',
         data: 'qcPassed',
         type: 'dropdown',
@@ -392,13 +404,25 @@ Library.hot = {
         include: !(Library.hot.hideCols.indexOf("volume") > -1)
       },
       {
-        header: 'Kit',
-        data: 'kitDescriptorName',
-        type: 'dropdown',
-        trimDropdown: false,
-        source: Library.hot.getKitDescriptors(),
-        renderer: Hot.requiredAutocompleteRenderer,
-        include: detailedBool
+        header: 'Qubit (ng/&#181;l)',
+        data: 'qcQubit',
+        type: 'numeric',
+        format: '0.0',
+        include: Library.hot.propagateOrEdit == 'Edit'
+      },
+      {
+        header: 'TapeStation (bp)',
+        data: 'qcTapeStation',
+        type: 'numeric',
+        format: '0.0',
+        include: Library.hot.propagateOrEdit == 'Edit'
+      },
+      {
+        header: 'qPCR (mol/&#181;l)',
+        data: 'qcQPcr',
+        type: 'numeric',
+        format: '0.0',
+        include: Library.hot.propagateOrEdit == 'Edit'
       }
     ].filter(function(col) { return col.include; });
   },
@@ -644,6 +668,15 @@ Library.hot = {
 
       lib.dnaSize = obj.dnaSize;
       lib.volume = obj.volume;
+      if (lib.qcQubit) {
+        lib.qcQubit = obj.qcQubit;
+      }
+      if (lib.qcTapeStation) {
+        lib.qcTapeStation = obj.qcTapeStation;
+      }
+      if (lib.qcQPcr) {
+        lib.qcQPcr = obj.qcQPcr;
+      }
 
       if (Hot.detailedSample) {
         lib.type = 'Detailed';


### PR DESCRIPTION
Add the ability to do certain QC procedures in bulk via the bulk library edit page. This is a temporary feature since it doesn't allow editing existing QCs in bulk nor setting dates or other particulars on QC. This is a stop gap measure to allow adding bulk QCs for OICR rollout until we can design something more comprehensive.