### PR TITLE
GLT-2108: Add Lane QC changes to RunChangeLog

### DIFF
--- a/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_partitionqc.sql
+++ b/sqlstore/src/main/resources/db/migration_afterMigrate/05_trigger_partitionqc.sql
@@ -2,26 +2,76 @@
 DELIMITER //
 
 DROP TRIGGER IF EXISTS PartitionQCInsert//
-CREATE TRIGGER PartitionQCInsert AFTER INSERT ON Run_Partition_QC
-FOR EACH ROW
-  INSERT INTO SequencerPartitionContainerChangeLog(containerId, columnsChanged, userId, message) VALUES (
-    (SELECT container_containerId FROM SequencerPartitionContainer_Partition WHERE partitions_partitionId = NEW.partitionId),
-    'QC',
-    (SELECT lastModifier FROM SequencerPartitionContainer JOIN SequencerPartitionContainer_Partition ON SequencerPartitionContainer.containerId = SequencerPartitionContainer_Partition.container_containerId WHERE partitions_partitionId = NEW.partitionId),
-    CONCAT('QC for ', (SELECT partitionNumber FROM _Partition WHERE partitionId = NEW.partitionId), ': N/A → ', (SELECT description FROM PartitionQCType WHERE partitionQcTypeId = NEW.partitionQcTypeId))
-  )//
+CREATE TRIGGER PartitionQCInsert
+  AFTER INSERT
+  ON Run_Partition_QC
+  FOR EACH ROW
+  BEGIN
+    SELECT
+      container_containerId,
+      lastModifier,
+      partitionNumber
+    INTO @containerId, @userId, @partitionNumber
+    FROM SequencerPartitionContainer
+      JOIN SequencerPartitionContainer_Partition
+        ON SequencerPartitionContainer.containerId = SequencerPartitionContainer_Partition.container_containerId
+      JOIN _Partition
+        ON SequencerPartitionContainer_Partition.partitions_partitionId = _Partition.partitionId
+    WHERE partitions_partitionId = NEW.partitionId;
+
+    SET @runId = NEW.runId;
+    SET @message = CONCAT('QC for ',
+                          @partitionNumber,
+                          ': N/A → ',
+                          (SELECT description
+                           FROM PartitionQCType
+                           WHERE partitionQcTypeId = NEW.partitionQcTypeId));
+
+    INSERT INTO SequencerPartitionContainerChangeLog (containerId, columnsChanged, userId, message)
+    VALUES (@containerId, 'QC', @userId, @message);
+
+    INSERT INTO RunChangeLog (runId, columnsChanged, userId, message)
+    VALUES (@runId, 'QC', @userId, @message);
+  END //
 
 DROP TRIGGER IF EXISTS PartitionQCUpdate//
-CREATE TRIGGER PartitionQCUpdate BEFORE UPDATE ON Run_Partition_QC
-FOR EACH ROW
+CREATE TRIGGER PartitionQCUpdate
+  BEFORE UPDATE
+  ON Run_Partition_QC
+  FOR EACH ROW
   BEGIN
-      IF NEW.partitionQcTypeId <> OLD.partitionQcTypeId  THEN
-        INSERT INTO SequencerPartitionContainerChangeLog(containerId, columnsChanged, userId, message) VALUES (
-          (SELECT container_containerId FROM SequencerPartitionContainer_Partition WHERE partitions_partitionId = NEW.partitionId),
-          'QC',
-          (SELECT lastModifier FROM SequencerPartitionContainer JOIN SequencerPartitionContainer_Partition ON SequencerPartitionContainer.containerId = SequencerPartitionContainer_Partition.container_containerId WHERE partitions_partitionId = NEW.partitionId),
-          CONCAT('QC for ', (SELECT partitionNumber FROM _Partition WHERE partitionId = NEW.partitionId), ': ', (SELECT description FROM PartitionQCType WHERE partitionQcTypeId = OLD.partitionQcTypeId), ' → ', (SELECT description FROM PartitionQCType WHERE partitionQcTypeId = NEW.partitionQcTypeId)));
-      END IF;
+    SELECT
+      container_containerId,
+      lastModifier,
+      partitionNumber
+    INTO @containerId, @userId, @partitionNumber
+    FROM SequencerPartitionContainer
+      JOIN SequencerPartitionContainer_Partition
+        ON SequencerPartitionContainer.containerId = SequencerPartitionContainer_Partition.container_containerId
+      JOIN _Partition
+        ON SequencerPartitionContainer_Partition.partitions_partitionId = _Partition.partitionId
+    WHERE partitions_partitionId = NEW.partitionId;
+
+    SET @runId = NEW.runId;
+    SET @message = CONCAT('QC for ',
+                          @partitionNumber,
+                          ': ',
+                          (SELECT description
+                           FROM PartitionQCType
+                           WHERE partitionQcTypeId = OLD.partitionQcTypeId),
+                          ' → ',
+                          (SELECT description
+                           FROM PartitionQCType
+                           WHERE partitionQcTypeId = NEW.partitionQcTypeId));
+
+    IF NEW.partitionQcTypeId <> OLD.partitionQcTypeId
+    THEN
+      INSERT INTO SequencerPartitionContainerChangeLog (containerId, columnsChanged, userId, message)
+      VALUES (@containerId, 'QC', @userId, @message);
+
+      INSERT INTO RunChangeLog (runId, columnsChanged, userId, message)
+      VALUES (@runId, 'QC', @userId, @message);
+    END IF;
   END//
 DELIMITER ;
 -- EndNoTest


### PR DESCRIPTION
When the Run_Partition_QC table is changed, compose some fields and store them in temporary user variables.  Store the changed records in both `SequencerPartitionContainerChangeLog` and `RunChangeLog`.

I auto-formatted the file for readability, apologies in advance.