### PR TITLE
GLT-2183: Create search widget

### DIFF
--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/BarcodableDto.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/BarcodableDto.java
@@ -1,0 +1,62 @@
+package uk.ac.bbsrc.tgac.miso.dto;
+
+public class BarcodableDto {
+  private Long id;
+  private String entityType;
+
+  private String name;
+  private String alias;
+  private String identificationBarcode;
+
+  private String url;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getEntityType() {
+    return entityType;
+  }
+
+  public void setEntityType(String entityType) {
+    this.entityType = entityType;
+  }
+
+  public String getAlias() {
+
+    return alias;
+  }
+
+  public void setAlias(String alias) {
+    this.alias = alias;
+  }
+
+  public String getName() {
+
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getIdentificationBarcode() {
+    return identificationBarcode;
+  }
+
+  public void setIdentificationBarcode(String identificationBarcode) {
+    this.identificationBarcode = identificationBarcode;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+}

--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -125,6 +125,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.impl.boxposition.LibraryBoxPosition;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.boxposition.PoolBoxPosition;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.boxposition.SampleBoxPosition;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.kit.KitDescriptor;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.view.BarcodableView;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.view.BoxableView;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.view.PoolableElementView;
 import uk.ac.bbsrc.tgac.miso.core.data.spreadsheet.SpreadSheetFormat;
@@ -430,7 +431,7 @@ public class Dtos {
 
   /**
    * Extracts parent details from the DTO, according to these possible cases:
-   * 
+   *
    * <ol>
    * <li>parent ID is provided. This implies that the parent exists, so no other parent information will be required</li>
    * <li>identity information and parentTissueSampleClassId are provided. This implies that a tissue parent should be created, and that the
@@ -438,7 +439,7 @@ public class Dtos {
    * provided to indicate a second aliquot level in the hierarchy</li>
    * <li>identity information is provided, but no parentTissueSampleClassId. You must be creating a tissue in this case.</li>
    * </ol>
-   * 
+   *
    * @param childDto
    *          the DTO to take parent details from
    * @return the parent details from the DTO, or null if there are none. A returned sample will also include its own parent if applicable.
@@ -2255,6 +2256,16 @@ public class Dtos {
     dto.setDescription(from.getDescription());
     dto.setUserName(from.getUser().getFullName());
     dto.setChangeTime(formatDateTime(from.getChangeTime()));
+    return dto;
+  }
+
+  public static BarcodableDto asDto(BarcodableView from) {
+    BarcodableDto dto = new BarcodableDto();
+    dto.setId(from.getId().getTargetId());
+    dto.setEntityType(from.getId().getTargetType().toString());
+    dto.setAlias(from.getAlias());
+    dto.setName(from.getName());
+    dto.setIdentificationBarcode(from.getIdentificationBarcode());
     return dto;
   }
 }

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/BarcodableViewService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/BarcodableViewService.java
@@ -13,6 +13,12 @@ public interface BarcodableViewService {
   List<BarcodableView> searchByBarcode(String barcode, Collection<Barcodable.EntityType> typeFilter);
 
   /**
+   * Searches against all Barcodable entities using exact matches
+   * @param query name, alias, or barcode of a Barcodable entity
+   */
+  List<BarcodableView> search(String query);
+
+  /**
    * Fetch the full entity object represented by the provided BarcodableView.
    * Return type depends on the target type of the provided view.
    * Incorrect usage (e.g. view.id.targetType != SAMPLE && Sample s = getEntity(view)) will result in a ClassCastException

--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultBarcodableViewService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultBarcodableViewService.java
@@ -38,6 +38,11 @@ public class DefaultBarcodableViewService implements BarcodableViewService {
   }
 
   @Override
+  public List<BarcodableView> search(String query) {
+    return barcodableViewDao.search(query);
+  }
+
+  @Override
   public <T extends Barcodable> T getEntity(BarcodableView view) throws IOException {
     EntityType entityType = view.getId().getTargetType();
     long id = view.getId().getTargetId();

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/BarcodableSearchRestController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/rest/BarcodableSearchRestController.java
@@ -1,0 +1,70 @@
+package uk.ac.bbsrc.tgac.miso.webapp.controller.rest;
+
+import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.isStringEmptyOrNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import uk.ac.bbsrc.tgac.miso.core.data.Barcodable;
+import uk.ac.bbsrc.tgac.miso.core.data.impl.view.BarcodableView;
+import uk.ac.bbsrc.tgac.miso.dto.BarcodableDto;
+import uk.ac.bbsrc.tgac.miso.dto.Dtos;
+import uk.ac.bbsrc.tgac.miso.service.BarcodableViewService;
+
+@Controller
+@RequestMapping("/rest/barcodable")
+public class BarcodableSearchRestController extends RestController {
+  private static final String BASEURL = "/miso";
+
+  @Autowired
+  private BarcodableViewService barcodableViewService;
+
+  @RequestMapping(value = "/search", method = RequestMethod.GET)
+  @ResponseBody
+  public List<BarcodableDto> search(@RequestParam(name = "q", required = false) String query) {
+    if (isStringEmptyOrNull(query)) {
+      return new ArrayList<>();
+    }
+
+    return barcodableViewService.search(query).stream().map(this::toDto).collect(Collectors.toList());
+  }
+
+  private BarcodableDto toDto(BarcodableView view) {
+    BarcodableDto dto = Dtos.asDto(view);
+
+    dto.setUrl(makeUrl(makeUrlComponent(view.getId().getTargetType()), view.getId().getTargetId()));
+
+    return dto;
+  }
+
+  private String makeUrlComponent(Barcodable.EntityType entityType) {
+    switch (entityType) {
+    case SAMPLE:
+      return "sample";
+    case BOX:
+      return "box";
+    case POOL:
+      return "pool";
+    case LIBRARY:
+      return "library";
+    case DILUTION:
+      return "library";
+    case CONTAINER:
+      return "container";
+    default:
+      throw new IllegalArgumentException("Cannot make URL: unknown entity type");
+    }
+  }
+
+  private String makeUrl(String urlComponent, long id) {
+    return BASEURL + "/" + urlComponent + "/" + Long.toString(id);
+  }
+}

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/util/form/PaneAjaxTag.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/util/form/PaneAjaxTag.java
@@ -19,18 +19,15 @@ package uk.ac.bbsrc.tgac.miso.webapp.util.form;
 import org.springframework.web.servlet.tags.RequestContextAwareTag;
 
 @SuppressWarnings("serial")
-public class TileAjaxTag extends RequestContextAwareTag {
+public class PaneAjaxTag extends RequestContextAwareTag {
 
   private String target;
 
-  private String url;
-
   @Override
   protected int doStartTagInternal() throws Exception {
-
     pageContext.getOut().append(String.format(
-        "<div id='%1$s'></div><script type='text/javascript'>jQuery(document).ready(function () { Tile.createPaneAjax('%1$s', TileTarget.%2$s, '%3$s');});</script>",
-        getId(), target, url));
+        "<div id='%1$s'></div><script type='text/javascript'>jQuery(document).ready(function () { PaneTarget.%2$s.createPane('%1$s');});</script>",
+        getId(), target));
     return SKIP_BODY;
   }
 
@@ -38,15 +35,7 @@ public class TileAjaxTag extends RequestContextAwareTag {
     return target;
   }
 
-  public String getUrl() {
-    return url;
-  }
-
   public void setTarget(String target) {
     this.target = target;
-  }
-
-  public void setUrl(String url) {
-    this.url = url;
   }
 }

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/util/form/PaneTag.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/util/form/PaneTag.java
@@ -22,8 +22,8 @@ import org.springframework.web.servlet.tags.RequestContextAwareTag;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@SuppressWarnings("serial")
-public class TileTag extends RequestContextAwareTag {
+@SuppressWarnings({"serial", "squid:S1948"})
+public class PaneTag extends RequestContextAwareTag {
   private boolean alwaysShow;
 
   private Object items;
@@ -43,7 +43,7 @@ public class TileTag extends RequestContextAwareTag {
     ObjectMapper mapper = new ObjectMapper();
 
     pageContext.getOut().append(String.format(
-        "<div id='%1$s'></div><script type='text/javascript'>jQuery(document).ready(function () { Tile.createPane('%1$s', TileTarget.%2$s, %3$s);});</script>",
+        "<div id='%1$s'></div><script type='text/javascript'>jQuery(document).ready(function () { Pane.createPane('%1$s', PaneTarget.%2$s, %3$s);});</script>",
         getId(), target, mapper.writeValueAsString(items)));
     return SKIP_BODY;
   }

--- a/miso-web/src/main/webapp/WEB-INF/miso-form.tld
+++ b/miso-web/src/main/webapp/WEB-INF/miso-form.tld
@@ -300,7 +300,7 @@
 	<tag>
 		<description>Renders a tile collection with a section header.</description>
 		<name>tiles</name>
-		<tag-class>uk.ac.bbsrc.tgac.miso.webapp.util.form.TileTag</tag-class>
+		<tag-class>uk.ac.bbsrc.tgac.miso.webapp.util.form.PaneTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
 			<description>Id for the table</description>
@@ -332,7 +332,7 @@
 	<tag>
 		<description>Renders a tile collection with a section header fetched on the client.</description>
 		<name>tiles-ajax</name>
-		<tag-class>uk.ac.bbsrc.tgac.miso.webapp.util.form.TileAjaxTag</tag-class>
+		<tag-class>uk.ac.bbsrc.tgac.miso.webapp.util.form.PaneAjaxTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
 			<description>Id for the table</description>
@@ -345,12 +345,6 @@
 			<name>target</name>
 			<required>true</required>
 			<rtexprvalue>false</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description>The URL to fetch the data from</description>
-			<name>url</name>
-			<required>true</required>
-			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<dynamic-attributes>false</dynamic-attributes>
 	</tag>

--- a/miso-web/src/main/webapp/pages/mainMenu.jsp
+++ b/miso-web/src/main/webapp/pages/mainMenu.jsp
@@ -57,48 +57,6 @@
                 <div id="searchRunresult"></div>
             </div>
         </div>
-
-        <div class="dashboard_widget">
-
-            <div class="widget_title ui-corner-top">
-                Sample <input type="text" size="20" id="searchSample" name="searchSample"/>
-            </div>
-            <div class="widget ui-corner-bottom">
-                <div id="searchSampleresult">
-                </div>
-            </div>
-        </div>
-
-        <div class="dashboard_widget">
-
-            <div class="widget_title ui-corner-top">
-                Library <input type="text" size="20" id="searchLibrary" name="searchLibrary"/>
-            </div>
-            <div class="widget ui-corner-bottom">
-                <div id="searchLibraryresult">
-                </div>
-            </div>
-        </div>
-        <div class="dashboard_widget">
-
-            <div class="widget_title ui-corner-top">
-                Pool <input type="text" size="20" id="searchPool" name="searchPool"/>
-            </div>
-            <div class="widget ui-corner-bottom">
-                <div id="searchPoolresult">
-                </div>
-            </div>
-        </div>
-        <div class="dashboard_widget">
-
-            <div class="widget_title ui-corner-top">
-                Library Dilution<input type="text" size="20" id="searchLibraryDilution" name="searchLibraryDilution"/>
-            </div>
-            <div class="widget ui-corner-bottom">
-                <div id="searchLibraryDilutionresult">
-                </div>
-            </div>
-        </div>
     </div>
 </div>
 <script type="text/javascript">
@@ -110,18 +68,6 @@
     }, 300, 2);
     Utils.timer.typewatchFunc(jQuery('#searchRun'), function () {
         Search.dashboardSearch(jQuery('#searchRun'))
-    }, 300, 2);
-    Utils.timer.typewatchFunc(jQuery('#searchSample'), function () {
-        Search.dashboardSearch(jQuery('#searchSample'))
-    }, 300, 2);
-    Utils.timer.typewatchFunc(jQuery('#searchLibrary'), function () {
-        Search.dashboardSearch(jQuery('#searchLibrary'))
-    }, 300, 2);
-    Utils.timer.typewatchFunc(jQuery('#searchLibraryDilution'), function () {
-        Search.dashboardSearch(jQuery('#searchLibraryDilution'))
-    }, 300, 2);
-    Utils.timer.typewatchFunc(jQuery('#searchPool'), function () {
-      Search.dashboardSearch(jQuery('#searchPool'))
     }, 300, 2);
   });
 </script>

--- a/miso-web/src/main/webapp/pages/mainMenu.jsp
+++ b/miso-web/src/main/webapp/pages/mainMenu.jsp
@@ -35,7 +35,9 @@
                  align="right"></div>
         </div>
 
-        <miso:tiles-ajax id="tiles_instrument_status" target="instrument_status" url="/miso/rest/instrumentstatus"/>
+        <miso:tiles-ajax id="tiles_barcode" target="barcode"/>
+        <miso:tiles-ajax id="tiles_instrument_status" target="instrument_status"/>
+
         <div class="dashboard_widget">
             <div class="widget_title ui-corner-top">
                 Project <input type="text" size="20" id="searchProject" name="searchProject"/>

--- a/miso-web/src/main/webapp/scripts/list_partition.js
+++ b/miso-web/src/main/webapp/scripts/list_partition.js
@@ -81,7 +81,7 @@ ListTarget.partition = {
                   + (order.remaining == 1 ? platformType.partitionName : platformType.pluralPartitionName) + " remaining";
             });
 
-        var tileParts = [Tile.title(item.pool.name + " (" + item.pool.alias + ")", problems.length == 0 ? Tile.statusOk() : Tile
+        var tileParts = [Tile.titleAndStatus(item.pool.name + " (" + item.pool.alias + ")", problems.length == 0 ? Tile.statusOk() : Tile
             .statusBad())].concat(problems);
         tileParts.push(Tile.lines(dilutionInfo, false));
         tileParts.push(Tile.lines(orderInfo, true));

--- a/miso-web/src/main/webapp/scripts/pane.js
+++ b/miso-web/src/main/webapp/scripts/pane.js
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2012. The Genome Analysis Centre, Norwich, UK
+ * MISO project contacts: Robert Davey @ TGAC
+ * *********************************************************************
+ *
+ * This file is part of MISO.
+ *
+ * MISO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MISO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MISO.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * *********************************************************************
+ */
+
+var PaneTarget = {};
+
+var Pane = (function() {
+  var removeChildren = function(div) {
+    while (div.hasChildNodes()) {
+      div.removeChild(div.lastChild);
+    }
+  };
+
+  var initPaneDiv = function(div) {
+    div.setAttribute("class", "dashboard_widget");
+    removeChildren(div);
+
+    return div;
+  };
+
+  var createTitleDiv = function(title) {
+    var titleDiv = document.createElement("DIV");
+
+    titleDiv.setAttribute("class", "widget_title ui-corner-top");
+    titleDiv.innerText = title;
+
+    return titleDiv;
+  };
+
+  var createInputDiv = function() {
+    var input = document.createElement("INPUT");
+
+    input.setAttribute("type", "text");
+    input.setAttribute("size", "20");
+
+    return input;
+  };
+
+  var createTitleDivWithSearch = function(title) {
+    var titleDiv = createTitleDiv(title);
+    var inputDiv = createInputDiv();
+
+    titleDiv.append(inputDiv);
+
+    return {
+      title: titleDiv,
+      input: inputDiv
+    };
+  };
+
+  var createContentDiv = function() {
+    var content = document.createElement("DIV");
+
+    content.setAttribute("class", "widget ui-corner-bottom");
+
+    return content;
+  };
+
+  var assemblePane = function(paneId, titleDiv, contentDiv) {
+    var div = initPaneDiv(document.getElementById(paneId));
+
+    div.appendChild(titleDiv);
+    div.appendChild(contentDiv);
+  };
+
+  var updateDiv = function(div, inner) {
+    removeChildren(div);
+    div.appendChild(inner);
+  };
+
+  var createTilesDiv = function(items, transform) {
+    var innerContent = document.createElement("DIV");
+
+    items.map(transform).forEach(function(item) {
+      if (item) {
+        innerContent.appendChild(item);
+      }
+    });
+
+    return innerContent;
+  };
+
+  var createErrorMessage = function(xhr, textStatus, errorThrown) {
+    var errorMessage = document.createElement("P");
+
+    try {
+      var responseObj = JSON.parse(xhr.responseText);
+      if (responseObj.detail) {
+        errorMessage.innerText = responseObj.detail;
+      }
+    } catch (e) {
+      errorMessage.innerText = errorThrown;
+    }
+
+    return errorMessage
+  };
+
+  var showLoader = function(div) {
+    var loader = document.createElement("IMG");
+
+    loader.src = "/styles/images/ajax-loader.gif";
+    updateDiv(div, loader);
+  };
+
+  var showResults = function(results, transform, div) {
+    updateDiv(div, createTilesDiv(results, transform));
+  };
+
+  var showError = function(xhr, textStatus, errorThrown, div) {
+    updateDiv(div, createErrorMessage(xhr, textStatus, errorThrown));
+  };
+
+  // Make a GET request to the given url with an optional query
+  var ajaxCall = function(onLoad, onSuccess, onError, url, query) {
+    var queryUrl = encodeURI(query === undefined ? url : url + "/?" + jQuery.param({q: query}));
+
+    onLoad();
+    jQuery.ajax({
+      'dataType': 'json',
+      'type': 'GET',
+      'url': queryUrl,
+      'contentType': 'application/json; charset=utf8',
+      'success': function(entities) {
+        onSuccess(entities)
+      },
+      'error': function(xhr, textStatus, errorThrown) {
+        onError(xhr, textStatus, errorThrown);
+      }
+    });
+  };
+
+  return {
+    updateDiv: updateDiv,
+    setFocusOnReady: function(div) {
+      jQuery(document).ready(function() {
+        div.focus();
+      });
+    },
+    createSearchPane: function(paneId, title) {
+      var titleDivs = createTitleDivWithSearch(title);
+      var contentDiv = createContentDiv();
+
+      assemblePane(paneId, titleDivs.title, contentDiv);
+
+      return {
+        title: titleDivs.title,
+        input: titleDivs.input,
+        content: contentDiv
+      };
+    },
+    createPane: function(paneId, title) {
+      var titleDiv = createTitleDiv(title);
+      var contentDiv = createContentDiv();
+
+      assemblePane(paneId, titleDiv, contentDiv);
+
+      return {
+        title: titleDiv,
+        content: contentDiv
+      };
+    },
+    updateTiles: function(div, transform, url, query) {
+      ajaxCall(function() {
+        showLoader(div)
+      }, function(results) {
+        showResults(results, transform, div);
+      }, function(xhr, textStatus, errorThrown) {
+        showError(xhr, textStatus, errorThrown, div);
+      }, url, query);
+    },
+    registerSearchHandlers: function(inputTag, transform, url, outputDiv) {
+      var doSearch = function() {
+        Pane.updateTiles(outputDiv, transform, url, inputTag.value);
+      };
+
+      // Wait 100 ms before doing the search to allow the paste buffer to copy into the input field
+      inputTag.onpaste = function() {
+        setTimeout(doSearch, 100)
+      };
+      inputTag.onkeyup = function(e) {
+        if (e.which == 13) { // Enter
+          doSearch();
+        }
+      };
+    }
+  }
+})();

--- a/miso-web/src/main/webapp/scripts/pane_barcode.js
+++ b/miso-web/src/main/webapp/scripts/pane_barcode.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2012. The Genome Analysis Centre, Norwich, UK
+ * MISO project contacts: Robert Davey @ TGAC
+ * *********************************************************************
+ *
+ * This file is part of MISO.
+ *
+ * MISO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MISO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MISO.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * *********************************************************************
+ */
+
+PaneTarget.barcode = (function() {
+  var title = "Search";
+  var url = "/miso/rest/barcodable/search";
+
+  var transform = function(searchResult) {
+    return Tile.make([
+        Tile.title(searchResult.entityType),
+        Tile.lines(["Name: " + searchResult.name, "Alias: " + searchResult.alias, "Barcode: " + searchResult.identificationBarcode])],
+      function() {
+        window.location = window.location.origin + searchResult.url;
+      }
+    );
+  };
+
+  var createHelpMessage = function() {
+    var message = document.createElement("P");
+
+    message.innerText = "Search barcodable items by name, alias, or barcode.  " +
+      "Alternatively, scan a barcode to see any matching items here.";
+
+    return message;
+  };
+
+  return {
+    createPane: function(paneId) {
+      var divs = Pane.createSearchPane(paneId, title);
+
+      Pane.updateDiv(divs.content, createHelpMessage());
+      Pane.registerSearchHandlers(divs.input, transform, url, divs.content);
+      Pane.setFocusOnReady(divs.input);
+    }
+  }
+})();

--- a/miso-web/src/main/webapp/scripts/pane_instrument_status.js
+++ b/miso-web/src/main/webapp/scripts/pane_instrument_status.js
@@ -21,16 +21,18 @@
  * *********************************************************************
  */
 
-TileTarget.instrument_status = {
-  name: "Instrument Status",
-  transform: function(data) {
+PaneTarget.instrument_status = (function() {
+  var title = "Instrument Status";
+  var url = "/miso/rest/instrumentstatus";
+
+  var transform = function(data) {
     var isRunning = data.run && data.run.status === 'Running';
     return Tile.make([
-        Tile.title(data.instrument.name, isRunning ? Tile.statusBusy() : Tile.statusOk()),
-        Tile.lines(data.run ? [
-            data.run.name + ' (' + data.run.alias + ')',
-            (isRunning ? ("Busy since " + data.run.startDate) : ("Idle since " + data.run.endDate))
-                + (data.run.progress ? (" " + data.run.progress) : "")] : ["Idle"], false)], function() {
+      Tile.titleAndStatus(data.instrument.name, isRunning ? Tile.statusBusy() : Tile.statusOk()),
+      Tile.lines(data.run ? [
+        data.run.name + ' (' + data.run.alias + ')',
+        (isRunning ? ("Busy since " + data.run.startDate) : ("Idle since " + data.run.endDate))
+        + (data.run.progress ? (" " + data.run.progress) : "")] : ["Idle"], false)], function() {
       Utils.showWizardDialog(data.instrument.name, [{
         "name": "View Instrument (" + data.instrument.name + ")",
         "handler": function() {
@@ -51,7 +53,14 @@ TileTarget.instrument_status = {
           }
         };
       })));
-
     });
-  }
-};
+  };
+
+  return {
+    createPane: function(paneId) {
+      var divs = Pane.createPane(paneId, title);
+
+      Pane.updateTiles(divs.content, transform, url);
+    }
+  };
+})();

--- a/miso-web/src/main/webapp/scripts/search.js
+++ b/miso-web/src/main/webapp/scripts/search.js
@@ -49,10 +49,6 @@ var Search = Search || {
     var self = this;
     self.dashboardSearch(jQuery('#searchProject'), true);
     self.dashboardSearch(jQuery('#searchRun'), true);
-    self.dashboardSearch(jQuery('#searchLibrary'), true);
-    self.dashboardSearch(jQuery('#searchSample'), true);
-    self.dashboardSearch(jQuery('#searchLibraryDilution'), true);
-    self.dashboardSearch(jQuery('#searchPool'), true);
   },
 
   insertResult: function(id, v) {

--- a/miso-web/src/main/webapp/scripts/tile.js
+++ b/miso-web/src/main/webapp/scripts/tile.js
@@ -21,116 +21,67 @@
  * *********************************************************************
  */
 
-TileTarget = {};
-
-Tile = (function() {
-  var showPane = function(elementId, target, inner) {
-    var div = document.getElementById(elementId);
-    div.setAttribute("class", "dashboard_widget");
-    while (div.hasChildNodes()) {
-      div.removeChild(div.lastChild);
-    }
+var Tile = {
+  title: function(label) {
     var title = document.createElement("DIV");
-    title.setAttribute("class", "widget_title ui-corner-top");
-    title.innerText = target.name;
-    div.appendChild(title);
 
-    var content = document.createElement("DIV");
-    content.setAttribute("class", "widget ui-corner-bottom");
-    content.appendChild(inner);
-    div.appendChild(content);
-  };
+    title.setAttribute("class", "name");
+    title.setAttribute("style", "font-weight:bold");
+    title.innerText = label;
 
-  return {
-    title: function(label, status) {
-      var title = document.createElement("DIV");
-      title.setAttribute("class", "name");
-      title.setAttribute("style", "font-weight:bold");
-      title.innerText = label;
-      title.appendChild(status);
-      return title;
-    },
-    error: function(message) {
-      var errorP = document.createElement("P");
-      errorP.setAttribute("class", "parsley-custom-error-message");
-      errorP.innerText = "⚠ " + message;
-      return errorP;
-    },
-    lines: function(lines, special) {
-      var p = document.createElement("P");
-      if (special) {
-        p.setAttribute("style", "font-style:italic");
-      }
+    return title;
+  },
+  titleAndStatus: function(label, status) {
+    var title = this.title(label);
 
-      lines.filter(function(line) {
-        return !!line;
-      }).forEach(function(line, index, arr) {
-        p.appendChild(document.createTextNode(line));
-        if (index < arr.length - 1) {
-          p.appendChild(document.createElement("BR"));
-        }
-      });
-      return p;
-    },
-    statusOk: function() {
-      var status = document.createElement("IMG");
-      status.setAttribute("src", "/styles/images/tile-ok.svg");
-      return status;
-    },
-    statusBad: function() {
-      var status = document.createElement("IMG");
-      status.setAttribute("src", "/styles/images/tile-bad.svg");
-      return status;
-    },
-    statusBusy: function() {
-      var status = document.createElement("IMG");
-      status.setAttribute("src", "/styles/images/tile-busy.svg");
-      return status;
-    },
-    make: function(tileparts, clickHandler) {
-      var div = document.createElement("DIV");
-      div.setAttribute("class", "tile");
-      tileparts.forEach(function(part) {
-        div.appendChild(part);
-      })
-      div.onclick = clickHandler;
-      return div;
-    },
-    createPane: function(elementId, target, items) {
-      var innerContent = document.createElement("DIV");
-      items.map(target.transform).forEach(function(item) {
-        if (item) {
-          innerContent.appendChild(item);
-        }
-      });
-      showPane(elementId, target, innerContent);
-    },
-    createPaneAjax: function(elementId, target, url) {
-      var loader = document.createElement("IMG");
-      loader.src = "/styles/images/ajax-loader.gif";
-      showPane(elementId, target, loader);
+    title.append(status);
 
-      jQuery.ajax({
-        'dataType': 'json',
-        'type': 'GET',
-        'url': url,
-        'contentType': 'application/json; charset=utf8',
-        'success': function(data, textStatus, xhr) {
-          Tile.createPane(elementId, target, data);
-        },
-        'error': function(xhr, textStatus, errorThrown) {
-          var errorMessage = document.createElement("P");
-          try {
-            var responseObj = JSON.parse(xhr.responseText);
-            if (responseObj.detail) {
-              errorMessage.innerText = responseObj.detail;
-            }
-          } catch (e) {
-            errorMessage.innerText = errorThrown;
-          }
-          showPane(elementId, target, errorMessage);
-        }
-      });
+    return title;
+  },
+  error: function(message) {
+    var errorP = document.createElement("P");
+    errorP.setAttribute("class", "parsley-custom-error-message");
+    errorP.innerText = "⚠ " + message;
+    return errorP;
+  },
+  lines: function(lines, special) {
+    var p = document.createElement("P");
+    if (special) {
+      p.setAttribute("style", "font-style:italic");
     }
-  };
-})();
+
+    lines.filter(function(line) {
+      return !!line;
+    }).forEach(function(line, index, arr) {
+      p.appendChild(document.createTextNode(line));
+      if (index < arr.length - 1) {
+        p.appendChild(document.createElement("BR"));
+      }
+    });
+    return p;
+  },
+  statusOk: function() {
+    var status = document.createElement("IMG");
+    status.setAttribute("src", "/styles/images/tile-ok.svg");
+    return status;
+  },
+  statusBad: function() {
+    var status = document.createElement("IMG");
+    status.setAttribute("src", "/styles/images/tile-bad.svg");
+    return status;
+  },
+  statusBusy: function() {
+    var status = document.createElement("IMG");
+    status.setAttribute("src", "/styles/images/tile-busy.svg");
+    return status;
+  },
+  make: function(tileparts, clickHandler) {
+    var div = document.createElement("DIV");
+    div.setAttribute("class", "tile");
+    tileparts.forEach(function(part) {
+      div.appendChild(part);
+    });
+    div.onclick = clickHandler;
+    return div;
+  },
+};

--- a/miso-web/src/main/webapp/styles/style-full.css
+++ b/miso-web/src/main/webapp/styles/style-full.css
@@ -698,11 +698,11 @@ div.checklist {
     font-weight: bold;
 }
 
-/*
+
 .widget_title input[type="text"] {
- float: right;
+    margin-left: 5px;
 }
-*/
+
 .widget {
     border: 1px solid lightgray;
     padding-top: 0px;
@@ -2006,7 +2006,6 @@ button.disabled {
     opacity: 1;
 }
 
-/* Outer */
 .popup {
     width: 100%;
     height: 100%;
@@ -2017,7 +2016,6 @@ button.disabled {
     background: rgba(0, 0, 0, 0.75);
 }
 
-/* Inner */
 .popup-inner {
     max-width: 700px;
     width: 90%;
@@ -2031,7 +2029,6 @@ button.disabled {
     border-radius: 3px;
     background: #fff;
     text-align: left;
-    /*font-size: 10px;*/
 }
 
 .popup-close {
@@ -2044,11 +2041,9 @@ button.disabled {
     transition: ease 0.25s all;
     transform: translate(50%, -50%);
     border-radius: 1000px;
-    /*background:black;*/
     background: #F1EDFF;
     font-size: 20px;
     text-align: center;
-    /*color:white !important;*/
     color: black;
     text-decoration: none;
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/BarcodableViewDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/BarcodableViewDao.java
@@ -10,4 +10,10 @@ public interface BarcodableViewDao {
   List<BarcodableView> searchByBarcode(String barcode);
 
   List<BarcodableView> searchByBarcode(String barcode, Collection<Barcodable.EntityType> typeFilter);
+
+  /**
+   * Searches against all Barcodable entities using exact matches
+   * @param query name, alias, or barcode of a Barcodable entity
+   */
+  List<BarcodableView> search(String query);
 }

--- a/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateBarcodableViewDao.java
+++ b/sqlstore/src/main/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateBarcodableViewDao.java
@@ -1,6 +1,7 @@
 package uk.ac.bbsrc.tgac.miso.persistence.impl;
 
 import static java.util.stream.Collectors.toList;
+import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.isStringEmptyOrNull;
 
 import java.util.Collection;
 import java.util.List;
@@ -51,5 +52,21 @@ public class HibernateBarcodableViewDao implements BarcodableViewDao {
     Predicate<BarcodableView> matchesTypeFilter = barcodableView -> typeFilter.contains(barcodableView.getId().getTargetType());
 
     return searchByBarcode(barcode).stream().filter(matchesTypeFilter).collect(toList());
+  }
+
+  @Override
+  public List<BarcodableView> search(String query) {
+    if (isStringEmptyOrNull(query))
+      throw new IllegalArgumentException("Search is empty");
+
+    @SuppressWarnings("unchecked")
+    List<BarcodableView> results = currentSession().createCriteria(BarcodableView.class)
+        .add(Restrictions.or(
+                Restrictions.eq("identificationBarcode", query),
+                Restrictions.eq("alias", query),
+                Restrictions.eq("name", query)))
+        .list();
+
+    return results;
   }
 }


### PR DESCRIPTION
Create a search widget that takes a name, alias, or barcode.
Also remove Sample, Library, Pool, and Library Dilution widgets that are now obsolete.

`tile.js` has been separated into `pane.js` for Pane-related functions and `tile.js` for Tile-related functions.

All commits will be renamed and squashed before merging.

Screenshot: 
![image](https://user-images.githubusercontent.com/35044180/36736778-6b64372e-1ba7-11e8-81c4-948ba2630f21.png)
I picked a barcode that had more than 1 matching entry (edge case, but possible).