### PR TITLE
GLT-2046: require targeted sequencing depending on library design code

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/LibraryDesignCode.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/LibraryDesignCode.java
@@ -22,6 +22,9 @@ public class LibraryDesignCode implements Serializable {
   @Column(nullable = false)
   private String description;
 
+  @Column(nullable = false)
+  private Boolean targetedSequencingRequired;
+
   public Long getId() {
     return libraryDesignCodeId;
   };
@@ -44,5 +47,13 @@ public class LibraryDesignCode implements Serializable {
 
   public void setDescription(String description) {
     this.description = description;
+  }
+
+  public Boolean isTargetedSequencingRequired() {
+    return targetedSequencingRequired;
+  }
+
+  public void setTargetedSequencingRequired(Boolean targetedSequencingRequired) {
+    this.targetedSequencingRequired = targetedSequencingRequired;
   }
 }

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -914,6 +914,7 @@ public class Dtos {
     dto.setId(from.getId());
     dto.setCode(from.getCode());
     dto.setDescription(from.getDescription());
+    dto.setTargetedSequencingRequired(from.isTargetedSequencingRequired());
     return dto;
   }
 
@@ -922,6 +923,7 @@ public class Dtos {
     if (from.getId() != null) to.setId(from.getId());
     to.setCode(from.getCode());
     to.setDescription(from.getDescription());
+    to.setTargetedSequencingRequired(from.isTargetedSequencingRequired());
     return to;
   }
 

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/LibraryDesignCodeDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/LibraryDesignCodeDto.java
@@ -5,6 +5,7 @@ public class LibraryDesignCodeDto {
   private Long id;
   private String code;
   private String description;
+  private Boolean targetedSequencingRequired;
 
   public Long getId() {
     return id;
@@ -30,9 +31,18 @@ public class LibraryDesignCodeDto {
     this.description = description;
   }
 
+  public Boolean isTargetedSequencingRequired() {
+    return targetedSequencingRequired;
+  }
+
+  public void setTargetedSequencingRequired(Boolean targetedSequencingRequired) {
+    this.targetedSequencingRequired = targetedSequencingRequired;
+  }
+
   @Override
   public String toString() {
-    return "LibraryDesignCodeDto [id=" + id + ", code=" + code + ", description=" + description + "]";
+    return "LibraryDesignCodeDto [id=" + id + ", code=" + code + ", description=" + description + ", targetedSequencingRequired="
+        + targetedSequencingRequired + "]";
   }
 
 }

--- a/miso-web/src/main/webapp/scripts/hot.js
+++ b/miso-web/src/main/webapp/scripts/hot.js
@@ -53,7 +53,7 @@ var HotUtils = {
     },
 
     /**
-     * Custom validator for text fields that fails on empty or extra-special characters, but passes if text is empty
+     * Custom validator for text fields that fails on extra-special characters, but passes if text is empty
      */
     optionalTextNoSpecialChars: function(value, callback) {
       return callback(Utils.validation.isEmpty(value) || Utils.validation.hasNoSpecialChars(value))
@@ -75,6 +75,20 @@ var HotUtils = {
         callback(false);
       } else {
         Handsontable.AutocompleteValidator.call(this, value, callback);
+      }
+    },
+
+    /**
+     * @return Custom validator for dropdown fields that fails on empty or a specified value that represents null/empty (e.g. "None"), or if
+     *         the value is not a member of the source array
+     */
+    requiredAutocompleteWithNullValue: function(nullValue) {
+      return function(value, callback) {
+        if (value === nullValue) {
+          callback(false);
+        } else {
+          HotUtils.validator.requiredAutocomplete(value, callback);
+        }
       }
     }
   },

--- a/miso-web/src/main/webapp/scripts/hot_dilution.js
+++ b/miso-web/src/main/webapp/scripts/hot_dilution.js
@@ -64,12 +64,21 @@ HotTarget.dilution = {
           type: 'dropdown',
           trimDropdown: false,
           source: [],
-          validator: HotUtils.validator.permitEmptyDropdown,
           include: Constants.isDetailedSample,
           unpack: function(dil, flat, setCellMeta) {
             flat.targetedSequencingAlias = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(Utils.array
                 .idPredicate(dil.targetedSequencingId), Constants.targetedSequencings), 'alias')
                 || '(None)';
+
+            // whether targeted sequencing is required depends on library's design code
+            var designCode = Utils.array.findFirstOrNull(function(code) {
+              return dil.library.libraryDesignCodeId == code.id;
+            }, Constants.libraryDesignCodes);
+            if (Utils.array.maybeGetProperty(designCode, 'targetedSequencingRequired')) {
+              setCellMeta('validator', HotUtils.validator.requiredAutocompleteWithNullValue('(None)'));
+            } else {
+              setCellMeta('validator', HotUtils.validator.permitEmptyDropdown);
+            }
           },
           pack: function(dil, flat, errorHandler) {
             dil.targetedSequencingId = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(function(tarSeq) {

--- a/sqlstore/src/main/resources/db/migration/V8503__tarseq_required.sql
+++ b/sqlstore/src/main/resources/db/migration/V8503__tarseq_required.sql
@@ -1,0 +1,1 @@
+ALTER TABLE LibraryDesignCode ADD COLUMN targetedSequencingRequired TINYINT(1) NOT NULL DEFAULT 0;


### PR DESCRIPTION
This patch doesn't actually make targeted sequencing required for any library design codes, as those are institute-specific. For testing on OICR, run this on your DB after the included migration:

```
UPDATE LibraryDesignCode SET targetedSequencingRequired = 1 WHERE code <> 'WG';
```

This will be added in a PR to `oicr` branch as well