### PR TITLE
Fixed Hibernate warnings

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Experiment.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Experiment.java
@@ -105,6 +105,34 @@ public class Experiment implements SecurableByProfile, Comparable<Experiment>, N
     public void setRun(Run run) {
       this.run = run;
     }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((experiment == null) ? 0 : experiment.hashCode());
+      result = prime * result + ((partition == null) ? 0 : partition.hashCode());
+      result = prime * result + ((run == null) ? 0 : run.hashCode());
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null) return false;
+      if (getClass() != obj.getClass()) return false;
+      RunPartition other = (RunPartition) obj;
+      if (experiment == null) {
+        if (other.experiment != null) return false;
+      } else if (!experiment.equals(other.experiment)) return false;
+      if (partition == null) {
+        if (other.partition != null) return false;
+      } else if (!partition.equals(other.partition)) return false;
+      if (run == null) {
+        if (other.run != null) return false;
+      } else if (!run.equals(other.run)) return false;
+      return true;
+    }
   }
 
   /** Field PREFIX */

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Partition.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/Partition.java
@@ -87,4 +87,11 @@ public interface Partition extends Identifiable, Comparable<Partition>, Serializ
    *          pool.
    */
   public void setPool(Pool pool);
+
+  @Override
+  int hashCode();
+
+  @Override
+  boolean equals(Object obj);
+
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/DilutionBoxableView.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/DilutionBoxableView.java
@@ -2,10 +2,7 @@ package uk.ac.bbsrc.tgac.miso.core.data.impl.view;
 
 import javax.persistence.Entity;
 
-import org.hibernate.annotations.Immutable;
-
 @Entity
-@Immutable
 public class DilutionBoxableView extends BoxableView {
 
   private static final long serialVersionUID = 1L;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/LibraryBoxableView.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/LibraryBoxableView.java
@@ -2,10 +2,7 @@ package uk.ac.bbsrc.tgac.miso.core.data.impl.view;
 
 import javax.persistence.Entity;
 
-import org.hibernate.annotations.Immutable;
-
 @Entity
-@Immutable
 public class LibraryBoxableView extends BoxableView {
 
   private static final long serialVersionUID = 1L;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/PoolBoxableView.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/PoolBoxableView.java
@@ -2,10 +2,7 @@ package uk.ac.bbsrc.tgac.miso.core.data.impl.view;
 
 import javax.persistence.Entity;
 
-import org.hibernate.annotations.Immutable;
-
 @Entity
-@Immutable
 public class PoolBoxableView extends BoxableView {
 
   private static final long serialVersionUID = 1L;

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/SampleBoxableView.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/view/SampleBoxableView.java
@@ -2,10 +2,7 @@ package uk.ac.bbsrc.tgac.miso.core.data.impl.view;
 
 import javax.persistence.Entity;
 
-import org.hibernate.annotations.Immutable;
-
 @Entity
-@Immutable
 public class SampleBoxableView extends BoxableView {
 
   private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Fixes these:

```
 WARN [localhost-startStop-1] - HHH000124: @Immutable used on a non root entity: ignored for uk.ac.bbsrc.tgac.miso.core.data.impl.view.DilutionBoxableView
 WARN [localhost-startStop-1] - HHH000124: @Immutable used on a non root entity: ignored for uk.ac.bbsrc.tgac.miso.core.data.impl.view.LibraryBoxableView
 WARN [localhost-startStop-1] - HHH000124: @Immutable used on a non root entity: ignored for uk.ac.bbsrc.tgac.miso.core.data.impl.view.PoolBoxableView
 WARN [localhost-startStop-1] - HHH000124: @Immutable used on a non root entity: ignored for uk.ac.bbsrc.tgac.miso.core.data.impl.view.SampleBoxableView
 WARN [localhost-startStop-1] - HHH000038: Composite-id class does not override equals(): uk.ac.bbsrc.tgac.miso.core.data.Experiment$RunPartition
 WARN [localhost-startStop-1] - HHH000039: Composite-id class does not override hashCode(): uk.ac.bbsrc.tgac.miso.core.data.Experiment$RunPartition
```