### PR TITLE
GLT-2197: correct user in Partition QC changelogs

### DIFF
--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPartitionQCService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultPartitionQCService.java
@@ -52,9 +52,15 @@ public class DefaultPartitionQCService implements PartitionQCService {
     PartitionQC managedQc = get(qc.getRun(), qc.getPartition());
     Run managedRun = runService.get(qc.getRun().getId());
     authorizationManager.throwIfNotWritable(managedRun);
+    Partition managedPartition = containerService.getPartition(qc.getPartition().getId());
+
+    // update run and container for accurate lastModified and lastModifier (used in changelogs)
+    runService.update(managedRun);
+    containerService.update(managedPartition.getSequencerPartitionContainer());
+
     if (managedQc == null) {
       qc.setRun(managedRun);
-      qc.setPartition(containerService.getPartition(qc.getPartition().getId()));
+      qc.setPartition(managedPartition);
       qc.setType(getType(qc.getType().getId()));
       partitionQcDao.create(qc);
     } else {

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePartitionQcDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernatePartitionQcDao.java
@@ -26,6 +26,7 @@ public class HibernatePartitionQcDao implements PartitionQcStore {
 
   @Override
   public void create(PartitionQC qc) throws IOException {
+    currentSession().flush(); // required to update related entity lastModifiers for changelogs
     currentSession().save(qc);
   }
 
@@ -64,6 +65,7 @@ public class HibernatePartitionQcDao implements PartitionQcStore {
 
   @Override
   public void update(PartitionQC managedQc) throws IOException {
+    currentSession().flush(); // required to update related entity lastModifiers for changelogs
     currentSession().update(managedQc);
   }
 


### PR DESCRIPTION
Using `@Synchronize("SequencerPartitionContainer")` on PartitionQC doesn't work for some reason, so full flush is needed