### PR TITLE
Allow non-unique indices within a family

### DIFF
--- a/docs/_posts/2017-12-07-admin-guide.md
+++ b/docs/_posts/2017-12-07-admin-guide.md
@@ -18,15 +18,18 @@ source code for the exact methods of <a href="https://github.com/TGAC/miso-lims/
 
 ## Indices (also known as Barcodes, Molecular IDs, Tag Barcodes)
 
-An `Index` has a name, a sequence, a position (1 or 2) and is a member of an `Index Family`. An `Index Family` has a name and is associated with a sequencing platform, and can be archived to hide its members when creating new libraries.
+An `Index` has a name, a sequence, a position (1 or 2) and is a member of an `Index Family`. An `Index Family`
+has a name and is associated with a sequencing platform, and can be archived to hide its members when creating new
+libraries. If a family is unique dual-indexed, that means that position 1 and 2 indices with the same name are always
+paired together.
 ```
-addIndexFamily(name, platformType, archived)
+addIndexFamily(name, platformType, archived, uniqueDualIndex)
 addIndex(familyName, name, sequence, position)
 ```
 
 For example, to add a set of Illumina indices named "Custom Indices A," with "Index 1" ACACACAC and "Index 2" GTGTGTGT:
 ```
-CALL addIndexFamily('Custom Indices A', 'ILLUMINA', 0);
+CALL addIndexFamily('Custom Indices A', 'ILLUMINA', 0, 0);
 CALL addIndex('Custom Indices A', 'Index 1', 'ACACACAC', 1);
 CALL addIndex('Custom Indices A', 'Index 2', 'GTGTGTGT', 1);
 ```

--- a/sqlstore/src/main/resources/db/migration/V8501__nonUniqueIndices.sql
+++ b/sqlstore/src/main/resources/db/migration/V8501__nonUniqueIndices.sql
@@ -1,0 +1,18 @@
+--StartNoTest
+
+ALTER TABLE Indices DROP FOREIGN KEY Indices_ibfk_1;
+
+set @var=if((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
+            CONSTRAINT_SCHEMA = DATABASE() AND
+            TABLE_NAME        = 'Indices' AND
+            CONSTRAINT_NAME   = 'uk_index' AND
+            CONSTRAINT_TYPE   = 'UNIQUE') = true,'ALTER TABLE Indices
+            DROP INDEX uk_index','select 1');
+
+prepare stmt from @var;
+execute stmt;
+deallocate prepare stmt;
+
+ALTER TABLE Indices ADD CONSTRAINT `Indices_ibfk_1` FOREIGN KEY (`indexFamilyId`) REFERENCES `IndexFamily` (`indexFamilyId`);
+
+-- EndNoTest

--- a/sqlstore/src/main/resources/db/migration_beforeMigrate/05_add_index.sql
+++ b/sqlstore/src/main/resources/db/migration_beforeMigrate/05_add_index.sql
@@ -6,12 +6,13 @@ DROP PROCEDURE IF EXISTS addIndexFamily//
 CREATE PROCEDURE addIndexFamily(
   iName varchar(255),
   iPlatformType varchar(20),
-  iArchived tinyint(1)
+  iArchived tinyint(1),
+  iUniqueDualIndex tinyint(1)
 ) BEGIN
   IF NOT EXISTS (SELECT 1 FROM IndexFamily WHERE name = iName)
   THEN
-    INSERT INTO IndexFamily(name, platformType, archived)
-    VALUES (iName, UPPER(iPlatformType), iArchived);
+    INSERT INTO IndexFamily(name, platformType, archived, uniqueDualIndex)
+    VALUES (iName, UPPER(iPlatformType), iArchived, iUniqueDualIndex);
   END IF;
 END//
 
@@ -30,14 +31,8 @@ CREATE PROCEDURE addIndex(
     SET errorMessage = CONCAT('IndexFamily ''', iFamilyName, ''' not found.');
     SIGNAL SQLSTATE '45000' SET message_text = errorMessage;
   ELSE
-    IF EXISTS (SELECT 1 FROM Indices WHERE indexFamilyId = famId AND sequence = iSequence AND position = iPosition)
-    THEN
-      SET errorMessage = CONCAT('An index with sequence ''', iSequence, ''' at position ', iPosition, ' already exists for indexFamily ', iFamilyName);
-      SIGNAL SQLSTATE '45000' SET message_text = errorMessage; 
-    ELSE
-      INSERT INTO Indices(name, sequence, position, indexFamilyId)
-      VALUES (iName, iSequence, iPosition, famId);
-    END IF;
+    INSERT INTO Indices(name, sequence, position, indexFamilyId)
+    VALUES (iName, iSequence, iPosition, famId);
   END IF;
   
 END//


### PR DESCRIPTION
The existing unique constraint doesn't always make sense with unique dual indices. Removal is necessary to add the indices requested in GC-2001. The migration checks for existence of the unique key before deleting it because I intend to run the SQL in production before it's released, so it needs to be idempotent.