### PR TITLE
Restore double-click-to-scan-pool-barcode functionality

### DIFF
--- a/miso-web/src/main/webapp/pages/editSequencerPartitionContainer.jsp
+++ b/miso-web/src/main/webapp/pages/editSequencerPartitionContainer.jsp
@@ -256,7 +256,7 @@
                         </c:when>
                         <c:otherwise>
                           <div id="p_div_${partitionCount.index}" class="elementListDroppableDiv">
-                            <ul class='runPartitionDroppable' bind='partitions[${partitionCount.index}].pool' partition='${partitionCount.index}' ondblclick='Container.partition.populateLane(this);'></ul>
+                            <ul class='runPartitionDroppable' bind='partitions[${partitionCount.index}].pool' partition='${partitionCount.index}' ondblclick='Container.partition.populatePartition(this);'></ul>
                           </div>
                         </c:otherwise>
                       </c:choose>


### PR DESCRIPTION
I must have missed this while changing all instances of "Lane" to "Partition".