### PR TITLE
GLT-1252 add collapse button to edit project page

### DIFF
--- a/miso-web/src/main/webapp/pages/editProject.jsp
+++ b/miso-web/src/main/webapp/pages/editProject.jsp
@@ -538,12 +538,53 @@
 </div>
 <br/>
 
-  <miso:list-section-ajax id="project_studies" name="Studies" target="study" project="${project}" config="{ isAdmin : ${fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')} }"/>
-  <miso:list-section-ajax id="project_samples" name="Samples" target="sample" project="${project}" config="{}"/>
-  <miso:list-section-ajax id="project_libraries" name="Libraries" target="library" project="${project}" config="{}"/>
-  <miso:list-section-ajax id="project_dilutions" name="Dilutions" target="dilution" project="${project}" config="{}"/>
-  <miso:list-section-ajax id="project_pools" name="Pools" target="pool" project="${project}" config="{}"/>
-  <miso:list-section-ajax id="project_runs" name="Runs" target="run" project="${project}" config="{}"/>
+  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#studies_section_arrowclick'), 'studies_section');">
+    Studies
+	<div id="studies_section_arrowclick" class="toggleLeft"></div>
+  </div>
+  <div id="studies_section">
+    <miso:list-section-ajax id="project_studies" name="Studies" target="study" project="${project}" config="{ isAdmin : ${fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')} }"/>
+  </div>
+
+  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#samples_section_arrowclick'), 'samples_section');">
+    Samples
+	<div id="samples_section_arrowclick" class="toggleLeft"></div>
+  </div>
+  <div id="samples_section">
+    <miso:list-section-ajax id="project_samples" name="Samples" target="sample" project="${project}" config="{}"/>
+  </div>
+
+  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#libraries_section_arrowclick'), 'libraries_section');">
+    Libraries
+	<div id="libraries_section_arrowclick" class="toggleLeft"></div>
+  </div>
+  <div id="libraries_section">
+	  <miso:list-section-ajax id="project_libraries" name="Libraries" target="library" project="${project}" config="{}"/>
+  </div>
+
+  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#dilutions_section_arrowclick'), 'dilutions_section');">
+    Dilutions
+	<div id="dilutions_section_arrowclick" class="toggleLeft"></div>
+  </div>
+  <div id="dilutions_section">
+	  <miso:list-section-ajax id="project_dilutions" name="Dilutions" target="dilution" project="${project}" config="{}"/>
+  </div>
+
+  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#pools_section_arrowclick'), 'pools_section');">
+    Pools
+	<div id="pools_section_arrowclick" class="toggleLeft"></div>
+  </div>
+  <div id="pools_section">
+	  <miso:list-section-ajax id="project_pools" name="Pools" target="pool" project="${project}" config="{}"/>
+  </div>
+
+  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#runs_section_arrowclick'), 'runs_section');">
+    Runs
+	<div id="runs_section_arrowclick" class="toggleLeft"></div>
+  </div>
+  <div id="runs_section">
+	  <miso:list-section-ajax id="project_runs" name="Runs" target="run" project="${project}" config="{}"/>
+  </div>
 </c:when>
 </c:choose>
 

--- a/miso-web/src/main/webapp/pages/editProject.jsp
+++ b/miso-web/src/main/webapp/pages/editProject.jsp
@@ -441,12 +441,20 @@
 </c:when>
 </c:choose>
 </div>
+<br/>
+
+<button id="collapse_all" type="button" class="fg-button ui-state-default ui-corner-all" onclick="Utils.ui.collapseClass('expandable_section')">
+    Collapse all
+</button>
+<br/>
+<br/>
+
 
 <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#issues_arrowclick'), 'issuesdiv');">
   Tracked Issues
   <div id="issues_arrowclick" class="toggleLeft"></div>
 </div>
-<div id="issuesdiv" class="note" style="display:none;">
+<div id="issuesdiv" class="note expandable_section" style="display:none;">
   <c:choose>
     <c:when test="${project.id != 0}">
       To link issues to this project please enter your issue keys here, separated by a single comma, e.g. FOO-1,FOO-2,FOO-3:<br/>
@@ -491,7 +499,7 @@
     Project Files
     <div id="upload_arrowclick" class="toggleLeft"></div>
   </div>
-  <div id="uploaddiv" class="simplebox" style="display:none;">
+  <div id="uploaddiv" class="simplebox expandable_section" style="display:none;">
     <table class="in">
       <tr>
         <td>
@@ -538,55 +546,61 @@
 </div>
 <br/>
 
-  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#studies_section_arrowclick'), 'studies_section');">
-    Studies
-	<div id="studies_section_arrowclick" class="toggleLeft"></div>
-  </div>
-  <div id="studies_section">
-    <miso:list-section-ajax id="project_studies" name="Studies" target="study" project="${project}" config="{ isAdmin : ${fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')} }"/>
-  </div>
+<div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#studies_section_arrowclick'), 'studies_section');">
+  Studies
+<div id="studies_section_arrowclick" class="toggleLeft"></div>
+</div>
+<div id="studies_section" class="expandable_section">
+  <miso:list-section-ajax id="project_studies" name="Studies" target="study" project="${project}" config="{ isAdmin : ${fn:contains(SPRING_SECURITY_CONTEXT.authentication.principal.authorities,'ROLE_ADMIN')} }"/>
+</div>
 
-  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#samples_section_arrowclick'), 'samples_section');">
-    Samples
-	<div id="samples_section_arrowclick" class="toggleLeft"></div>
-  </div>
-  <div id="samples_section">
-    <miso:list-section-ajax id="project_samples" name="Samples" target="sample" project="${project}" config="{}"/>
-  </div>
+<div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#samples_section_arrowclick'), 'samples_section');">
+  Samples
+<div id="samples_section_arrowclick" class="toggleLeft"></div>
+</div>
+<div id="samples_section" class="expandable_section">
+  <miso:list-section-ajax id="project_samples" name="Samples" target="sample" project="${project}" config="{}"/>
+</div>
 
-  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#libraries_section_arrowclick'), 'libraries_section');">
-    Libraries
-	<div id="libraries_section_arrowclick" class="toggleLeft"></div>
-  </div>
-  <div id="libraries_section">
-	  <miso:list-section-ajax id="project_libraries" name="Libraries" target="library" project="${project}" config="{}"/>
-  </div>
+<div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#libraries_section_arrowclick'), 'libraries_section');">
+  Libraries
+<div id="libraries_section_arrowclick" class="toggleLeft"></div>
+</div>
+<div id="libraries_section" class="expandable_section">
+  <miso:list-section-ajax id="project_libraries" name="Libraries" target="library" project="${project}" config="{}"/>
+</div>
 
-  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#dilutions_section_arrowclick'), 'dilutions_section');">
-    Dilutions
-	<div id="dilutions_section_arrowclick" class="toggleLeft"></div>
-  </div>
-  <div id="dilutions_section">
-	  <miso:list-section-ajax id="project_dilutions" name="Dilutions" target="dilution" project="${project}" config="{}"/>
-  </div>
+<div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#dilutions_section_arrowclick'), 'dilutions_section');">
+  Dilutions
+<div id="dilutions_section_arrowclick" class="toggleLeft"></div>
+</div>
+<div id="dilutions_section" class="expandable_section">
+  <miso:list-section-ajax id="project_dilutions" name="Dilutions" target="dilution" project="${project}" config="{}"/>
+</div>
 
-  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#pools_section_arrowclick'), 'pools_section');">
-    Pools
-	<div id="pools_section_arrowclick" class="toggleLeft"></div>
-  </div>
-  <div id="pools_section">
-	  <miso:list-section-ajax id="project_pools" name="Pools" target="pool" project="${project}" config="{}"/>
-  </div>
+<div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#pools_section_arrowclick'), 'pools_section');">
+  Pools
+<div id="pools_section_arrowclick" class="toggleLeft"></div>
+</div>
+<div id="pools_section" class="expandable_section">
+  <miso:list-section-ajax id="project_pools" name="Pools" target="pool" project="${project}" config="{}"/>
+</div>
 
-  <div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#runs_section_arrowclick'), 'runs_section');">
-    Runs
-	<div id="runs_section_arrowclick" class="toggleLeft"></div>
-  </div>
-  <div id="runs_section">
-	  <miso:list-section-ajax id="project_runs" name="Runs" target="run" project="${project}" config="{}"/>
-  </div>
+<div class="sectionDivider" onclick="Utils.ui.toggleLeftInfo(jQuery('#runs_section_arrowclick'), 'runs_section');">
+  Runs
+<div id="runs_section_arrowclick" class="toggleLeft"></div>
+</div>
+<div id="runs_section" class="expandable_section">
+  <miso:list-section-ajax id="project_runs" name="Runs" target="run" project="${project}" config="{}"/>
+</div>
+
 </c:when>
 </c:choose>
+<br/>
+
+<button id="collapse_all" type="button" class="fg-button ui-state-default ui-corner-all" onclick="Utils.ui.collapseClass('expandable_section')">
+    Collapse all
+</button>
 
 <div id="addProjectOverviewNoteDialog" title="Create new Note"></div>
 

--- a/miso-web/src/main/webapp/pages/permissions.jsp
+++ b/miso-web/src/main/webapp/pages/permissions.jsp
@@ -25,7 +25,7 @@
   Permissions
   <div id="permissions_arrowclick" class="toggleLeft"></div>
 </div>
-<div id="permissions" class="note" style="display:none">
+<div id="permissions" class="note expandable_section" style="display:none">
   <h2>Permissions</h2>
   <table class="in">
     <tr>

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -580,6 +580,12 @@ Utils.ui = {
     Utils.ui.toggleElement(id);
   },
 
+  collapseClass: function(class_) {
+    jQuery('.' + class_).slideUp({
+      'duration': 500
+    });
+  },
+
   goodDateFormat: 'yy-mm-dd',
 
   addDatePicker: function(id) {

--- a/miso-web/src/main/webapp/scripts/lims.js
+++ b/miso-web/src/main/webapp/scripts/lims.js
@@ -556,13 +556,19 @@ Utils.ui = {
     return Element.extend(element);
   },
 
+  toggleElement: function(id) {
+    jQuery("#" + id).slideToggle({
+      'duration': 500
+    });
+  },
+
   toggleRightInfo: function(div, id) {
     if (jQuery(div).hasClass("toggleRight")) {
       jQuery(div).removeClass("toggleRight").addClass("toggleRightDown");
     } else {
       jQuery(div).removeClass("toggleRightDown").addClass("toggleRight");
     }
-    jQuery("#" + id).toggle("blind", {}, 500);
+    Utils.ui.toggleElement(id);
   },
 
   toggleLeftInfo: function(div, id) {
@@ -571,7 +577,7 @@ Utils.ui = {
     } else {
       jQuery(div).removeClass("toggleLeftDown").addClass("toggleLeft");
     }
-    jQuery("#" + id).toggle("blind", {}, 500);
+    Utils.ui.toggleElement(id);
   },
 
   goodDateFormat: 'yy-mm-dd',


### PR DESCRIPTION
Only affects behaviour of Edit Project page and Create Project page.

Looks like this when fully collapsed:
![image](https://user-images.githubusercontent.com/35044180/35104798-ead219ac-fc37-11e7-9351-35e559dc9c2d.png)
