### PR TITLE
GLT-2073 override user-set 'not done' if run is 'done'

### DIFF
--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultRunService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultRunService.java
@@ -706,8 +706,10 @@ public class DefaultRunService implements RunService, AuthorizedPaginatedDataSou
         return true;
       }
     } else {
-      if (!target.didSomeoneElseChangeColumn("health", user) && target.getHealth() != source.getHealth()) {
+      if (!target.didSomeoneElseChangeColumn("health", user) || (target.getHealth().isDone() && !source.getHealth().isDone())) {
         // A human user has never change the health of this run, so we will.
+        // Alternatively, a human set the status to not-done but runscanner has indicated that the run is now done, so we will update with
+        // this.
         target.setHealth(source.getHealth());
         target.setCompletionDate(source.getHealth().isDone() ? source.getCompletionDate() : null);
         return true;


### PR DESCRIPTION
If user has set status to Started/Running/Requested/Unknown, run scanner will now override that to update the status if it sees that the run has Completed/Failed.