### PR TITLE
fix JSON parsing errors in Lib & LD Handsontables

### DIFF
--- a/miso-web/src/main/webapp/scripts/hot.js
+++ b/miso-web/src/main/webapp/scripts/hot.js
@@ -637,7 +637,7 @@ var HotUtils = {
     baseobj.unpack = function(obj, flat, setCellMeta) {
       flat[flatProperty] = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(function(item) {
         return item[id] == obj[modelProperty];
-      }, items), name) || (required ? '' : '(None)');
+      }, items), name) || (required ? null : '(None)');
     };
     baseobj.pack = function(obj, flat, errorHandler) {
       obj[modelProperty] = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(function(item) {
@@ -691,7 +691,7 @@ var HotUtils = {
       'type': 'text',
       'include': include,
       'unpack': function(obj, flat, setCellMeta) {
-        flat[property] = obj[property] || null;
+        flat[property] = Utils.valOrNull(obj[property]);
       },
       'validator': required ? HotUtils.validator.requiredNumber : HotUtils.validator.optionalNumber,
       'pack': function(obj, flat, errorHandler) {
@@ -723,7 +723,7 @@ var HotUtils = {
       'include': include,
       'validator': validator,
       'unpack': function(obj, flat, setCellMeta) {
-        flat[property] = obj[property] || null;
+        flat[property] = Utils.valOrNull(obj[property]);
       },
       'pack': function(obj, flat, errorHandler) {
         if (!Utils.validation.isEmpty(flat[property])) {
@@ -742,7 +742,7 @@ var HotUtils = {
     baseobj.include = include;
     if (!baseobj.hasOwnProperty('unpack')) {
       baseobj.unpack = function(obj, flat, setCellMeta) {
-        flat[property] = obj[property] || null;
+        flat[property] = Utils.valOrNull(obj[property]);
       };
     }
     baseobj.pack = function(obj, flat, errorHandler) {

--- a/miso-web/src/main/webapp/scripts/hot_dilution.js
+++ b/miso-web/src/main/webapp/scripts/hot_dilution.js
@@ -16,7 +16,7 @@ HotTarget.dilution = {
           validator: HotUtils.validator.optionalTextNoSpecialChars,
           unpackAfterSave: true,
           unpack: function(dil, flat, setCellMeta) {
-            flat.name = dil.name || null;
+            flat.name = Utils.valOrNull(dil.name);
           },
           pack: function(dil, flat, errorHandler) {
             dil.name = flat.name;
@@ -52,7 +52,7 @@ HotTarget.dilution = {
           validator: HotUtils.validator.requiredText,
           include: true,
           unpack: function(dil, flat, setCellMeta) {
-            flat.creationDate = dil.creationDate;
+            flat.creationDate = Utils.valOrNull(dil.creationDate);
           },
           pack: function(dil, flat, errorHandler) {
             dil.creationDate = flat.creationDate;

--- a/miso-web/src/main/webapp/scripts/hot_library.js
+++ b/miso-web/src/main/webapp/scripts/hot_library.js
@@ -95,7 +95,7 @@ HotTarget.library = (function() {
             include: true,
             unpackAfterSave: true,
             unpack: function(lib, flat, setCellMeta) {
-              flat.name = lib.name;
+              flat.name = Utils.valOrNull(lib.name);
             },
             pack: function(lib, flat, errorHandler) {
             }
@@ -136,7 +136,7 @@ HotTarget.library = (function() {
             unpackAfterSave: true,
             unpack: function(lib, flat, setCellMeta) {
               validationCache[lib.alias] = true;
-              flat.alias = lib.alias;
+              flat.alias = Utils.valOrNull(lib.alias);
               if (lib.nonStandardAlias) {
                 HotUtils.makeCellNSAlias(setCellMeta);
               }
@@ -169,7 +169,7 @@ HotTarget.library = (function() {
             readOnly: true,
             include: config.sortableLocation && !config.isLibraryReceipt,
             unpack: function(sam, flat, setCellMeta) {
-              flat.sampleBoxPositionLabel = sam.sampleBoxPositionLabel;
+              flat.sampleBoxPositionLabel = Utils.valOrNull(sam.sampleBoxPositionLabel);
             },
             pack: function(sam, flat, errorHandler) {
               sam.sampleBoxPositionLabel = flat.sampleBoxPositionLabel;
@@ -203,7 +203,7 @@ HotTarget.library = (function() {
             allowEmpty: !config.isLibraryReceipt,
             include: config.isLibraryReceipt || !create,
             unpack: function(lib, flat, setCellMeta) {
-              flat.receivedDate = lib.receivedDate || null;
+              flat.receivedDate = Utils.valOrNull(lib.receivedDate);
             },
             pack: function(lib, flat, errorHandler) {
               lib.receivedDate = flat.receivedDate;
@@ -270,7 +270,7 @@ HotTarget.library = (function() {
             validator: HotUtils.validator.requiredAutocomplete,
             include: true,
             unpack: function(lib, flat, setCellMeta) {
-              flat.platformType = lib.platformType;
+              flat.platformType = Utils.valOrNull(lib.platformType);
             },
             pack: function(lib, flat, errorHandler) {
               lib.platformType = flat.platformType;
@@ -326,7 +326,7 @@ HotTarget.library = (function() {
             source: [''],
             include: true,
             unpack: function(lib, flat, setCellMeta) {
-              flat.indexFamilyName = flat.platformType ? (lib.indexFamilyName || 'No indices') : '';
+              flat.indexFamilyName = flat.platformType ? (lib.indexFamilyName || 'No indices') : null;
             },
             pack: function(lib, flat, errorHandler) {
             },

--- a/miso-web/src/main/webapp/scripts/hot_sample.js
+++ b/miso-web/src/main/webapp/scripts/hot_sample.js
@@ -103,7 +103,7 @@ HotTarget.sample = (function() {
             include: !config.isLibraryReceipt,
             unpackAfterSave: true,
             unpack: function(sam, flat, setCellMeta) {
-              flat.name = sam.name || null;
+              flat.name = Utils.valOrNull(sam.name);
             },
             pack: function(sam, flat, errorHandler) {
             }
@@ -143,7 +143,7 @@ HotTarget.sample = (function() {
             unpackAfterSave: true,
             unpack: function(sam, flat, setCellMeta) {
               validationCache[sam.alias] = true;
-              flat.alias = sam.alias || null;
+              flat.alias = Utils.valOrNull(sam.alias);
               if (sam.nonStandardAlias) {
                 HotUtils.makeCellNSAlias(setCellMeta);
               }
@@ -168,7 +168,7 @@ HotTarget.sample = (function() {
             allowEmpty: true,
             include: (!Constants.isDetailedSample || config.targetSampleClass.alias != 'Identity') && !config.isLibraryReceipt,
             unpack: function(sam, flat, setCellMeta) {
-              flat.receivedDate = sam.receivedDate || null;
+              flat.receivedDate = Utils.valOrNull(sam.receivedDate);
             },
             pack: function(sam, flat, errorHandler) {
               sam.receivedDate = flat.receivedDate;
@@ -181,7 +181,7 @@ HotTarget.sample = (function() {
           HotUtils.makeColumnForText('Sci. Name', true, 'scientificName', {
             validator: HotUtils.validator.requiredTextNoSpecialChars,
             unpack: function(obj, flat, setCellMeta) {
-              flat.scientificName = obj.scientificName || config.defaultSciName;
+              flat.scientificName = obj.scientificName || config.defaultSciName || null;
             }
           }),
           {
@@ -207,11 +207,11 @@ HotTarget.sample = (function() {
             unpack: function(sam, flat, setCellMeta) {
               var label = Constants.isDetailedSample ? 'shortName' : 'name';
               if (config.hasProject) {
-                flat.projectAlias = config.project[label] || null;
+                flat.projectAlias = Utils.valOrNull(config.project[label]);
               } else {
                 flat.projectAlias = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(function(item) {
                   return item.id == sam.projectId;
-                }, config.projects), 'alias') || null;
+                }, config.projects), 'alias');
               }
             },
             pack: function(sam, flat, errorHandler) {
@@ -243,7 +243,7 @@ HotTarget.sample = (function() {
             unpack: function(sam, flat, setCellMeta) {
               flat.parentTissueSampleClassAlias = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(function(item) {
                 return item.id == sam.parentTissueSampleClassId;
-              }, Constants.sampleClasses), 'alias') || null;
+              }, Constants.sampleClasses), 'alias');
             },
             pack: function(sam, flat, errorHandler) {
               sam.parentTissueSampleClassId = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(function(item) {
@@ -260,7 +260,7 @@ HotTarget.sample = (function() {
             validator: HotUtils.validator.requiredTextNoSpecialChars,
             include: show['Identity'],
             unpack: function(sam, flat, setCellMeta) {
-              flat.externalName = sam.externalName || null;
+              flat.externalName = Utils.valOrNull(sam.externalName);
             },
             pack: function(sam, flat, errorHandler) {
               if (!getSelectedIdentity(flat)) {
@@ -374,7 +374,7 @@ HotTarget.sample = (function() {
             unpack: function(sam, flat, setCellMeta) {
               flat.sampleClassAlias = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(function(item) {
                 return item.id == sam.sampleClassId;
-              }, Constants.sampleClasses), 'alias') || null;
+              }, Constants.sampleClasses), 'alias');
             },
             pack: function(sam, flat, errorHandler) {
               sam.sampleClassId = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(function(item) {
@@ -432,8 +432,7 @@ HotTarget.sample = (function() {
             unpack: function(sam, flat, setCellMeta) {
               if (sam.stain) {
                 flat.stainName = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(Utils.array.idPredicate(sam.stain.id),
-                    Constants.stains), 'name')
-                    || null;
+                    Constants.stains), 'name');
               } else {
                 flat.stainName = '(None)';
               }
@@ -526,8 +525,7 @@ HotTarget.sample = (function() {
                     || 'Not Ready';
               } else {
                 flat.detailedQcStatusDescription = Utils.array.maybeGetProperty(Utils.array.findFirstOrNull(Utils.array
-                    .idPredicate(sam.detailedQcStatusId), Constants.detailedQcStatuses), 'description')
-                    || null;
+                    .idPredicate(sam.detailedQcStatusId), Constants.detailedQcStatuses), 'description');
               }
             },
             pack: function(sam, flat, errorHandler) {

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -460,6 +460,10 @@ var Utils = Utils
           row: rowVal,
           col: colVal
         };
+      },
+      
+      valOrNull: function(val) {
+        return val || null;
       }
     };
 


### PR DESCRIPTION
The JSON parser can't handle `undefined`, so this change adds a null if the Handsontable unpack field is undefined.