### PR TITLE
GLT-2464: fixed missing Libraries in Pinery

### DIFF
--- a/pinery-miso/src/main/resources/ca/on/oicr/pinery/lims/miso/queryAllSamples.sql
+++ b/pinery-miso/src/main/resources/ca/on/oicr/pinery/lims/miso/queryAllSamples.sql
@@ -136,7 +136,7 @@ SELECT l.alias NAME
         ,NULL tissueType 
         ,LEFT(l.alias, LOCATE('_', l.alias)-1) project 
         ,lai.archived archived 
-        ,l.creationDate created 
+        ,l.created created 
         ,l.creator createdById 
         ,l.lastModified modified 
         ,l.lastModifier modifiedById 


### PR DESCRIPTION
This change should have been made either way, but I have no idea why it was causing the libraries to not show up in the flatfiles "all samples" endpoint.