### PR TITLE
Fix travis ITs

### DIFF
--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/AbstractIT.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/AbstractIT.java
@@ -1,7 +1,6 @@
 package uk.ac.bbsrc.tgac.miso.webapp.integrationtest;
 
 import static org.junit.Assert.assertNotNull;
-import io.github.bonigarcia.wdm.ChromeDriverManager;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +16,6 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -27,6 +25,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.HomePage;
 import uk.ac.bbsrc.tgac.miso.webapp.integrationtest.page.LoginPage;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/it-context.xml")
@@ -48,19 +48,16 @@ public abstract class AbstractIT {
 
   @BeforeClass
   public static final void setupAbstractClass() {
-    ChromeDriverManager.getInstance().setup();
+    WebDriverManager.chromedriver().setup();
   }
 
   @Before
   public final void setupAbstractTest() {
     ChromeOptions opts = new ChromeOptions();
+    opts.setHeadless(true);
     // large width is important so that all columns of handsontables get rendered
-    opts.addArguments("--headless", "--disable-gpu", "--window-size=4000x1440");
-
-    DesiredCapabilities caps = new DesiredCapabilities();
-    caps.setCapability(ChromeOptions.CAPABILITY, opts);
-
-    driver = new ChromeDriver(caps);
+    opts.addArguments("--disable-gpu", "--window-size=4000x1440");
+    driver = new ChromeDriver(opts);
 
     // don't allow page load or script execution to take longer than 10 seconds
     driver.manage().timeouts().pageLoadTimeout(15, TimeUnit.SECONDS);

--- a/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/WorksetPage.java
+++ b/miso-web/src/it/java/uk/ac/bbsrc/tgac/miso/webapp/integrationtest/page/WorksetPage.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -94,7 +95,11 @@ public class WorksetPage extends FormPage<WorksetPage.Field> {
       waitUntil(ExpectedConditions.or(ExpectedConditions.stalenessOf(html), ExpectedConditions.stalenessOf(errorBox)));
     } else {
       saveButton.click();
-      waitUntil(ExpectedConditions.or(ExpectedConditions.stalenessOf(html), ExpectedConditions.visibilityOf(errorBox)));
+      try {
+        waitUntil(ExpectedConditions.or(ExpectedConditions.stalenessOf(html), ExpectedConditions.visibilityOf(errorBox)));
+      } catch (StaleElementReferenceException e) {
+        waitUntil(ExpectedConditions.stalenessOf(html));
+      }
     }
     if (ExpectedConditions.stalenessOf(html).apply(getDriver())) {
       waitForPageRefresh(html);


### PR DESCRIPTION
Seems to prevent the `StaleElementReferenceException` on `WorksetPageIT#testCreate`. I also only saw a single test (`ProjectPageIT#testConfirmTablesAllVisibleWithoutErrors`) time out in 5 test runs on Travis, but that could just be random, since these changes really shouldn't help with the timeouts.