### PR TITLE
Updated to latest Spring patch versions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -158,23 +158,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-jdbc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.integration</groupId>
-      <artifactId>spring-integration-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.ldap</groupId>
-      <artifactId>spring-ldap-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,9 +154,9 @@
   </distributionManagement>
   <properties>
     <skipUTs>${skipTests}</skipUTs>
-    <spring-version>4.3.6.RELEASE</spring-version>
-    <spring-security-version>4.2.1.RELEASE</spring-security-version>
-    <spring-integration-version>4.3.6.RELEASE</spring-integration-version>
+    <spring-version>4.3.18.RELEASE</spring-version>
+    <spring-security-version>4.2.7.RELEASE</spring-security-version>
+    <spring-integration-version>4.3.17.RELEASE</spring-integration-version>
     <hibernate.version>4.2.21.Final</hibernate.version>
     <joda-time.version>2.9</joda-time.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -579,11 +579,6 @@
         <version>${spring-version}</version>
       </dependency>
       <dependency>
-        <groupId>org.springframework.batch</groupId>
-        <artifactId>spring-batch-core</artifactId>
-        <version>2.1.2.RELEASE</version>
-      </dependency>
-      <dependency>
         <groupId>org.springframework.integration</groupId>
         <artifactId>spring-integration-core</artifactId>
         <version>${spring-integration-version}</version>
@@ -609,9 +604,12 @@
         <version>${spring-integration-version}</version>
       </dependency>
       <dependency>
-        <groupId>org.springframework.ldap</groupId>
-        <artifactId>spring-ldap-core</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <!-- This ensures that Spring Security's transitive dependencies use the same Spring version -->
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
@@ -637,17 +635,6 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-web</artifactId>
         <version>${spring-security-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security.oauth</groupId>
-        <artifactId>spring-security-oauth</artifactId>
-        <version>1.0.0.RELEASE</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>commons-codec</artifactId>
-            <groupId>commons-codec</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>uk.ac.bbsrc.tgac.miso</groupId>


### PR DESCRIPTION
This was an attempt to resolve an exception I keep seeing in my logs: `java.lang.NoSuchMethodError: org.springframework.context.support.AbstractApplicationContext.clearResourceCaches()V`. I'm still seeing the exception, but updated dependencies usually aren't a bad thing.