### PR TITLE
PacBio Transformer dies on surprising JSON

### DIFF
--- a/notification-server/src/main/java/uk/ac/bbsrc/tgac/miso/notification/service/PacBioTransformer.java
+++ b/notification-server/src/main/java/uk/ac/bbsrc/tgac/miso/notification/service/PacBioTransformer.java
@@ -190,6 +190,8 @@ public class PacBioTransformer implements FileSetTransformer<String, String, Fil
             log.error("Attempting fall-back date resolution...", e);
           } catch (UnsupportedEncodingException e) {
             log.error("Cannot encode plateId to be URL friendly.", e);
+          } catch (JSONException jsonEx) {
+            log.error("run folder does not match expected structure.  Skipping for now. " + rootFile.getName());
           }
         } else {
           log.error(rootFile.getName() + " :: Permission denied");


### PR DESCRIPTION
So what is happening is this:
The new PacBio Sequel machine folder structure is different to the current structure.  This transformer doesn't handle the new folder structure so tries to pull 'sequencerName' out of the wrong place, throws an exception causing the transform method to return early - undoing all it's work so far!
Catching and logging here enables to method to complete so at least recognised PacBio runs will be populated.
Next step is to parse the new directory structure...