### PR TITLE
GLT-1611 Notification server uses RunImpl instead of subclasses

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/MisoRequestManager.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/manager/MisoRequestManager.java
@@ -1106,6 +1106,7 @@ public class MisoRequestManager implements RequestManager {
       run.getStatus().setInstrumentName(run.getSequencerReference().getName());
 
       if (run.getId() == AbstractRun.UNSAVED_ID) {
+        run.setSecurityProfile(securityProfileStore.get(securityProfileStore.save(run.getSecurityProfile())));
         run.setLastModifier(getCurrentUser());
         run.getStatus().setLastUpdated(new Date());
 
@@ -1167,17 +1168,7 @@ public class MisoRequestManager implements RequestManager {
   @Override
   public void saveRuns(Collection<Run> runs) throws IOException {
     if (runStore != null) {
-      List<Run> newRuns = new ArrayList<>();
-      List<Run> savedRuns = new ArrayList<>();
       for (Run run : runs) {
-        if (run.getId() == AbstractRun.UNSAVED_ID) {
-          newRuns.add(run);
-        } else {
-          savedRuns.add(run);
-        }
-      }
-      runStore.saveAll(newRuns);
-      for (Run run : savedRuns) {
         saveRun(run);
       }
     } else {

--- a/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/IlluminaNotificationMessageConsumerMechanism.java
+++ b/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/IlluminaNotificationMessageConsumerMechanism.java
@@ -61,9 +61,9 @@ import uk.ac.bbsrc.tgac.miso.core.data.SequencerPartitionContainer;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerReference;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencingParameters;
 import uk.ac.bbsrc.tgac.miso.core.data.Status;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.RunImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SequencerPartitionContainerImpl;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.illumina.IlluminaRun;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.illumina.IlluminaStatus;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.StatusImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.type.HealthType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.exception.InterrogationException;
@@ -126,7 +126,9 @@ public class IlluminaNotificationMessageConsumerMechanism
       String runName = run.getString(IlluminaTransformer.JSON_RUN_NAME);
       sb.append("Processing " + runName);
       log.debug("Processing " + runName);
-      Status is = new IlluminaStatus();
+      // https://jira.oicr.on.ca/browse/GLT-1611
+      // Changed back to IlluminaStatus() in future.
+      Status is = new StatusImpl();
       is.setRunAlias(runName);
       Run r = null;
 
@@ -147,7 +149,9 @@ public class IlluminaNotificationMessageConsumerMechanism
             log.debug("Saving new run and status: " + runName);
             if (!run.has(IlluminaTransformer.JSON_STATUS)) {
               // probably MiSeq
-              r = new IlluminaRun();
+              // https://jira.oicr.on.ca/browse/GLT-1611
+              // Changed back to IlluminaRun() in future.
+              r = new RunImpl();
               r.setPlatformRunId(Integer.parseInt(m.group(2)));
               r.setAlias(runName);
               r.setFilePath(runName);
@@ -155,10 +159,14 @@ public class IlluminaNotificationMessageConsumerMechanism
               r.setPairedEnd(false);
               is.setHealth(ht);
               r.setStatus(is);
+              r.setPlatformType(PlatformType.ILLUMINA);
             } else {
               String xml = run.getString(IlluminaTransformer.JSON_STATUS);
-              is = new IlluminaStatus(xml);
-              r = new IlluminaRun(xml);
+              // https://jira.oicr.on.ca/browse/GLT-1611
+              // Changed back to IlluminaStatus(xml) in future.
+              r = new RunImpl();
+              ((RunImpl) r).illuminaRunConfig(xml, null);
+              is = r.getStatus();
               is.setHealth(ht);
               r.getStatus().setHealth(ht);
             }

--- a/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/PacBioNotificationMessageConsumerMechanism.java
+++ b/notification-consumer-services/src/main/java/uk/ac/bbsrc/tgac/miso/notification/consumer/service/mechanism/PacBioNotificationMessageConsumerMechanism.java
@@ -55,8 +55,8 @@ import uk.ac.bbsrc.tgac.miso.core.data.SequencerReference;
 import uk.ac.bbsrc.tgac.miso.core.data.Status;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.RunImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SequencerPartitionContainerImpl;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.StatusImpl;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.pacbio.PacBioRun;
-import uk.ac.bbsrc.tgac.miso.core.data.impl.pacbio.PacBioStatus;
 import uk.ac.bbsrc.tgac.miso.core.data.type.HealthType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.exception.InterrogationException;
@@ -135,7 +135,9 @@ public class PacBioNotificationMessageConsumerMechanism
       if (!isStringEmptyOrNull(status)) {
         try {
           if (!status.startsWith("ERROR")) {
-            Status is = new PacBioStatus(status);
+            // https://jira.oicr.on.ca/browse/GLT-1611
+            // Changed back to PacBioStatus(status) in future.
+            Status is = new StatusImpl();
             is.setHealth(ht);
             is.setRunAlias(runName);
 
@@ -154,7 +156,12 @@ public class PacBioNotificationMessageConsumerMechanism
             if (attemptRunPopulation) {
               if (r == null) {
                 log.info("\\_ Saving new run and status: " + is.getRunAlias());
-                r = new PacBioRun(status);
+                // https://jira.oicr.on.ca/browse/GLT-1611
+                // Changed back to PacBioRun(status) in future.
+                r = new RunImpl();
+                r.setPlatformType(PlatformType.PACBIO);
+                r.setStatus(is);
+
                 r.setAlias(run.getString("runName"));
                 r.setDescription(m.group(1));
                 r.setPairedEnd(false);


### PR DESCRIPTION
Notification server failed because hibernate does not know about the
RunImpl subclasses. Modified to use RunImpl rather than subclasses. Will switch
to subclasses when the Notification Server is revisited.