### PR TITLE
Move miscellaneous implementations into interface packages

### DIFF
--- a/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/MisoServiceManager.java
+++ b/migration/src/main/java/uk/ac/bbsrc/tgac/miso/migration/destination/MisoServiceManager.java
@@ -16,7 +16,7 @@ import com.eaglegenomics.simlims.core.manager.LocalSecurityManager;
 import uk.ac.bbsrc.tgac.miso.core.security.SuperuserAuthentication;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.NamingScheme;
 import uk.ac.bbsrc.tgac.miso.core.service.naming.OicrNamingScheme;
-import uk.ac.bbsrc.tgac.miso.persistence.HibernateSampleClassDao;
+import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSampleClassDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateBoxDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateChangeLogDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateDetailedQcStatusDao;

--- a/migration/src/test/java/uk/ac/bbsrc/tgac/miso/migration/destination/ValueTypeLookupTest.java
+++ b/migration/src/test/java/uk/ac/bbsrc/tgac/miso/migration/destination/ValueTypeLookupTest.java
@@ -50,7 +50,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.type.LibraryStrategyType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.LibraryType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.PlatformType;
 import uk.ac.bbsrc.tgac.miso.core.data.type.QcType;
-import uk.ac.bbsrc.tgac.miso.persistence.HibernateSampleClassDao;
+import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateSampleClassDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateDetailedQcStatusDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateIndexDao;
 import uk.ac.bbsrc.tgac.miso.persistence.impl.HibernateInstrumentDao;

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultInstrumentStatusService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultInstrumentStatusService.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.service;
+package uk.ac.bbsrc.tgac.miso.service.impl;
 
 import java.io.IOException;
 import java.util.List;
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.InstrumentStatus;
 import uk.ac.bbsrc.tgac.miso.core.store.InstrumentStatusStore;
+import uk.ac.bbsrc.tgac.miso.service.InstrumentStatusService;
 
 @Service
 @Transactional(rollbackFor = Exception.class)

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleClassDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleClassDao.java
@@ -1,4 +1,4 @@
-package uk.ac.bbsrc.tgac.miso.persistence;
+package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import java.util.Date;
 import java.util.List;
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import uk.ac.bbsrc.tgac.miso.core.data.SampleClass;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.SampleClassImpl;
+import uk.ac.bbsrc.tgac.miso.persistence.SampleClassDao;
 
 @Repository
 @Transactional


### PR DESCRIPTION
The following implementations were packaged with interfaces, so I moved them to their respective implementation packages:

DefaultInstrumentStatusService
HibernateSampleClassDao