### PR TITLE
Don't climb hierarchy unnecessarily when making spreadsheets

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/spreadsheet/SampleSpreadSheets.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/spreadsheet/SampleSpreadSheets.java
@@ -22,6 +22,9 @@ public enum SampleSpreadSheets implements Spreadsheet<Sample> {
 
   private static <S extends DetailedSample, T> Function<Sample, T> detailedSample(Class<S> clazz, Function<S, T> function, T defaultValue) {
     return s -> {
+      if (clazz.isInstance(s)) {
+        return function.apply(clazz.cast(s));
+      }
       if (LimsUtils.isDetailedSample(s)) {
         S parent = LimsUtils.getParent(clazz, (DetailedSample) s);
         if (parent != null) {


### PR DESCRIPTION
If the object in the spreadsheet has it, use it rather than looking at its parents

JIRA: GC-1729