### PR TITLE
Bulk sample IT fixups

### DIFF
--- a/miso-web/pom.xml
+++ b/miso-web/pom.xml
@@ -656,6 +656,7 @@
                 <miso.it.baseUrl>http://localhost:${miso.it.tomcat.servlet.port}/</miso.it.baseUrl>
                 <miso.it.h2.url>jdbc:h2:tcp://localhost:${miso.it.h2.port}/mem:miso-it;mode=mysql;DB_CLOSE_DELAY=-1;</miso.it.h2.url>
               </systemPropertyVariables>
+              <skipTests>${skipITs}</skipTests>
             </configuration>
           </plugin>
         </plugins>

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/SampleBulkCreateIT.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/SampleBulkCreateIT.java
@@ -164,7 +164,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     rnaAliquot.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    rnaAliquot.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    rnaAliquot.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -305,7 +305,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     tissue.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    tissue.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    tissue.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -350,7 +350,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     saveSingleAndAssertSuccess(table);
 
-    tissue.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    tissue.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -433,7 +433,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     slide.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    slide.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    slide.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -485,7 +485,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     saveSingleAndAssertSuccess(table);
 
-    slide.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    slide.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -555,7 +555,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     curls.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    curls.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    curls.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -602,7 +602,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     saveSingleAndAssertSuccess(table);
 
-    curls.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    curls.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -684,7 +684,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     gDnaStock.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    gDnaStock.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    gDnaStock.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -737,7 +737,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     gDnaStock.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    gDnaStock.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    gDnaStock.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -819,7 +819,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     rnaStock.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    rnaStock.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    rnaStock.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -891,7 +891,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     rnaStock.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    rnaStock.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    rnaStock.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -974,7 +974,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     gDnaAliquot.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    gDnaAliquot.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    gDnaAliquot.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -1031,7 +1031,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     gDnaAliquot.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    gDnaAliquot.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    gDnaAliquot.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -1107,7 +1107,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     saveSingleAndAssertSuccess(table);
 
     rnaAliquot.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
-    rnaAliquot.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    rnaAliquot.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -1211,7 +1211,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     saveSingleAndAssertSuccess(table);
 
-    identity.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    identity.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes against what got saved to the database
@@ -1241,7 +1241,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     saveSingleAndAssertSuccess(table);
 
-    identity.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
+    identity.forEach((k, v) -> assertEquals("Checking value of column '" + k + "'", v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
 
     // verify attributes on the Edit single Sample page

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/SampleBulkCreateIT.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/SampleBulkCreateIT.java
@@ -35,6 +35,7 @@ import uk.ac.bbsrc.tgac.miso.core.util.LimsUtils;
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.BulkSamplePage;
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.BulkSamplePage.Columns;
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element.HandsOnTable;
+import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element.HandsOnTableSaveResult;
 
 public class SampleBulkCreateIT extends AbstractIT {
 
@@ -114,6 +115,16 @@ public class SampleBulkCreateIT extends AbstractIT {
   }
 
   @Test
+  public void testSaveEmptyFail() throws Exception {
+    // Goal: ensure save fails and error message is shown when trying to save with required fields empty
+    BulkSamplePage page = getCreatePage(1, projectId, rAliquotClassId);
+    HandsOnTable table = page.getTable();
+    HandsOnTableSaveResult result = table.save();
+    assertEquals(0, result.getItemsSaved());
+    assertFalse(result.getSaveErrors().isEmpty());
+  }
+
+  @Test
   public void testCreateOneRnaAliquotWithProject() throws Exception {
     // Goal: ensure one whole RNA (aliquot) associated with a predefined project can be saved
     BulkSamplePage page = getCreatePage(1, projectId, rAliquotClassId);
@@ -149,9 +160,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     rnaAliquot.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     rnaAliquot.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -292,9 +301,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     tissue.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     tissue.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -340,9 +347,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     tissue.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
@@ -424,9 +429,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     slide.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     slide.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -479,9 +482,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     slide.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
@@ -550,9 +551,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     curls.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     curls.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -600,9 +599,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     curls.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
@@ -683,9 +680,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     gDnaStock.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     gDnaStock.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -738,9 +733,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     gDnaStock.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     gDnaStock.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -822,9 +815,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     rnaStock.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     rnaStock.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -896,9 +887,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     rnaStock.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     rnaStock.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -981,9 +970,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     gDnaAliquot.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     gDnaAliquot.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -1040,9 +1027,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     gDnaAliquot.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     gDnaAliquot.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -1118,9 +1103,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     assertIdentityLookupWasSuccessful(page, table);
 
-    page.clickSaveButton();
-
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     rnaAliquot.put(Columns.ALIAS, table.getText(Columns.ALIAS, 0));
     rnaAliquot.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
@@ -1225,8 +1208,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     identity.forEach((k, v) -> table.enterText(k, 0, v));
 
-    page.clickSaveButton();
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     identity.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
@@ -1256,8 +1238,7 @@ public class SampleBulkCreateIT extends AbstractIT {
 
     identity.forEach((k, v) -> table.enterText(k, 0, v));
 
-    page.clickSaveButton();
-    assertSaveWasSuccessful(page, table);
+    saveSingleAndAssertSuccess(table);
 
     identity.forEach((k, v) -> assertEquals(v, table.getText(k, 0)));
     String newId = table.getText(Columns.NAME, 0).substring(3, table.getText(Columns.NAME, 0).length());
@@ -1340,9 +1321,12 @@ public class SampleBulkCreateIT extends AbstractIT {
     assertEquals("identity lookup was successful", "First Receipt (PRO1)", table.getText(Columns.IDENTITY_ALIAS, 0));
   }
 
-  private void assertSaveWasSuccessful(BulkSamplePage page, HandsOnTable table) {
-    assertTrue("Sample was saved", page.getSuccessMessages().contains("Saved"));
-    assertTrue("No errors are present", page.areErrorsHidden());
+  private void saveSingleAndAssertSuccess(HandsOnTable table) {
+    HandsOnTableSaveResult result = table.save();
+
+    assertTrue("Sample was saved", result.getItemsSaved() == 1);
+    assertTrue("No errors are present", result.getServerErrors().isEmpty());
+    assertTrue("No errors are present", result.getSaveErrors().isEmpty());
 
     assertTrue("Sample name has been generated", table.getText(Columns.NAME, 0).contains("SAM"));
     assertTrue("Sample alias has been generated", !isStringEmptyOrNull(table.getText(Columns.ALIAS, 0)));

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/SampleBulkCreateIT.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/SampleBulkCreateIT.java
@@ -36,6 +36,7 @@ import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.BulkSamplePage;
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.BulkSamplePage.Columns;
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element.HandsOnTable;
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element.HandsOnTableSaveResult;
+import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element.SampleHandsOnTable;
 
 public class SampleBulkCreateIT extends AbstractIT {
 
@@ -128,7 +129,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneRnaAliquotWithProject() throws Exception {
     // Goal: ensure one whole RNA (aliquot) associated with a predefined project can be saved
     BulkSamplePage page = getCreatePage(1, projectId, rAliquotClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> rnaAliquot = new HashMap<>();
     rnaAliquot.put(Columns.DESCRIPTION, "Description");
@@ -158,7 +159,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     rnaAliquot.put(Columns.EXTERNAL_NAME, "ext14"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, rnaAliquot.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -261,11 +262,11 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateTissueDependencyCells() throws Exception {
     // Goal: ensure that changing the external name value causes the identity alias dropdown to be populated
     BulkSamplePage page = getCreatePage(1, null, 23L);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     assertTrue("identity alias is empty", isStringEmptyOrNull(table.getText(Columns.IDENTITY_ALIAS, 0)));
     table.enterText(Columns.IDENTITY_ALIAS, 0, "Identity 1");
-    page.waitForIdentityLookup();
+    table.waitForIdentityLookup(0);
     assertTrue("identity alias no longer empty", !isStringEmptyOrNull(table.getText(Columns.IDENTITY_ALIAS, 0)));
   }
 
@@ -273,7 +274,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneTissueNoProject() throws Exception {
     // Goal: ensure one tissue can be saved
     BulkSamplePage page = getCreatePage(1, null, tissueClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> tissue = new HashMap<>();
     tissue.put(Columns.DESCRIPTION, "Description");
@@ -299,7 +300,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     tissue.put(Columns.EXTERNAL_NAME, "ext1"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, tissue.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -320,7 +321,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneTissueWithProject() throws Exception {
     // Goal: ensure one tissue associated with a predefined project can be saved
     BulkSamplePage page = getCreatePage(1, projectId, tissueClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> tissue = new HashMap<>();
     tissue.put(Columns.DESCRIPTION, "Description");
@@ -345,7 +346,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     tissue.put(Columns.EXTERNAL_NAME, "ext2"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, tissue.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -397,7 +398,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneSlideNoProject() throws Exception {
     // Goal: ensure one slide can be saved
     BulkSamplePage page = getCreatePage(1, null, slideClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> slide = new HashMap<>();
     slide.put(Columns.DESCRIPTION, "Description");
@@ -427,7 +428,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     slide.put(Columns.EXTERNAL_NAME, "ext3"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, slide.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -451,7 +452,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneSlideWithProject() throws Exception {
     // Goal: ensure one slide with predefined project can be saved
     BulkSamplePage page = getCreatePage(1, projectId, slideClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> slide = new HashMap<>();
     slide.put(Columns.DESCRIPTION, "Description");
@@ -480,7 +481,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     slide.put(Columns.EXTERNAL_NAME, "ext4"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, slide.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -522,7 +523,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneCurlsNoProject() throws Exception {
     // Goal: ensure one Curls can be saved
     BulkSamplePage page = getCreatePage(1, null, curlsClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> curls = new HashMap<>();
     curls.put(Columns.DESCRIPTION, "Description");
@@ -549,7 +550,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     curls.put(Columns.EXTERNAL_NAME, "ext5"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, curls.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -572,7 +573,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneCurlsWithProject() throws Exception {
     // Goal: ensure one Curls associated with a predefined project can be saved
     BulkSamplePage page = getCreatePage(1, projectId, curlsClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> curls = new HashMap<>();
     curls.put(Columns.DESCRIPTION, "Description");
@@ -597,7 +598,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     curls.put(Columns.EXTERNAL_NAME, "ext6"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, curls.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -649,7 +650,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneGdnaStockNoProject() throws Exception {
     // Goal: ensure one gDNA (stock) can be saved
     BulkSamplePage page = getCreatePage(1, null, gStockClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> gDnaStock = new HashMap<>();
     gDnaStock.put(Columns.DESCRIPTION, "Description");
@@ -678,7 +679,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     gDnaStock.put(Columns.EXTERNAL_NAME, "ext7"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, gDnaStock.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -703,7 +704,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneGdnaStockWithProject() throws Exception {
     // Goal: ensure one gDNA (stock) associated with a predefined project can be saved
     BulkSamplePage page = getCreatePage(1, projectId, gStockClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> gDnaStock = new HashMap<>();
     gDnaStock.put(Columns.DESCRIPTION, "Description");
@@ -731,7 +732,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     gDnaStock.put(Columns.EXTERNAL_NAME, "ext8"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, gDnaStock.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -781,7 +782,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneRnaStockNoProject() throws Exception {
     // Goal: ensure whole RNA (stock) can be saved
     BulkSamplePage page = getCreatePage(1, null, rStockClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> rnaStock = new HashMap<>();
     rnaStock.put(Columns.DESCRIPTION, "Description");
@@ -813,7 +814,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     rnaStock.put(Columns.EXTERNAL_NAME, "ext9"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, rnaStock.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -855,7 +856,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneRnaStockWithProject() throws Exception {
     // Goal: ensure one whole RNA (stock) associated with a predefined project can be saved
     BulkSamplePage page = getCreatePage(1, projectId, rStockClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> rnaStock = new HashMap<>();
     rnaStock.put(Columns.DESCRIPTION, "Description");
@@ -885,7 +886,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     rnaStock.put(Columns.EXTERNAL_NAME, "ext10"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, rnaStock.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -938,7 +939,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneGdnaAliquotNoProject() throws Exception {
     // Goal: ensure one gDNA (aliquot) can be saved
     BulkSamplePage page = getCreatePage(1, null, gAliquotClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> gDnaAliquot = new HashMap<>();
     gDnaAliquot.put(Columns.DESCRIPTION, "Description");
@@ -968,7 +969,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     gDnaAliquot.put(Columns.EXTERNAL_NAME, "ext11"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, gDnaAliquot.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -996,7 +997,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneGdnaAliquotWithProject() throws Exception {
     // Goal: ensure one gDNA (aliquot) associated with a predefined project can be saved
     BulkSamplePage page = getCreatePage(1, projectId, gAliquotClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> gDnaAliquot = new HashMap<>();
     gDnaAliquot.put(Columns.DESCRIPTION, "Description");
@@ -1025,7 +1026,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     gDnaAliquot.put(Columns.EXTERNAL_NAME, "ext12"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, gDnaAliquot.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -1068,7 +1069,7 @@ public class SampleBulkCreateIT extends AbstractIT {
   public void testCreateOneRnaAliquotNoProject() throws Exception {
     // Goal: ensure one whole RNA (aliquot) can be saved
     BulkSamplePage page = getCreatePage(1, null, rAliquotClassId);
-    HandsOnTable table = page.getTable();
+    SampleHandsOnTable table = page.getTable();
 
     Map<String, String> rnaAliquot = new HashMap<>();
     rnaAliquot.put(Columns.DESCRIPTION, "Description");
@@ -1101,7 +1102,7 @@ public class SampleBulkCreateIT extends AbstractIT {
     rnaAliquot.put(Columns.EXTERNAL_NAME, "ext13"); // increment
     table.enterText(Columns.EXTERNAL_NAME, 0, rnaAliquot.get(Columns.EXTERNAL_NAME));
 
-    assertIdentityLookupWasSuccessful(page, table);
+    assertIdentityLookupWasSuccessful(table, 0);
 
     saveSingleAndAssertSuccess(table);
 
@@ -1316,8 +1317,8 @@ public class SampleBulkCreateIT extends AbstractIT {
     assertEquals("confirm purpose", hotAttributes.get(Columns.PURPOSE), fromDb.getSamplePurpose().getAlias());
   }
 
-  private void assertIdentityLookupWasSuccessful(BulkSamplePage page, HandsOnTable table) {
-    page.waitForIdentityLookup();
+  private void assertIdentityLookupWasSuccessful(SampleHandsOnTable table, int rowNum) {
+    table.waitForIdentityLookup(rowNum);
     assertEquals("identity lookup was successful", "First Receipt (PRO1)", table.getText(Columns.IDENTITY_ALIAS, 0));
   }
 

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/SampleBulkCreateIT.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/SampleBulkCreateIT.java
@@ -1208,6 +1208,9 @@ public class SampleBulkCreateIT extends AbstractIT {
     identity.put(Columns.QC_STATUS, "Ready");
 
     identity.forEach((k, v) -> table.enterText(k, 0, v));
+    // Setting project a second time because of odd case where it is not set correctly the first time
+    // (Happened on Travis CI branch build, but not on the PR build or outside of Travis CI)
+    table.enterText(Columns.PROJECT, 0, "PRO2");
 
     saveSingleAndAssertSuccess(table);
 

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/BulkSamplePage.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/BulkSamplePage.java
@@ -11,7 +11,7 @@ import org.openqa.selenium.support.PageFactory;
 
 import com.google.common.base.Joiner;
 
-import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element.HandsOnTable;
+import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element.SampleHandsOnTable;
 
 public class BulkSamplePage extends HeaderFooterPage {
 
@@ -58,13 +58,13 @@ public class BulkSamplePage extends HeaderFooterPage {
   private static final String CREATE_URL_FORMAT = "%smiso/sample/bulk/new?quantity=%d&projectId=%s&sampleClassId=%d";
   private static final String EDIT_URL_FORMAT = "%smiso/sample/bulk/edit?ids=%s";
 
-  private final HandsOnTable table;
+  private final SampleHandsOnTable table;
 
   public BulkSamplePage(WebDriver driver) {
     super(driver);
     PageFactory.initElements(driver, this);
     waitWithTimeout().until(or(titleContains("Create Samples "), titleContains("Edit Samples ")));
-    table = new HandsOnTable(driver);
+    table = new SampleHandsOnTable(driver);
   }
 
   public static BulkSamplePage getForCreate(WebDriver driver, String baseUrl, Integer quantity, Long projectId, Long sampleClassId) {
@@ -81,12 +81,8 @@ public class BulkSamplePage extends HeaderFooterPage {
     return new BulkSamplePage(driver);
   }
 
-  public HandsOnTable getTable() {
+  public SampleHandsOnTable getTable() {
     return table;
-  }
-
-  public void waitForIdentityLookup() {
-    waitExplicitly(3000);
   }
 
   public String getSensibleDate(String date) {

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/BulkSamplePage.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/BulkSamplePage.java
@@ -5,12 +5,11 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.*;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
-import java.util.List;
 
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+
+import com.google.common.base.Joiner;
 
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element.HandsOnTable;
 
@@ -59,24 +58,13 @@ public class BulkSamplePage extends HeaderFooterPage {
   private static final String CREATE_URL_FORMAT = "%smiso/sample/bulk/new?quantity=%d&projectId=%s&sampleClassId=%d";
   private static final String EDIT_URL_FORMAT = "%smiso/sample/bulk/edit?ids=%s";
 
-  @FindBy(id = "hotContainer")
-  private WebElement hotContainer;
-  @FindBy(id = "save")
-  private WebElement saveButton;
-  @FindBy(id = "successMessages")
-  private WebElement successMessages;
-  @FindBy(id = "errors")
-  private WebElement errors;
-  @FindBy(id = "ajaxLoader")
-  private WebElement ajaxSpinner;
-
   private final HandsOnTable table;
 
   public BulkSamplePage(WebDriver driver) {
     super(driver);
     PageFactory.initElements(driver, this);
     waitWithTimeout().until(or(titleContains("Create Samples "), titleContains("Edit Samples ")));
-    table = new HandsOnTable(driver, hotContainer);
+    table = new HandsOnTable(driver);
   }
 
   public static BulkSamplePage getForCreate(WebDriver driver, String baseUrl, Integer quantity, Long projectId, Long sampleClassId) {
@@ -86,43 +74,15 @@ public class BulkSamplePage extends HeaderFooterPage {
     return new BulkSamplePage(driver);
   }
 
-  public static BulkSamplePage getForEdit(WebDriver driver, String baseUrl, List<Long> sampleIds) {
-    String ids = makeCommaSeparatedString(sampleIds);
+  public static BulkSamplePage getForEdit(WebDriver driver, String baseUrl, Collection<Long> sampleIds) {
+    String ids = Joiner.on(',').join(sampleIds);
     String url = String.format(EDIT_URL_FORMAT, baseUrl, ids);
     driver.get(url);
     return new BulkSamplePage(driver);
   }
 
-  private static String makeCommaSeparatedString(Collection<Long> longs) {
-    StringBuilder sb = new StringBuilder();
-    for (Long l : longs) {
-      sb.append(l).append(",");
-    }
-    sb.deleteCharAt(sb.length() - 1);
-    return sb.toString();
-  }
-
   public HandsOnTable getTable() {
     return table;
-  }
-
-  public void clickSaveButton() {
-    saveButton.click();
-    // give time for spinner to appear, then wait for it to be hidden again
-    waitExplicitly(1000);
-    waitWithTimeout().until(invisibilityOf(ajaxSpinner));
-  }
-
-  public String getSuccessMessages() {
-    return successMessages.getText();
-  }
-
-  public String getErrorMessages() {
-    return errors.getText();
-  }
-
-  public boolean areErrorsHidden() {
-    return errors.getAttribute("class").contains("hidden");
   }
 
   public void waitForIdentityLookup() {

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/element/HandsOnTable.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/element/HandsOnTable.java
@@ -105,7 +105,7 @@ public class HandsOnTable extends AbstractElement {
         .trim();
   }
 
-  private WebElement getCell(String columnHeading, int rowNum) {
+  protected WebElement getCell(String columnHeading, int rowNum) {
     int colNum = columnHeadings.indexOf(columnHeading);
     if (colNum == -1) {
       throw new IllegalArgumentException("Column " + columnHeading + " doesn't exist");

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/element/HandsOnTable.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/element/HandsOnTable.java
@@ -1,5 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element;
 
+import static org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOf;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -8,6 +10,8 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
@@ -20,14 +24,22 @@ public class HandsOnTable extends AbstractElement {
   private static final By dropdownArrowSelector = By.className("htAutocompleteArrow");
   private static final By activeDropdownSelector = By.cssSelector("div.handsontableInputHolder[style*='block']");
   private static final By dropdownOptionRowsSelector = By.cssSelector("div.ht_master table.htCore > tbody > tr");
-
-  private final WebElement hotContainer;
   private final List<String> columnHeadings;
   private final List<WebElement> inputRows;
 
-  public HandsOnTable(WebDriver driver, WebElement hotContainer) {
+
+  @FindBy(id = "hotContainer")
+  private WebElement hotContainer;
+
+  @FindBy(id = "save")
+  private WebElement saveButton;
+
+  @FindBy(id = "ajaxLoader")
+  private WebElement ajaxLoader;
+
+  public HandsOnTable(WebDriver driver) {
     super(driver);
-    this.hotContainer = hotContainer;
+    PageFactory.initElements(driver, this);
     this.columnHeadings = hotContainer.findElements(columnHeadingsSelector).stream()
         .map(element -> element.getText().trim())
         .collect(Collectors.toList());
@@ -74,6 +86,12 @@ public class HandsOnTable extends AbstractElement {
     new Actions(getDriver())
         .sendKeys(Keys.ESCAPE)
         .build().perform();
+  }
+
+  public HandsOnTableSaveResult save() {
+    saveButton.click();
+    waitUntil(invisibilityOf(ajaxLoader));
+    return new HandsOnTableSaveResult(getDriver());
   }
 
   /**

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/element/HandsOnTableSaveResult.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/element/HandsOnTableSaveResult.java
@@ -1,0 +1,83 @@
+package uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+import com.google.common.collect.Lists;
+
+public class HandsOnTableSaveResult extends AbstractElement {
+
+  // Assumption: these same IDs are used for all MISO HOT pages
+  @FindBy(id = "successMessages")
+  private WebElement successMessagesContainer;
+
+  @FindBy(id = "serverErrors")
+  private WebElement serverErrorsContainer;
+
+  @FindBy(id = "saveErrors")
+  private WebElement saveErrorsContainer;
+
+  private static final Pattern SAVE_MESSAGE_REGEX = Pattern.compile(".*Saved (\\d+) items\\..*");
+
+  private static final By LIST_ITEM_SELECTOR = By.cssSelector("li");
+
+  private final int itemsSaved;
+  private final List<String> serverErrors;
+  private final List<String> saveErrors;
+
+  public HandsOnTableSaveResult(WebDriver driver) {
+    super(driver);
+    PageFactory.initElements(driver, this);
+    this.itemsSaved = findSavedCount();
+    this.serverErrors = Collections.unmodifiableList(findServerErrorMessages());
+    this.saveErrors = Collections.unmodifiableList(findSaveErrorMessages());
+  }
+
+  private int findSavedCount() {
+    Matcher m = SAVE_MESSAGE_REGEX.matcher(successMessagesContainer.getText());
+    if (!m.matches()) {
+      return 0;
+    } else {
+      return Integer.parseInt(m.group(1));
+    }
+  }
+
+  private List<String> findServerErrorMessages() {
+    List<String> errors = Lists.newArrayList();
+    List<WebElement> elements = serverErrorsContainer.findElements(LIST_ITEM_SELECTOR);
+    for (WebElement element : elements) {
+      errors.add(element.getText());
+    }
+    return errors;
+  }
+
+  private List<String> findSaveErrorMessages() {
+    List<String> errors = Lists.newArrayList();
+    List<WebElement> elements = saveErrorsContainer.findElements(LIST_ITEM_SELECTOR);
+    for (WebElement element : elements) {
+      errors.add(element.getText());
+    }
+    return errors;
+  }
+
+  public int getItemsSaved() {
+    return itemsSaved;
+  }
+
+  public List<String> getServerErrors() {
+    return serverErrors;
+  }
+
+  public List<String> getSaveErrors() {
+    return saveErrors;
+  }
+
+}

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/element/SampleHandsOnTable.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/element/SampleHandsOnTable.java
@@ -1,0 +1,23 @@
+package uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.element;
+
+import static uk.ac.bbsrc.tgac.miso.webapp.integrationtest.util.MoreExpectedConditions.textDoesNotContain;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.BulkSamplePage.Columns;
+
+public class SampleHandsOnTable extends HandsOnTable {
+
+  private static final String LOOKUP_TEXT = "(...searching...)";
+
+  public SampleHandsOnTable(WebDriver driver) {
+    super(driver);
+  }
+
+  public void waitForIdentityLookup(int rowNum) {
+    WebElement lookupField = getCell(Columns.IDENTITY_ALIAS, rowNum);
+    waitUntil(textDoesNotContain(lookupField, LOOKUP_TEXT));
+  }
+
+}

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/util/MoreExpectedConditions.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/util/MoreExpectedConditions.java
@@ -1,0 +1,16 @@
+package uk.ac.bbsrc.tgac.miso.webapp.integrationtest.util;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+
+public class MoreExpectedConditions {
+
+  private MoreExpectedConditions() {
+    throw new IllegalStateException("Util class not intended for instantiation");
+  }
+
+  public static ExpectedCondition<Boolean> textDoesNotContain(WebElement element, String text) {
+    return (driver) -> !element.getText().contains(text);
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
     <downloadUrl>http://repos.tgac.ac.uk/maven/repo</downloadUrl>
   </distributionManagement>
   <properties>
+    <skipUTs>${skipTests}</skipUTs>
     <spring-version>4.3.6.RELEASE</spring-version>
     <spring-security-version>4.2.1.RELEASE</spring-security-version>
     <spring-integration-version>4.3.6.RELEASE</spring-integration-version>
@@ -1048,6 +1049,7 @@
             <include>**/*Test.java</include>
             <include>**/*Tests.java</include>
           </includes>
+          <skipTests>${skipUTs}</skipTests>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
* Eliminated need for explicit waits
* added skipUTs parameter to skip unit tests but not integration tests
  * Can use skipITs and skipUTs together: `mvn clean verify -DskipUTs=true -DskipITs=false`
  * Defaults are unchanged: unit tests run, ITs don't
  * `-DskipTests=true` will still skip all tests unless overridden by one of the other attributes