### PR TITLE
Use strings in front end for double fields

### DIFF
--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/DetailedSampleDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/DetailedSampleDto.java
@@ -22,7 +22,7 @@ public class DetailedSampleDto extends SampleDto {
   private String groupId;
   private String groupDescription;
   private Boolean isSynthetic;
-  private Double concentration;
+  private String concentration;
   private boolean nonStandardAlias;
   private Long identityId;
 
@@ -139,11 +139,11 @@ public class DetailedSampleDto extends SampleDto {
     this.isSynthetic = isSynthetic;
   }
 
-  public Double getConcentration() {
+  public String getConcentration() {
     return concentration;
   }
 
-  public void setConcentration(Double concentration) {
+  public void setConcentration(String concentration) {
     this.concentration = concentration;
   }
 

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -307,7 +307,9 @@ public class Dtos {
     if (!isStringEmptyOrNull(from.getTaxonIdentifier())) {
       dto.setTaxonIdentifier(from.getTaxonIdentifier());
     }
-    dto.setVolume(from.getVolume());
+    if (from.getVolume() != null) {
+      dto.setVolume(from.getVolume().toString());
+    }
     dto.setDiscarded(from.isDiscarded());
     dto.setLastModified(getDateAsString(from.getLastModified()));
 
@@ -352,7 +354,7 @@ public class Dtos {
       dto.setSynthetic(from.isSynthetic());
     }
     if (from.getConcentration() != null) {
-      dto.setConcentration(from.getConcentration());
+      dto.setConcentration(from.getConcentration().toString());
     }
     dto.setNonStandardAlias(from.hasNonStandardAlias());
     if (from.getDetailedQcStatus() != null) {
@@ -405,7 +407,7 @@ public class Dtos {
       to.setSynthetic(from.getSynthetic());
     }
     if (from.getConcentration() != null) {
-      to.setConcentration(from.getConcentration());
+      to.setConcentration(Double.valueOf(from.getConcentration()));
     }
     if (from.getIdentityId() != null) {
       to.setIdentityId(from.getIdentityId());
@@ -633,7 +635,9 @@ public class Dtos {
     }
     to.setAlias(from.getAlias());
     to.setDescription(from.getDescription());
-    to.setVolume(from.getVolume());
+    if (from.getVolume() != null) {
+      to.setVolume(Double.valueOf(from.getVolume()));
+    }
     if (from.getDiscarded() != null) to.setDiscarded(from.getDiscarded());
     if (from.getProjectId() != null) {
       to.setProject(new ProjectImpl());
@@ -1052,7 +1056,9 @@ public class Dtos {
     dto.setCreationDate(getDateString(from.getCreationDate()));
     dto.setDescription(from.getDescription());
     dto.setId(from.getId());
-    dto.setConcentration(from.getInitialConcentration());
+    if (from.getInitialConcentration() != null) {
+      dto.setConcentration(from.getInitialConcentration().toString());
+    }
     if (from.getLibrarySelectionType() != null) {
       dto.setLibrarySelectionTypeId(from.getLibrarySelectionType().getId());
     }
@@ -1089,7 +1095,9 @@ public class Dtos {
         }
       }
     }
-    dto.setVolume(from.getVolume());
+    if (from.getVolume() != null) {
+      dto.setVolume(from.getVolume().toString());
+    }
     dto.setDnaSize(from.getDnaSize());
     if (!isStringEmptyOrNull(from.getIdentificationBarcode())) {
       dto.setIdentificationBarcode(from.getIdentificationBarcode());
@@ -1124,7 +1132,9 @@ public class Dtos {
     to.setName(from.getName());
     to.setDescription(from.getDescription());
     to.setIdentificationBarcode(from.getIdentificationBarcode());
-    to.setInitialConcentration(from.getConcentration());
+    if (from.getConcentration() != null) {
+      to.setInitialConcentration(Double.valueOf(from.getConcentration()));
+    }
     to.setLowQuality(from.getLowQuality());
     if (from.getPaired() != null) {
       to.setPaired(from.getPaired());
@@ -1163,7 +1173,9 @@ public class Dtos {
       }
       to.setIndices(indices);
     }
-    to.setVolume(from.getVolume());
+    if (from.getVolume() != null) {
+      to.setVolume(Double.valueOf(from.getVolume()));
+    }
     to.setDnaSize(from.getDnaSize());
     to.setLocationBarcode(from.getLocationBarcode());
     to.setCreationDate(extractDateOrNull(from.getCreationDate()));
@@ -1355,12 +1367,16 @@ public class Dtos {
     if (!isStringEmptyOrNull(from.getDescription())) {
       dto.setDescription(from.getDescription());
     }
-    dto.setConcentration(from.getConcentration());
+    if (from.getConcentration() != null) {
+      dto.setConcentration(from.getConcentration().toString());
+    }
     dto.setReadyToRun(from.getReadyToRun());
     dto.setQcPassed(from.getQcPassed());
     dto.setCreationDate(getDateString(from.getCreationDate()));
     dto.setDiscarded(from.isDiscarded());
-    dto.setVolume(from.getVolume());
+    if (from.getVolume() != null) {
+      dto.setVolume(from.getVolume().toString());
+    }
     dto.setPlatformType(from.getPlatformType().name());
     dto.setLongestIndex(from.getLongestIndex());
     if (from.getLastModified() != null) {
@@ -1733,12 +1749,16 @@ public class Dtos {
     PoolImpl to = new PoolImpl();
     to.setId(dto.getId() == null ? PoolImpl.UNSAVED_ID : dto.getId());
     to.setAlias(dto.getAlias());
-    to.setConcentration(dto.getConcentration());
+    if (dto.getConcentration() != null) {
+      to.setConcentration(Double.valueOf(dto.getConcentration()));
+    }
     to.setCreationDate(extractDateOrNull(dto.getCreationDate()));
     to.setDescription(dto.getDescription());
     to.setIdentificationBarcode(dto.getIdentificationBarcode());
     to.setDiscarded(dto.isDiscarded());
-    to.setVolume(dto.getVolume());
+    if (dto.getVolume() != null) {
+      to.setVolume(Double.valueOf(dto.getVolume()));
+    }
     to.setPlatformType(PlatformType.valueOf(dto.getPlatformType()));
     to.setPoolableElementViews(dto.getPooledElements().stream().map(dilution -> {
       PoolableElementView view = new PoolableElementView();

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/LibraryDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/LibraryDto.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public class LibraryDto implements WritableUrls {
 
   private String alias;
-  private Double concentration;
+  private String concentration;
   private String creationDate;
   private String description;
   private String identificationBarcode;
@@ -43,13 +43,13 @@ public class LibraryDto implements WritableUrls {
   private String index2Label;
   private String indexFamilyName;
   private String url;
-  private Double volume;
+  private String volume;
   private Long boxId;
   private List<LibraryQcDto> qcs;
   private Integer dnaSize;
-  private Double qcQubit;
-  private Double qcTapeStation;
-  private Double qcQPcr;
+  private String qcQubit;
+  private String qcTapeStation;
+  private String qcQPcr;
 
   public String getAlias() {
     return alias;
@@ -59,7 +59,7 @@ public class LibraryDto implements WritableUrls {
     return boxId;
   }
 
-  public Double getConcentration() {
+  public String getConcentration() {
     return concentration;
   }
 
@@ -171,7 +171,7 @@ public class LibraryDto implements WritableUrls {
     return url;
   }
 
-  public Double getVolume() {
+  public String getVolume() {
     return volume;
   }
 
@@ -183,7 +183,7 @@ public class LibraryDto implements WritableUrls {
     this.boxId = boxId;
   }
 
-  public void setConcentration(Double concentration) {
+  public void setConcentration(String concentration) {
     this.concentration = concentration;
   }
 
@@ -296,7 +296,7 @@ public class LibraryDto implements WritableUrls {
     this.url = url;
   }
 
-  public void setVolume(Double volume) {
+  public void setVolume(String volume) {
     this.volume = volume;
   }
 
@@ -313,27 +313,27 @@ public class LibraryDto implements WritableUrls {
     setUrl(WritableUrls.buildUriPath(baseUri, "/rest/library/{id}", getId()));
   }
 
-  public Double getQcQubit() {
+  public String getQcQubit() {
     return qcQubit;
   }
 
-  public void setQcQubit(Double qcQubit) {
+  public void setQcQubit(String qcQubit) {
     this.qcQubit = qcQubit;
   }
 
-  public Double getQcTapeStation() {
+  public String getQcTapeStation() {
     return qcTapeStation;
   }
 
-  public void setQcTapeStation(Double qcTapeStation) {
+  public void setQcTapeStation(String qcTapeStation) {
     this.qcTapeStation = qcTapeStation;
   }
 
-  public Double getQcQPcr() {
+  public String getQcQPcr() {
     return qcQPcr;
   }
 
-  public void setQcQPcr(Double qcQPcr) {
+  public void setQcQPcr(String qcQPcr) {
     this.qcQPcr = qcQPcr;
   }
 }

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/PoolDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/PoolDto.java
@@ -12,7 +12,7 @@ public class PoolDto implements WritableUrls {
   private String url;
   private String name;
   private String alias;
-  private Double concentration;
+  private String concentration;
   private String identificationBarcode;
   private String locationLabel;
   private Boolean readyToRun;
@@ -24,7 +24,7 @@ public class PoolDto implements WritableUrls {
   private String description;
   private Long boxId;
   private boolean discarded;
-  private Double volume;
+  private String volume;
   private String platformType;
   private int longestIndex;
 
@@ -40,7 +40,7 @@ public class PoolDto implements WritableUrls {
     return boxId;
   }
 
-  public Double getConcentration() {
+  public String getConcentration() {
     return concentration;
   }
 
@@ -100,7 +100,7 @@ public class PoolDto implements WritableUrls {
     this.boxId = boxId;
   }
 
-  public void setConcentration(Double concentration) {
+  public void setConcentration(String concentration) {
     this.concentration = concentration;
   }
 
@@ -168,11 +168,11 @@ public class PoolDto implements WritableUrls {
     this.discarded = isDiscarded;
   }
 
-  public Double getVolume() {
+  public String getVolume() {
     return volume;
   }
 
-  public void setVolume(Double volume) {
+  public void setVolume(String volume) {
     this.volume = volume;
   }
 

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleDto.java
@@ -49,13 +49,13 @@ public class SampleDto implements WritableUrls {
   private String taxonIdentifier;
   private Long rootSampleClassId;
   private String rootSampleClassUrl;
-  private Double volume;
+  private String volume;
   private Boolean discarded;
   private Long updatedById;
   private String updatedByUrl;
   private String lastModified;
-  private Double qcDv200;
-  private Double qcRin;
+  private String qcDv200;
+  private String qcRin;
   private List<SampleQcDto> qcs;
 
   public Long getId() {
@@ -197,11 +197,11 @@ public class SampleDto implements WritableUrls {
     this.rootSampleClassUrl = rootSampleClassUrl;
   }
 
-  public Double getVolume() {
+  public String getVolume() {
     return volume;
   }
 
-  public void setVolume(Double volume) {
+  public void setVolume(String volume) {
     this.volume = volume;
   }
 
@@ -245,19 +245,19 @@ public class SampleDto implements WritableUrls {
     this.boxId = boxId;
   }
 
-  public Double getQcDv200() {
+  public String getQcDv200() {
     return qcDv200;
   }
 
-  public void setQcDv200(Double qcDv200) {
+  public void setQcDv200(String qcDv200) {
     this.qcDv200 = qcDv200;
   }
 
-  public Double getQcRin() {
+  public String getQcRin() {
     return qcRin;
   }
 
-  public void setQcRin(Double qcRin) {
+  public void setQcRin(String qcRin) {
     this.qcRin = qcRin;
   }
 

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleStockDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/SampleStockDto.java
@@ -9,11 +9,12 @@ import uk.ac.bbsrc.tgac.miso.core.data.SampleStock;
 @JsonTypeName(value = SampleStock.CATEGORY_NAME)
 public class SampleStockDto extends SampleTissueDto {
 
-  private Double concentration;
+  private String concentration;
   private String strStatus;
   private Boolean dnaseTreated;
 
-  public Double getConcentration() {
+  @Override
+  public String getConcentration() {
     return concentration;
   }
 
@@ -21,7 +22,8 @@ public class SampleStockDto extends SampleTissueDto {
     return strStatus;
   }
 
-  public void setConcentration(Double concentration) {
+  @Override
+  public void setConcentration(String concentration) {
     this.concentration = concentration;
   }
 

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/LibraryRestController.java
@@ -50,7 +50,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.ac.bbsrc.tgac.miso.core.data.Library;
 import uk.ac.bbsrc.tgac.miso.core.data.LibraryQC;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryQCImpl;
-import uk.ac.bbsrc.tgac.miso.core.manager.RequestManager;
 import uk.ac.bbsrc.tgac.miso.core.util.PaginatedDataSource;
 import uk.ac.bbsrc.tgac.miso.core.util.PaginationFilter;
 import uk.ac.bbsrc.tgac.miso.dto.DataTablesResponseDto;
@@ -85,9 +84,6 @@ public class LibraryRestController extends RestController {
 
   @Autowired
   private LibraryService libraryService;
-
-  @Autowired
-  private RequestManager requestManager;
 
   public void setLibraryService(LibraryService libraryService) {
     this.libraryService = libraryService;
@@ -157,19 +153,22 @@ public class LibraryRestController extends RestController {
     if (libraryDto.getQcQubit() != null) {
       LibraryQC qc = new LibraryQCImpl();
       qc.setQcType(libraryService.getLibraryQcTypeByName("Qubit"));
-      qc.setResults(libraryDto.getQcQubit());
+      if (libraryDto.getQcQubit() == null) throw new IllegalArgumentException("Cannot create QC with null results");
+      qc.setResults(Double.valueOf(libraryDto.getQcQubit()));
       libraryService.addQc(library, qc);
     }
     if (libraryDto.getQcTapeStation() != null) {
       LibraryQC qc = new LibraryQCImpl();
       qc.setQcType(libraryService.getLibraryQcTypeByName("Tape Station"));
-      qc.setResults(libraryDto.getQcTapeStation());
+      if (libraryDto.getQcTapeStation() == null) throw new IllegalArgumentException("Cannot create QC with null results");
+      qc.setResults(Double.valueOf(libraryDto.getQcTapeStation()));
       libraryService.addQc(library, qc);
     }
     if (libraryDto.getQcQPcr() != null) {
       LibraryQC qc = new LibraryQCImpl();
       qc.setQcType(libraryService.getLibraryQcTypeByName("qPCR"));
-      qc.setResults(libraryDto.getQcQPcr());
+      if (libraryDto.getQcQPcr() == null) throw new IllegalArgumentException("Cannot create QC with null results");
+      qc.setResults(Double.valueOf(libraryDto.getQcQPcr()));
       libraryService.addQc(library, qc);
     }
     libraryService.update(library);

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/SampleController.java
@@ -268,13 +268,15 @@ public class SampleController extends RestController {
     if (sampleDto.getQcRin() != null) {
       SampleQC qc = new SampleQCImpl();
       qc.setQcType(sampleService.getSampleQcTypeByName("RIN"));
-      qc.setResults(sampleDto.getQcRin());
+      if (sampleDto.getQcRin() == null) throw new IllegalArgumentException("Cannot create QC with null results");
+      qc.setResults(Double.valueOf(sampleDto.getQcRin()));
       sampleService.addQc(sample, qc);
     }
     if (sampleDto.getQcDv200() != null) {
       SampleQC qc = new SampleQCImpl();
       qc.setQcType(sampleService.getSampleQcTypeByName("DV200"));
-      qc.setResults(sampleDto.getQcDv200());
+      if (sampleDto.getQcDv200() == null) throw new IllegalArgumentException("Cannot create QC with null results");
+      qc.setResults(Double.valueOf(sampleDto.getQcDv200()));
       sampleService.addQc(sample, qc);
     }
   }

--- a/miso-web/src/main/webapp/scripts/hot.js
+++ b/miso-web/src/main/webapp/scripts/hot.js
@@ -34,6 +34,14 @@ var HotUtils = {
     },
     
     /**
+     * Custom validator for optional numeric fields
+     */
+    optionalNumber : function(value, callback) {
+      return callback(Utils.validation.isEmpty(value) || Handsontable.helper
+    	  .isNumeric(value));
+    },
+    
+    /**
      * Custom validator for text fields that fails on extra-special characters
      */
     noSpecialChars : function(value, callback) {
@@ -654,13 +662,13 @@ var HotUtils = {
     return {
       'header' : headerName,
       'data' : property,
-      'type' : 'numeric',
+      'type' : 'text',
       'include' : include,
       'unpack' : function(obj, flat, setCellMeta) {
         flat[property] = obj[property];
       },
       'validator' : required ? HotUtils.validator.requiredNumber
-          : Handsontable.NumericValidator,
+          : HotUtils.validator.optionalNumber,
       'pack' : function(obj, flat, errorHandler) {
         var output;
         if (Utils.validation.isEmpty(flat[property])) {


### PR DESCRIPTION
This will cause the numbers to be saved with user-defined precision, instead of Handsontable-implemented precision.