### PR TITLE
Refactor and fix problems with inferring tissue for tissue processing

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Sample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Sample.java
@@ -62,7 +62,6 @@ public interface Sample
   public static final Long UNSAVED_ID = 0L;
   /** Field PREFIX */
   public static final String PREFIX = "SAM";
-
   public void setId(long id);
 
   /**

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtils.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtils.java
@@ -649,16 +649,6 @@ public class LimsUtils {
     return null;
   }
 
-  public static boolean hasStockParent(Long id, Iterable<SampleValidRelationship> relationships) {
-    for (SampleValidRelationship relationship : relationships) {
-      if (!relationship.getArchived() && relationship.getChild().getId() == id
-          && relationship.getParent().getSampleCategory().equals(SampleStock.CATEGORY_NAME)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public static void validateNameOrThrow(Nameable object, NamingScheme namingScheme) throws IOException {
     ValidationResult val = namingScheme.validateName(object.getName());
     if (!val.isValid()) throw new IOException("Save failed - invalid name:" + val.getMessage());
@@ -769,7 +759,7 @@ public class LimsUtils {
   public static Date toBadDate(LocalDate localDate, ZoneId timezone) {
     return Date.from(localDate.atStartOfDay(timezone).toInstant());
   }
-  
+
   public static Date toBadDate(LocalDate localDate) {
     return toBadDate(localDate, ZoneId.systemDefault());
   }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleClassService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/SampleClassService.java
@@ -18,10 +18,8 @@ public interface SampleClassService {
 
   void delete(Long sampleClassId) throws IOException;
 
-  public SampleClass inferStockFromAliquot(SampleClass sampleClass);
+  public SampleClass inferParentFromChild(long childClassId, String childCategory, String parentCategory);
 
   List<SampleClass> listByCategory(String sampleCategory) throws IOException;
-
-  SampleClass inferTissueFromStock(SampleClass sampleClass);
 
 }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
@@ -478,11 +478,8 @@ public class EditSampleController {
   @Autowired
   private SampleClassService sampleClassService;
 
-  public static final List<String> CATEGORIES = Arrays.asList(SampleIdentity.CATEGORY_NAME, SampleTissue.CATEGORY_NAME,
-      SampleTissueProcessing.CATEGORY_NAME, SampleStock.CATEGORY_NAME, SampleAliquot.CATEGORY_NAME);
-
   private static final Comparator<SampleClass> SAMPLECLASS_CATEGORY_ALIAS = (SampleClass o1, SampleClass o2) -> {
-    int categoryOrder = CATEGORIES.indexOf(o1.getSampleCategory()) - CATEGORIES.indexOf(o2.getSampleCategory());
+    int categoryOrder = SampleClass.CATEGORIES.indexOf(o1.getSampleCategory()) - SampleClass.CATEGORIES.indexOf(o2.getSampleCategory());
     if (categoryOrder != 0) return categoryOrder;
     return o1.getAlias().compareTo(o2.getAlias());
   };
@@ -496,7 +493,7 @@ public class EditSampleController {
       if (SampleTissue.CATEGORY_NAME.equals(sc.getSampleCategory())) {
         tissueClasses.add(sc);
       }
-      if (sc.canCreateNew(relationships)) {
+      if (sc.hasPathToIdentity(relationships)) {
         sampleClasses.add(sc);
       }
     }
@@ -958,7 +955,8 @@ public class EditSampleController {
         builder.setTissueClass(sampleClassService.get(builder.getTissueClass().getId()));
       }
       if (builder.getParent() == null && builder.getSampleClass().getSampleCategory().equals(SampleAliquot.CATEGORY_NAME)) {
-        builder.setStockClass(sampleClassService.inferStockFromAliquot(builder.getSampleClass()));
+        builder.setStockClass(sampleClassService.inferParentFromChild(builder.getSampleClass().getId(), SampleAliquot.CATEGORY_NAME,
+            SampleStock.CATEGORY_NAME));
       }
       sample = builder.build();
     }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/MenuController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/MenuController.java
@@ -55,8 +55,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import uk.ac.bbsrc.tgac.miso.core.data.SampleIdentity.DonorSex;
 import uk.ac.bbsrc.tgac.miso.core.data.IndexFamily;
+import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
+import uk.ac.bbsrc.tgac.miso.core.data.SampleIdentity.DonorSex;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleValidRelationship;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryDilution;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.PoolImpl;
@@ -282,7 +283,7 @@ public class MenuController implements ServletContextAware {
     node.put("libraryDilutionConcentrationUnits", LibraryDilution.UNITS);
     node.put("poolConcentrationUnits", PoolImpl.CONCENTRATION_UNITS);
 
-    final Iterable<SampleValidRelationship> relationships = sampleValidRelationshipService.getAll();
+    final Collection<SampleValidRelationship> relationships = sampleValidRelationshipService.getAll();
 
     createArray(mapper, baseUri, node, "libraryDesigns", libraryDesignService.list(), Dtos::asDto);
     createArray(mapper, baseUri, node, "libraryTypes", libraryService.listLibraryTypes(), Dtos::asDto);
@@ -293,7 +294,7 @@ public class MenuController implements ServletContextAware {
     createArray(mapper, baseUri, node, "kitDescriptors", kitService.listKitDescriptors(), Dtos::asDto);
     createArray(mapper, baseUri, node, "sampleClasses", sampleClassService.getAll(), model -> {
       SampleClassDto dto = Dtos.asDto(model);
-      dto.setCanCreateNew(model.canCreateNew(relationships));
+      dto.setCanCreateNew(model.hasPathToIdentity(relationships));
       return dto;
     });
     createArray(mapper, baseUri, node, "sampleValidRelationships", relationships, Dtos::asDto);
@@ -313,7 +314,7 @@ public class MenuController implements ServletContextAware {
     createArray(mapper, baseUri, node, "boxSizes", boxService.listSizes(), Function.identity());
     createArray(mapper, baseUri, node, "boxUses", boxService.listUses(), Function.identity());
     createArray(mapper, baseUri, node, "studyTypes", studyService.listTypes(), Dtos::asDto);
-    createArray(mapper, baseUri, node, "sampleCategories", EditSampleController.CATEGORIES, Function.identity());
+    createArray(mapper, baseUri, node, "sampleCategories", SampleClass.CATEGORIES, Function.identity());
 
     Collection<IndexFamily> indexFamilies = indexService.getIndexFamilies();
     indexFamilies.add(IndexFamily.NULL);

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleClassController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleClassController.java
@@ -24,6 +24,7 @@
 package uk.ac.bbsrc.tgac.miso.webapp.controller.rest;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -83,10 +84,10 @@ public class SampleClassController extends RestController {
   @RequestMapping(value = "/sampleclasses", method = RequestMethod.GET, produces = { "application/json" })
   @ResponseBody
   public Set<SampleClassDto> getSampleClasses(UriComponentsBuilder uriBuilder, HttpServletResponse response) throws IOException {
-    Iterable<SampleValidRelationship> relationships = sampleValidRelationshipService.getAll();
+    Collection<SampleValidRelationship> relationships = sampleValidRelationshipService.getAll();
     return sampleClassService.getAll().stream().map(sc -> {
       SampleClassDto dto = Dtos.asDto(sc);
-      dto.setCanCreateNew(sc.canCreateNew(relationships));
+      dto.setCanCreateNew(sc.hasPathToIdentity(relationships));
       dto.writeUrls(uriBuilder);
       return dto;
     }).collect(Collectors.toSet());


### PR DESCRIPTION
This fixes a bug where tissue class was not inferred for tissue processing
samples created directly. It also shares that logic for all sample class
inference. Additionally, it limits the list of available option so that new
samples cannot be created from a class with no inference path to an identity.

JIRA: GLT-1922