### PR TITLE
GLT-1803: fix properties used in header.jsp

### DIFF
--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/context/ApplicationContextProvider.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/context/ApplicationContextProvider.java
@@ -24,7 +24,6 @@
 package uk.ac.bbsrc.tgac.miso.webapp.context;
 
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
@@ -41,14 +40,8 @@ import org.springframework.context.ApplicationContextAware;
 public class ApplicationContextProvider implements ApplicationContextAware {
   private static ApplicationContext ctx = null;
 
-  private static String bugUrl;
-
   public static ApplicationContext getApplicationContext() {
     return ctx;
-  }
-
-  public static String getBugUrl() {
-    return bugUrl;
   }
 
   private String baseUrl = "";
@@ -64,11 +57,5 @@ public class ApplicationContextProvider implements ApplicationContextAware {
 
   public void setBaseUrl(String baseUrl) {
     this.baseUrl = baseUrl;
-  }
-
-  @Value("${miso.bugUrl}")
-  private void setBugUrl(String bugUrl) {
-    // This instance method writes to a static field because that's how Spring's injection system works.
-    ApplicationContextProvider.bugUrl = bugUrl;
   }
 }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/component/CommonModelAttributeProvider.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/component/CommonModelAttributeProvider.java
@@ -1,0 +1,26 @@
+package uk.ac.bbsrc.tgac.miso.webapp.controller.component;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class CommonModelAttributeProvider {
+
+  @Value("${miso.bugUrl:#{null}}")
+  private String bugUrl;
+
+  @Value("${miso.instanceName:#{null}}")
+  private String instanceName;
+
+  @ModelAttribute("misoBugUrl")
+  public String getBugUrl() {
+    return bugUrl;
+  }
+
+  @ModelAttribute("misoInstanceName")
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+}

--- a/miso-web/src/main/resources/external/miso.properties
+++ b/miso-web/src/main/resources/external/miso.properties
@@ -27,7 +27,10 @@ miso.baseDirectory:/storage/miso/
 miso.fileStorageDirectory:/storage/miso/files/
 miso.submissionStorageDirectory:/storage/miso/files/submission/
 
-# Where to send bug reports for your organisation
+# Instance name to display at the top of all pages (optional)
+#miso.instanceName:Develop
+
+# Where to send bug reports for your organisation (optional)
 miso.bugUrl:https://github.com/TGAC/miso-lims/issues/new
 
 ## config for naming scheme - see the MISO maintainer guide for all configuration options

--- a/miso-web/src/main/resources/internal/miso.properties
+++ b/miso-web/src/main/resources/internal/miso.properties
@@ -27,6 +27,9 @@ miso.baseDirectory:/storage/miso/
 miso.fileStorageDirectory:/storage/miso/files/
 miso.submissionStorageDirectory:/storage/miso/files/submission/
 
+# Instance name to display at the top of all pages (optional)
+#miso.instanceName:Develop
+
 ## config for naming scheme - see the MISO maintainer guide for all configuration options
 miso.naming.scheme:default
 

--- a/miso-web/src/main/webapp/header.jsp
+++ b/miso-web/src/main/webapp/header.jsp
@@ -104,7 +104,7 @@
       <a href='<c:url value='/'/>'>
         <img src="<c:url value='/styles/images/miso_bowl1_logo-tm.png'/>" alt="MISO Logo" name="logo" border="0" id="misologo"/>
       </a>
-       <span id="instanceName">${initParam['miso.name']}</span>
+       <span id="instanceName">${misoInstanceName}</span>
     </td>
     <td class="headertable" align="right">
       <img src="<c:url value='/styles/images/brand_logo.png'/>" alt="Brand Logo" name="logo" border="0" id="brandlogo"/>
@@ -155,7 +155,9 @@
 
 <sec:authorize access="isAuthenticated()">
   <div id="loggedInBanner" style="display:inline-block">
-    <a href="${ApplicationContextProvider.getBugUrl()}" target="_blank">Report a problem</a> |
+    <c:if test="${misoBugUrl != null}">
+      <a href="${misoBugUrl}" target="_blank">Report a problem</a> |
+    </c:if>
     Logged in as:
     <b id="currentUser"><sec:authentication property="principal.username"/></b>
     | <a href="<c:url value="/logout"/>">Logout</a>


### PR DESCRIPTION
Bug URL was provided by ApplicationContextProvider, which still worked on my machine, but apparently stopped working on staging and prod.

Instance name was in the ROOT.xml instead of properties file.

Both are now set in miso.properties and injected via CommonModelAttributeProvider into models returned from all Controllers.