### PR TITLE
Allow library creation for all platforms

### DIFF
--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/BulkLibraryIT.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/BulkLibraryIT.java
@@ -140,7 +140,7 @@ public class BulkLibraryIT extends AbstractIT {
     assertTrue(codes.contains("MR"));
 
     Set<String> platforms = table.getDropdownOptions(LibColumns.PLATFORM, 0);
-    assertEquals(2, platforms.size());
+    assertEquals(6, platforms.size()); // All members of PlatformType
     assertTrue(platforms.contains("Illumina"));
     assertTrue(platforms.contains("PacBio"));
 

--- a/miso-web/src/main/webapp/scripts/hot_library.js
+++ b/miso-web/src/main/webapp/scripts/hot_library.js
@@ -445,11 +445,7 @@ HotTarget.library = (function() {
             type: 'dropdown',
             readOnly: !create,
             trimDropdown: false,
-            source: Constants.platformTypes.filter(function(pt) {
-              return pt.active || data.reduce(function(acc, lib) {
-                return acc || pt.key == lib.platformType;
-              }, false);
-            }).map(function(pt) {
+            source: Constants.platformTypes.map(function(pt) {
               return pt.key;
             }),
             validator: HotUtils.validator.requiredAutocomplete,


### PR DESCRIPTION
#1409 (looks like I never merged this, oops)
Solves the problem where new users get annoyed because they can't create any libraries if they haven't added any sequencers. Also helpful for users who may be preparing libraries and sending them elsewhere for sequencing.