### PR TITLE
Add average insert size calculation button

### DIFF
--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -1344,6 +1345,12 @@ public class Dtos {
     dto.setLongestIndex(from.getLongestIndex());
     dto.setLastModified(formatDateTime(from.getLastModified()));
     dto.setDilutionCount(from.getPoolableElementViews().size());
+    from.getPoolableElementViews().stream()//
+        .map(PoolableElementView::getLibraryDnaSize)//
+        .filter(Objects::nonNull)//
+        .mapToDouble(Long::doubleValue)//
+        .average()//
+        .ifPresent(dto::setInsertSize);
     if (includeContents) {
       Set<DilutionDto> pooledElements = new HashSet<>();
       for (PoolableElementView ld : from.getPoolableElementViews()) {

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/PoolDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/PoolDto.java
@@ -31,6 +31,7 @@ public class PoolDto implements WritableUrls {
   private int longestIndex;
   private boolean hasLowQualityLibraries;
   private int dilutionCount;
+  private Double insertSize;
 
   public String getAlias() {
     return alias;
@@ -225,5 +226,13 @@ public class PoolDto implements WritableUrls {
 
   public void setDilutionCount(int dilutionCount) {
     this.dilutionCount = dilutionCount;
+  }
+
+  public Double getInsertSize() {
+    return insertSize;
+  }
+
+  public void setInsertSize(Double insertSize) {
+    this.insertSize = insertSize;
   }
 }

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/ListTablesIT.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/ListTablesIT.java
@@ -39,7 +39,7 @@ public class ListTablesIT extends AbstractIT {
       Columns.VOLUME, Columns.CREATOR, Columns.CREATION_DATE);
   private static final Set<String> poolsColumns = Sets.newHashSet(Columns.SORT, Columns.NAME, Columns.ALIAS,
       Columns.DESCRIPTION, Columns.DATE_CREATED, Columns.DILUTIONS, Columns.POOL_CONCENTRATION, Columns.LOCATION,
-      Columns.LAST_MODIFIED);
+      Columns.AVG_INSERT_SIZE, Columns.LAST_MODIFIED);
   private static final Set<String> ordersColumns = Sets.newHashSet(Columns.NAME, Columns.ALIAS, Columns.DESCRIPTION,
       Columns.PLATFORM, Columns.LONGEST_INDEX, Columns.SEQUENCING_PARAMETERS, Columns.REMAINING, Columns.LAST_MODIFIED);
   private static final Set<String> containersColumns = Sets.newHashSet(Columns.SORT, Columns.SERIAL_NUMBER, Columns.LAST_RUN_NAME,

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/AbstractListPage.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/AbstractListPage.java
@@ -82,6 +82,7 @@ public interface AbstractListPage {
     public static final String EXTERNAL = "External";
     public static final String LOGGED_IN = "Logged In";
     public static final String GROUP_NAME = "Group Name";
+    public static final String AVG_INSERT_SIZE = "Average Insert Size";
   }
 
   public static class ListTarget {

--- a/miso-web/src/main/webapp/scripts/list_pool.js
+++ b/miso-web/src/main/webapp/scripts/list_pool.js
@@ -80,6 +80,15 @@ ListTarget.pool = {
           "include": true,
           "iSortPriority": 0
         }, {
+          "sTitle": "Average Insert Size",
+          "mData": "insertSize",
+          "bSortable": false,
+          "mRender": function(data, type, full) {
+            return data ? Math.round(data) : "N/A";
+          },
+          "include": true,
+          "iSortPriority": 0
+        }, {
           "sTitle": "Last Modified",
           "mData": "lastModified",
           "include": Constants.isDetailedSample,


### PR DESCRIPTION
From an internal request to replace previously removed functionality to calculate average insert size of pools selected on the List Pools page.

Users can select a number of pools and click "Avg. Insert Size", and an OK dialog is shown with the results of the calculation.