### PR TITLE
Rename all DAO tests consistently

### DIFF
--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateAlertDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateAlertDaoTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyLong;
@@ -36,7 +36,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateAlertDao;
  * @author Chris Salt
  *
  */
-public class SQLAlertDAOTest extends AbstractDAOTest {
+public class HibernateAlertDaoTest extends AbstractDAOTest {
 
   @Autowired
   private JdbcTemplate template;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateBoxDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateBoxDaoTest.java
@@ -21,7 +21,7 @@
  * *********************************************************************
  */
 
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -53,7 +53,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateBoxDao;
 
-public class SQLBoxDAOTest extends AbstractDAOTest {
+public class HibernateBoxDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateChangeLogDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateChangeLogDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyLong;
@@ -26,7 +26,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateChangeLogDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateLibraryDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSecurityDao;
 
-public class SQLChangeLogDAOTest extends AbstractDAOTest {
+public class HibernateChangeLogDaoTest extends AbstractDAOTest {
 
   @Mock
   private HibernateSecurityDao securityDAO;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateExperimentDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateExperimentDaoTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -38,7 +38,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateExperimentDao;
  * @author Chris Salt
  *
  */
-public class SQLExperimentDAOTest extends AbstractDAOTest {
+public class HibernateExperimentDaoTest extends AbstractDAOTest {
 
   @Autowired
   @Spy

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIndexDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateIndexDaoTest.java
@@ -16,7 +16,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.Index;
 import uk.ac.bbsrc.tgac.miso.core.data.IndexFamily;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 
-public class HiberateIndexDaoTest extends AbstractDAOTest {
+public class HibernateIndexDaoTest extends AbstractDAOTest {
   private HibernateIndexDao dao;
   @Autowired
   private SessionFactory sessionFactory;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateKitDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateKitDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.hasEntry;
@@ -35,7 +35,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateChangeLogDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateKitDao;
 
-public class SQLKitDAOTest extends AbstractDAOTest {
+public class HibernateKitDaoTest extends AbstractDAOTest {
 
   @InjectMocks
   private HibernateKitDao dao;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryDaoTest.java
@@ -1,5 +1,5 @@
 
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -34,7 +34,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.IndexStore;
 import uk.ac.bbsrc.tgac.miso.core.store.SampleStore;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateLibraryDao;
 
-public class SQLLibraryDAOTest extends AbstractDAOTest {
+public class HibernateLibraryDaoTest extends AbstractDAOTest {
 
   @Autowired
   private JdbcTemplate jdbcTemplate;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryDilutionDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryDilutionDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -28,7 +28,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateLibraryDilutionDao;
 
-public class SQLLibraryDilutionDAOTest extends AbstractDAOTest {
+public class HibernateLibraryDilutionDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryQcDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateLibraryQcDaoTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -29,7 +29,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateLibraryQcDao;
  * @author Chris Salt
  *
  */
-public class SQLLibraryQCDAOTest extends AbstractDAOTest {
+public class HibernateLibraryQcDaoTest extends AbstractDAOTest {
 
   @Autowired
   private SessionFactory sessionFactory;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePlatformDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePlatformDaoTest.java
@@ -20,7 +20,7 @@
  * * *********************************************************************
  * */
 
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -44,7 +44,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.PlatformImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernatePlatformDao;
 
-public class SQLPlatformDAOTest extends AbstractDAOTest {
+public class HibernatePlatformDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolQcDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePoolQcDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -24,7 +24,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.QcType;
 import uk.ac.bbsrc.tgac.miso.core.exception.MalformedPoolException;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernatePoolQCDao;
 
-public class SQLPoolQCDAOTest extends AbstractDAOTest {
+public class HibernatePoolQcDaoTest extends AbstractDAOTest {
   
   @Rule
   public ExpectedException expectedException = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePrintServiceDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePrintServiceDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -20,7 +20,7 @@ import uk.ac.bbsrc.tgac.miso.core.service.printing.Backend;
 import uk.ac.bbsrc.tgac.miso.core.service.printing.Driver;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernatePrinterDao;
 
-public class SQLPrintServiceDAOTest extends AbstractDAOTest {
+public class HibernatePrintServiceDaoTest extends AbstractDAOTest {
   @Rule
   public final ExpectedException exception = ExpectedException.none();
 

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateProjectDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateProjectDaoTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -39,7 +39,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateProjectDao;
  * @author Chris Salt
  *
  */
-public class SQLProjectDAOTest extends AbstractDAOTest {
+public class HibernateProjectDaoTest extends AbstractDAOTest {
 
   @Autowired
   private JdbcTemplate jdbcTemplate;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateReferenceGenomeDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateReferenceGenomeDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -16,7 +16,7 @@ import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
 import uk.ac.bbsrc.tgac.miso.core.data.ReferenceGenome;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateReferenceGenomeDao;
 
-public class SQLReferenceGenomeDAOTest extends AbstractDAOTest {
+public class HibernateReferenceGenomeDaoTest extends AbstractDAOTest {
 
   @Autowired
   private SessionFactory sessionFactory;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRunDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRunDaoTest.java
@@ -21,7 +21,7 @@
  * *********************************************************************
  */
 
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -72,7 +72,7 @@ import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateChangeLogDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateRunDao;
 
-public class SQLRunDAOTest extends AbstractDAOTest {
+public class HibernateRunDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRunQcDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateRunQcDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -32,7 +32,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.QcType;
 import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateRunQcDao;
 
-public class SQLRunQCDAOTest extends AbstractDAOTest {
+public class HibernateRunQcDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
@@ -41,9 +41,9 @@ import uk.ac.bbsrc.tgac.miso.core.service.naming.validation.ValidationResult;
 import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSampleDao;
 
-public class SQLSampleDAOTest extends AbstractDAOTest {
+public class HibernateSampleDaoTest extends AbstractDAOTest {
 
-  private static final Logger log = LoggerFactory.getLogger(SQLSampleDAOTest.class);
+  private static final Logger log = LoggerFactory.getLogger(HibernateSampleDaoTest.class);
   @Rule
   public final ExpectedException exception = ExpectedException.none();
 

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleQcDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleQcDaoTest.java
@@ -20,7 +20,7 @@
  * *********************************************************************
  */
 
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -49,7 +49,7 @@ import uk.ac.bbsrc.tgac.miso.core.exception.MalformedSampleException;
 import uk.ac.bbsrc.tgac.miso.core.store.SampleStore;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSampleQcDao;
 
-public class SQLSampleQCDAOTest extends AbstractDAOTest {
+public class HibernateSampleQcDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSecurityDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSecurityDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -33,7 +33,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import uk.ac.bbsrc.tgac.miso.core.store.Store;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSecurityDao;
 
-public class SQLSecurityDAOTest extends AbstractDAOTest {
+public class HibernateSecurityDaoTest extends AbstractDAOTest {
   
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSecurityProfileDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSecurityProfileDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -24,7 +24,7 @@ import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSecurityProfileDao;
 
-public class SQLSecurityProfileDAOTest extends AbstractDAOTest {
+public class HibernateSecurityProfileDaoTest extends AbstractDAOTest {
 
   private static final User USER = new UserImpl();
   private static final Group GROUP = new Group();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencerPartitionContainerDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencerPartitionContainerDaoTest.java
@@ -20,7 +20,7 @@
  * * *********************************************************************
  * */
 
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -55,7 +55,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import uk.ac.bbsrc.tgac.miso.core.store.SecurityStore;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSequencerPartitionContainerDao;
 
-public class SQLSequencerPartitionContainerDAOTest extends AbstractDAOTest {
+public class HibernateSequencerPartitionContainerDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencerReferenceDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencerReferenceDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -26,7 +26,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernatePlatformDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSequencerReferenceDao;
 
-public class SQLSequencerReferenceDAOTest extends AbstractDAOTest {
+public class HibernateSequencerReferenceDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencerServiceRecordDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSequencerServiceRecordDaoTest.java
@@ -21,7 +21,7 @@
  * *********************************************************************
  */
 
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -52,7 +52,7 @@ import uk.ac.bbsrc.tgac.miso.core.manager.MisoFilesManager;
 import uk.ac.bbsrc.tgac.miso.core.store.SequencerReferenceStore;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSequencerServiceRecordDao;
 
-public class SQLSequencerServiceRecordDAOTest extends AbstractDAOTest {
+public class HibernateSequencerServiceRecordDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateStatusDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateStatusDaoTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.junit.Assert.*;
 
@@ -29,7 +29,7 @@ import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateStatusDao;
  * @author Chris Salt
  *
  */
-public class SQLStatusDAOTest extends AbstractDAOTest {
+public class HibernateStatusDaoTest extends AbstractDAOTest {
 
   @Autowired
   private JdbcTemplate jdbcTemplate;

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateStudyDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateStudyDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.*;
@@ -31,7 +31,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 import uk.ac.bbsrc.tgac.miso.core.exception.MisoNamingException;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateStudyDao;
 
-public class SQLStudyDAOTest extends AbstractDAOTest {
+public class HibernateStudyDaoTest extends AbstractDAOTest {
 
   @Rule
   public final ExpectedException exception = ExpectedException.none();

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTargetedSequencingDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateTargetedSequencingDaoTest.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.sqlstore;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -16,7 +16,7 @@ import uk.ac.bbsrc.tgac.miso.AbstractDAOTest;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.TargetedSequencing;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateTargetedSequencingDao;
 
-public class SQLTargetedSequencingDAOTest extends AbstractDAOTest {
+public class HibernateTargetedSequencingDaoTest extends AbstractDAOTest {
 
   @Autowired
   private SessionFactory sessionFactory;


### PR DESCRIPTION
In particular, I'm tired of `HiberateIndexDaoTest`.