### PR TITLE
fix migration numbering -- db changes required

### DIFF
--- a/sqlstore/src/main/resources/db/migration/V0270__auto_main.sql
+++ b/sqlstore/src/main/resources/db/migration/V0270__auto_main.sql
@@ -5,4 +5,8 @@ UPDATE SampleTissue SET tissueOriginId = (SELECT tissueOriginId FROM TissueOrigi
 ALTER TABLE SampleTissue CHANGE tissueTypeId tissueTypeId bigint(20) NOT NULL;
 ALTER TABLE SampleTissue CHANGE tissueOriginId tissueOriginId bigint(20) NOT NULL;
 
+-- PacBio_library_options
 
+INSERT INTO LibraryType (description, platformType, archived) VALUES ('Whole Genome', 'PACBIO', 0);
+
+INSERT INTO LibrarySelectionType (name, description) VALUES ('SageHLS', 'Sage High Molecular Weight Library System'), ('BluePippin', 'Sage BluePippin size selection');

--- a/sqlstore/src/main/resources/db/migration/V5201__PacBio_library_options.sql
+++ b/sqlstore/src/main/resources/db/migration/V5201__PacBio_library_options.sql
@@ -1,3 +1,0 @@
-INSERT INTO LibraryType (description, platformType, archived) VALUES ('Whole Genome', 'PACBIO', 0);
-
-INSERT INTO LibrarySelectionType (name, description) VALUES ('SageHLS', 'Sage High Molecular Weight Library System'), ('BluePippin', 'Sage BluePippin size selection');


### PR DESCRIPTION
I accidentally mis-numbered a migration in the last release and it didn't get picked up by `compact-migrations`, so it got applied to the database independently. This PR moves the code from that migration into the V270 migration that resulted from compaction, because it has already been applied to the database.

The next OICR release should go smoothly, as I have already deleted the V5201 record from `schema_version` and updated the checksum for V0720:
```
mysql > DELETE FROM schema_version WHERE version = 5201;
mysql > UPDATE schema_version SET checksum = '-74045544' WHERE version = 0270;
```