### PR TITLE
GLT-1637 Modify how hibernate loads collections

### DIFF
--- a/core/src/main/java/com/eaglegenomics/simlims/core/Group.java
+++ b/core/src/main/java/com/eaglegenomics/simlims/core/Group.java
@@ -13,6 +13,9 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 
 /**
@@ -33,6 +36,7 @@ public class Group implements Serializable, Comparable<Group> {
   private String description = "";
   private String name = "";
   @ManyToMany(targetEntity = UserImpl.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "User_Group", joinColumns = { @JoinColumn(name = "groups_groupId") }, inverseJoinColumns = {
       @JoinColumn(name = "users_userId")
   })

--- a/core/src/main/java/com/eaglegenomics/simlims/core/SecurityProfile.java
+++ b/core/src/main/java/com/eaglegenomics/simlims/core/SecurityProfile.java
@@ -14,6 +14,9 @@ import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
 import uk.ac.bbsrc.tgac.miso.core.data.impl.UserImpl;
 
 /**
@@ -46,21 +49,25 @@ public class SecurityProfile implements Serializable {
   private User owner = null;
 
   @ManyToMany(targetEntity = UserImpl.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "SecurityProfile_ReadUser", inverseJoinColumns = { @JoinColumn(name = "readUser_userId") }, joinColumns = {
       @JoinColumn(name = "SecurityProfile_profileId") })
   private Collection<User> readUsers = new HashSet<>();
 
   @ManyToMany(targetEntity = UserImpl.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "SecurityProfile_WriteUser", inverseJoinColumns = { @JoinColumn(name = "writeUser_userId") }, joinColumns = {
       @JoinColumn(name = "SecurityProfile_profileId") })
   private Collection<User> writeUsers = new HashSet<>();
 
   @ManyToMany(targetEntity = Group.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "SecurityProfile_ReadGroup", inverseJoinColumns = { @JoinColumn(name = "readGroup_groupId") }, joinColumns = {
       @JoinColumn(name = "SecurityProfile_profileId") })
   private Collection<Group> readGroups = new HashSet<>();
 
   @ManyToMany(targetEntity = Group.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "SecurityProfile_WriteGroup", inverseJoinColumns = { @JoinColumn(name = "writeGroup_groupId") }, joinColumns = {
       @JoinColumn(name = "SecurityProfile_profileId") })
   private Collection<Group> writeGroups = new HashSet<>();

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
@@ -53,6 +53,8 @@ import javax.persistence.TemporalType;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.JoinFormula;
 import org.slf4j.Logger;
@@ -125,6 +127,7 @@ public abstract class AbstractLibrary extends AbstractBoxable implements Library
   private Double initialConcentration;
 
   @ManyToMany(targetEntity = Index.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "Library_Index", joinColumns = {
       @JoinColumn(name = "library_libraryId", nullable = false) }, inverseJoinColumns = {
           @JoinColumn(name = "index_indexId", nullable = false) })

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractProject.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractProject.java
@@ -52,6 +52,8 @@ import javax.persistence.Transient;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,6 +137,7 @@ public abstract class AbstractProject implements Project {
   private Date lastUpdated;
 
   @ManyToMany(targetEntity = UserImpl.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "Project_Watcher", joinColumns = { @JoinColumn(name = "projectId") },
       inverseJoinColumns = { @JoinColumn(name = "userId") })
   private Set<User> watchUsers = new HashSet<>();

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractRun.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractRun.java
@@ -48,6 +48,8 @@ import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Transient;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,6 +131,7 @@ public abstract class AbstractRun implements Run {
   private final Set<MisoListener> listeners = new HashSet<>();
 
   @ManyToMany(targetEntity = UserImpl.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "Run_Watcher", joinColumns = { @JoinColumn(name = "runId") }, inverseJoinColumns = { @JoinColumn(name = "userId") })
   private Set<User> watchUsers = new HashSet<>();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoolImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoolImpl.java
@@ -56,6 +56,8 @@ import javax.persistence.Transient;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.JoinFormula;
 import org.slf4j.Logger;
@@ -110,6 +112,7 @@ public class PoolImpl extends AbstractBoxable implements Pool, Serializable {
   @JoinFormula("(SELECT bp.boxId FROM BoxPosition bp WHERE bp.targetId = poolId AND bp.targetType = 'Pool')")
   @JsonBackReference
   private Box box;
+
   @OneToMany(targetEntity = PoolChangeLog.class, mappedBy = "pool")
   private final Collection<ChangeLog> changeLog = new ArrayList<>();
 
@@ -186,6 +189,7 @@ public class PoolImpl extends AbstractBoxable implements Pool, Serializable {
   private Group watchGroup;
 
   @ManyToMany(targetEntity = UserImpl.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "Pool_Watcher", joinColumns = { @JoinColumn(name = "poolId") }, inverseJoinColumns = { @JoinColumn(name = "userId") })
   private Set<User> watchUsers = new HashSet<>();
 

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/ProjectOverview.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/ProjectOverview.java
@@ -49,6 +49,8 @@ import javax.persistence.Transient;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,6 +130,7 @@ public class ProjectOverview implements Watchable, Alertable, Nameable, Serializ
   private boolean libraryPreparationComplete;
   @Transient
   private final Set<MisoListener> listeners = new HashSet<>();
+
   @OneToMany(targetEntity = Note.class, cascade = CascadeType.ALL)
   @JoinTable(name = "ProjectOverview_Note", joinColumns = {
       @JoinColumn(name = "overview_overviewId") }, inverseJoinColumns = {
@@ -149,6 +152,7 @@ public class ProjectOverview implements Watchable, Alertable, Nameable, Serializ
   private Group watchGroup;
 
   @ManyToMany(targetEntity = UserImpl.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "ProjectOverview_Watcher", joinColumns = { @JoinColumn(name = "overviewId") }, inverseJoinColumns = {
       @JoinColumn(name = "userId") })
   private Set<User> watchUsers = new HashSet<>();
@@ -481,6 +485,7 @@ public class ProjectOverview implements Watchable, Alertable, Nameable, Serializ
     this.startDate = startDate;
   }
 
+  @Override
   public void setWatchGroup(Group watchGroup) {
     this.watchGroup = watchGroup;
   }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SequencerPartitionContainerImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SequencerPartitionContainerImpl.java
@@ -45,6 +45,8 @@ import javax.persistence.OrderBy;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.BatchSize;
+
 import com.eaglegenomics.simlims.core.SecurityProfile;
 import com.eaglegenomics.simlims.core.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -86,6 +88,7 @@ public class SequencerPartitionContainerImpl implements SequencerPartitionContai
   private String locationBarcode;
 
   @ManyToMany(targetEntity = RunImpl.class, mappedBy = "containers")
+  @BatchSize(size = 10)
   private Collection<Run> runs = null;
 
   @ManyToOne(targetEntity = SecurityProfile.class, cascade = CascadeType.PERSIST)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/TargetedSequencing.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/TargetedSequencing.java
@@ -17,6 +17,9 @@ import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
 import com.eaglegenomics.simlims.core.User;
 
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
@@ -39,6 +42,7 @@ public class TargetedSequencing implements Serializable {
   private String description;
 
   @ManyToMany(mappedBy = "targetedSequencing")
+  @Fetch(FetchMode.SUBSELECT)
   private final Collection<KitDescriptor> kitDescriptors = new HashSet<>();
 
   @Column(nullable = false)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/UserImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/UserImpl.java
@@ -39,6 +39,8 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.GrantedAuthority;
@@ -82,6 +84,7 @@ public class UserImpl implements User, Serializable {
   private boolean active = true;
 
   @ManyToMany(targetEntity = Group.class)
+  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "User_Group", inverseJoinColumns = { @JoinColumn(name = "groups_groupId") }, joinColumns = {
       @JoinColumn(name = "users_userId") })
   private Collection<Group> groups = new HashSet<>();


### PR DESCRIPTION
Marked smaller collections as subselect so they will be completely
loaded on the first reference. Marked larger collections as batch so items
will be retrieved in chunks instead of one at a time.