### PR TITLE
GLT-1853 Avoid redrawing order table when adjusting visibility of columns

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/PoolOrderCompletion.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/PoolOrderCompletion.java
@@ -10,6 +10,7 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
@@ -20,6 +21,9 @@ import javax.persistence.MapKeyEnumerated;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import uk.ac.bbsrc.tgac.miso.core.data.PoolOrderCompletion.PoolOrderCompletionId;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolImpl;
@@ -63,6 +67,30 @@ public class PoolOrderCompletion implements Serializable {
       this.pool = pool;
     }
 
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((parameters == null) ? 0 : parameters.hashCode());
+      result = prime * result + ((pool == null) ? 0 : pool.hashCode());
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null) return false;
+      if (getClass() != obj.getClass()) return false;
+      PoolOrderCompletionId other = (PoolOrderCompletionId) obj;
+      if (parameters == null) {
+        if (other.parameters != null) return false;
+      } else if (!parameters.equals(other.parameters)) return false;
+      if (pool == null) {
+        if (other.pool != null) return false;
+      } else if (!pool.equals(other.pool)) return false;
+      return true;
+    }
+
   }
 
   private static final long serialVersionUID = 1L;
@@ -72,13 +100,14 @@ public class PoolOrderCompletion implements Serializable {
   @Id
   private SequencingParameters parameters;
 
-  @ElementCollection(targetClass = Integer.class)
+  @ElementCollection(targetClass = Integer.class, fetch = FetchType.EAGER)
   @CollectionTable(name = "OrderCompletion_Items", joinColumns = { @JoinColumn(name = "poolId", referencedColumnName = "poolId"),
       @JoinColumn(name = "parametersId", referencedColumnName = "parametersId") })
   @Column(name = "num_partitions")
   @MapKeyClass(HealthType.class)
   @MapKeyColumn(name = "health", unique = true)
   @MapKeyEnumerated(EnumType.STRING)
+  @Fetch(FetchMode.SUBSELECT)
   private Map<HealthType, Integer> items;
 
   @Temporal(TemporalType.TIMESTAMP)

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SequencingParametersImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/SequencingParametersImpl.java
@@ -161,4 +161,52 @@ public class SequencingParametersImpl implements SequencingParameters {
     this.xpath = xpath;
   }
 
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((createdBy == null) ? 0 : createdBy.hashCode());
+    result = prime * result + ((creationDate == null) ? 0 : creationDate.hashCode());
+    result = prime * result + ((lastUpdated == null) ? 0 : lastUpdated.hashCode());
+    result = prime * result + ((name == null) ? 0 : name.hashCode());
+    result = prime * result + ((parametersId == null) ? 0 : parametersId.hashCode());
+    result = prime * result + ((platform == null) ? 0 : platform.hashCode());
+    result = prime * result + ((updatedBy == null) ? 0 : updatedBy.hashCode());
+    result = prime * result + ((xpath == null) ? 0 : xpath.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    SequencingParametersImpl other = (SequencingParametersImpl) obj;
+    if (createdBy == null) {
+      if (other.createdBy != null) return false;
+    } else if (!createdBy.equals(other.createdBy)) return false;
+    if (creationDate == null) {
+      if (other.creationDate != null) return false;
+    } else if (!creationDate.equals(other.creationDate)) return false;
+    if (lastUpdated == null) {
+      if (other.lastUpdated != null) return false;
+    } else if (!lastUpdated.equals(other.lastUpdated)) return false;
+    if (name == null) {
+      if (other.name != null) return false;
+    } else if (!name.equals(other.name)) return false;
+    if (parametersId == null) {
+      if (other.parametersId != null) return false;
+    } else if (!parametersId.equals(other.parametersId)) return false;
+    if (platform == null) {
+      if (other.platform != null) return false;
+    } else if (!platform.equals(other.platform)) return false;
+    if (updatedBy == null) {
+      if (other.updatedBy != null) return false;
+    } else if (!updatedBy.equals(other.updatedBy)) return false;
+    if (xpath == null) {
+      if (other.xpath != null) return false;
+    } else if (!xpath.equals(other.xpath)) return false;
+    return true;
+  }
+
 }

--- a/miso-web/src/main/webapp/scripts/list.js
+++ b/miso-web/src/main/webapp/scripts/list.js
@@ -71,7 +71,7 @@ ListUtils = {
                           jqTable.fnSetColumnVis(index, column
                               .visibilityFilter(data.aaData.map(function(d) {
                                 return d[column.mData];
-                              })));
+                              })), false);
                         });
                         fnCallback(data, textStatus, xhr);
                       },


### PR DESCRIPTION
GLT-1853 Avoid redrawing order table when dynamically adjusting the visibility
of the columns. This reduces the number REST calls made and improves the display
time of the table.
Made retrieval of OrderCompletion_Items EAGER. This reduces the total number of
SQL queries hibernate issues when displaying the order page.