### PR TITLE
DetailedSample: fix external name lookup

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SampleStore.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/store/SampleStore.java
@@ -166,7 +166,7 @@ public interface SampleStore extends Store<Sample>, PaginatedDataSource<Sample> 
    * @return List<Sample> set of Identities belonging to a given project which have an external name that matches the input string
    * @throws IOException
    */
-  List<SampleIdentity> getIdentitiesByExactExternalNameAndProject(String externalName, Long projectId) throws IOException;
+  Collection<SampleIdentity> getIdentitiesByExactExternalNameAndProject(String externalName, Long projectId) throws IOException;
 
   /**
    * Find a ghost Tissue with Identity, Tissue Origin, Tissue Type, times received, tube number, and passage number matching the provided

--- a/miso-service/src/test/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleServiceTest.java
+++ b/miso-service/src/test/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleServiceTest.java
@@ -5,10 +5,8 @@ import static uk.ac.bbsrc.tgac.miso.core.util.LimsUtils.hasTemporaryName;
 import static uk.ac.bbsrc.tgac.miso.sqlstore.util.DbUtils.generateTemporaryName;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.hibernate.exception.ConstraintViolationException;
@@ -471,12 +469,12 @@ public class DefaultSampleServiceTest {
     Project project = new ProjectImpl();
     project.setId(1L);
     project.setReferenceGenome(humanReferenceGenome());
-    List<SampleIdentity> idList = new ArrayList<>();
+    Set<SampleIdentity> idSet = new HashSet<>();
     SampleIdentity id1 = new SampleIdentityImpl();
     id1.setExternalName("String1,String2");
     id1.setProject(project);
-    idList.add(id1);
-    Mockito.when(sut.getIdentitiesByExactExternalNameAndProject(Matchers.anyString(), Matchers.anyLong())).thenReturn(idList);
+    idSet.add(id1);
+    Mockito.when(sut.getIdentitiesByExactExternalNameAndProject(Matchers.anyString(), Matchers.anyLong())).thenReturn(idSet);
     Sample newSample = new SampleImpl();
     newSample.setProject(project);
     exception.expect(ConstraintViolationException.class);

--- a/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
+++ b/sqlstore/src/test/java/uk/ac/bbsrc/tgac/miso/persistence/impl/HibernateSampleDaoTest.java
@@ -282,14 +282,14 @@ public class HibernateSampleDaoTest extends AbstractDAOTest {
   @Test
   public void testGetIdentityByExactMatchExternalNameWithNonExactMatch() throws IOException {
     String query = "EXT1";
-    List<SampleIdentity> exactMatches = (List<SampleIdentity>) dao.getIdentitiesByExactExternalName(query);
+    Collection<SampleIdentity> exactMatches = dao.getIdentitiesByExactExternalName(query);
     assertTrue(exactMatches.isEmpty());
   }
 
   @Test
   public void testGetidentityByExactMatchExternalNameWithExactMatch() throws IOException {
     String query = "EXT15";
-    List<SampleIdentity> exactMatches = (List<SampleIdentity>) dao.getIdentitiesByExactExternalName(query);
+    Collection<SampleIdentity> exactMatches = dao.getIdentitiesByExactExternalName(query);
     assertFalse(exactMatches.isEmpty());
   }
 


### PR DESCRIPTION
GC-1792
deduplicates identities found when the target external name has two comma-separated parts.