### PR TITLE
Change reads/cluster terminology in Illumina summary

### DIFF
--- a/runscanner-illumina/main.cpp
+++ b/runscanner-illumina/main.cpp
@@ -250,29 +250,27 @@ void add_global_chart(
   add_chart_row(values, "% > Q30", q_30.str());
   if (run_summary.begin() != run_summary.end()) {
     // Read has two different meanings in this context due to Illumina
-    // terminology
-    auto total_read_count = std::accumulate(
+    // terminology, so we're going with clusters because that's what SAV says
+
+    std::stringstream total_reads;
+    total_reads.imbue(std::locale(""));
+    total_reads << std::accumulate(
         run_summary.begin()->begin(), run_summary.begin()->end(), 0L,
         [](long acc,
            const illumina::interop::model::summary::lane_summary &summary) {
           return acc + summary.reads();
         });
+    add_chart_row(values, "Clusters", total_reads.str());
 
-    auto total_sequencing_reads = std::accumulate(
-        run.run_info().reads().begin(), run.run_info().reads().end(), 0,
-        [](int acc, const illumina::interop::model::run::read_info &read) {
-          return acc + (read.is_index() ? 0 : 1);
+    std::stringstream total_reads_pf;
+    total_reads_pf.imbue(std::locale(""));
+    total_reads_pf << std::accumulate(
+        run_summary.begin()->begin(), run_summary.begin()->end(), 0L,
+        [](long acc,
+           const illumina::interop::model::summary::lane_summary &summary) {
+          return acc + summary.reads_pf();
         });
-
-    std::stringstream total_clusters;
-    total_clusters.imbue(std::locale(""));
-    total_clusters << (total_read_count / total_sequencing_reads);
-    add_chart_row(values, "Clusters", total_clusters.str());
-
-    std::stringstream total_reads;
-    total_reads.imbue(std::locale(""));
-    total_reads << total_read_count;
-    add_chart_row(values, "Total Reads", total_reads.str());
+    add_chart_row(values, "Clusters PF", total_reads_pf.str());
   }
   result["values"] = std::move(values);
   output.append(std::move(result));


### PR DESCRIPTION
The changes read to clusters, remove this previous ill-conceived cluster number
and adds a reads/cluster PF number.