### PR TITLE
removed unused plugin dependency, fix library update bug

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
@@ -52,8 +52,6 @@ import javax.persistence.TemporalType;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 
 import com.eaglegenomics.simlims.core.Note;
 import com.eaglegenomics.simlims.core.SecurityProfile;
@@ -117,7 +115,6 @@ public abstract class AbstractLibrary extends AbstractBoxable implements Library
   private Double initialConcentration;
 
   @ManyToMany(targetEntity = Index.class)
-  @Fetch(FetchMode.SUBSELECT)
   @JoinTable(name = "Library_Index", joinColumns = {
       @JoinColumn(name = "library_libraryId", nullable = false) }, inverseJoinColumns = {
           @JoinColumn(name = "index_indexId", nullable = false) })

--- a/miso-web/pom.xml
+++ b/miso-web/pom.xml
@@ -76,24 +76,6 @@
       <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>docker-maven-plugin</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>jcl-over-slf4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-nop</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -465,11 +465,6 @@
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.fabric8</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <version>0.22.1</version>
-      </dependency>
-      <dependency>
         <groupId>io.github.bonigarcia</groupId>
         <artifactId>webdrivermanager</artifactId>
         <version>1.7.0</version>
@@ -934,6 +929,11 @@
           <groupId>com.samaxes.maven</groupId>
           <artifactId>minify-maven-plugin</artifactId>
           <version>1.7.4</version>
+        </plugin>
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>0.22.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
* some libraries were failing to update due to weird SQL generated by Hibernate for `FetchMode.SUBSELECT` when lazy-loading a library's indices. Was happening when setting nonStandardAlias on existing libraries with duplicate aliases
* Deploy to Tomcat was working before removing the FetchMode annotation and interestingly failed after removing it. Was due to dependency clash in miso-web. A different version of `bouncycastle.org:bcprov` was introduced by docker-maven-plugin, which doesn't seem to belong as a dependency anyway