### PR TITLE
GLT-2324 allow variable number of decimal places for QCs

### DIFF
--- a/miso-web/src/main/webapp/scripts/hot_qc.js
+++ b/miso-web/src/main/webapp/scripts/hot_qc.js
@@ -65,7 +65,8 @@ HotTarget.qc = function(qcTarget) {
       }, {
         header: 'Result',
         data: 'results',
-        type: 'numeric',
+        type: 'text',
+        validator: HotUtils.validator.requiredNumber,
         include: true,
         depends: 'typeName',
         update: function(qc, flat, flatProperty, value, setReadOnly, setOptions, setData) {
@@ -85,8 +86,7 @@ HotTarget.qc = function(qcTarget) {
             setData(false);
           } else {
             setOptions({
-              type: 'numeric',
-              format: '0.' + '0'.repeat(qcType.precisionAfterDecimal)
+              type: 'text',
             });
             setData(0);
           }


### PR DESCRIPTION
This brings the QC number handling in line with how we do other floats (see `makeColumnForFloat`). HoT has an inherent limitation where if the column is of type `numeric` then you have to specify the format of the number, which is rigidly applied, ie. if format is `0.00` then `1 -> 1.00` and `1.003 -> 1.00`. This solves it by having it be displayed as text (so however many decimal places are entered get preserved) but validated as a number.