### PR TITLE
[GLT-2414] Add line graph with custom x axis floor

### DIFF
--- a/miso-web/src/main/webapp/scripts/run_graph.js
+++ b/miso-web/src/main/webapp/scripts/run_graph.js
@@ -131,7 +131,14 @@ var RunGraph = (function() {
       };
     });
   };
+
+  // Line graph starting at 0 on x axis
   var lineGraph = function(typeName, title, yLabel) {
+    return lineGraph_CustomX(typeName, title, yLabel, 0)
+  }
+
+  // Line graph with a custom starting point on the x axis
+  var lineGraph_CustomX = function(typeName, title, yLabel, xStart) {
     return function(metrics, width, renamePartitions) {
       return metrics.filter(function(metric) {
         return metric.type == typeName;
@@ -158,7 +165,7 @@ var RunGraph = (function() {
               },
               xAxis: {
                 allowDecimals: false,
-                floor: 0,
+                floor: xStart,
               },
               yAxis: {
                 floor: 0,
@@ -329,8 +336,7 @@ var RunGraph = (function() {
         lineGraph('illumina-called-intensity-by-cycle', 'Called Intensity', 'Average Intensity per Cycle'),
         lineGraph('illumina-base-percent-by-cycle', 'Base %', 'Percentage'),
         illuminaPerLanePlot('illumina-cluster-density-by-lane', 'Cluster Density', 'Density (K/mm²)'),
-        lineGraph('illumina-clusters-by-lane', 'Lane', 'Clusters'),
-        barGraph('illumina-yield-by-read', 'Yields', 'Yield (gb)')],
+        lineGraph_CustomX('illumina-clusters-by-lane', 'Lane', 'Clusters', 1), barGraph('illumina-yield-by-read', 'Yields', 'Yield (gb)')],
     // Takes a list of metrics and renders them to #metricsdiv
     renderMetrics: function(metrics, partitionNames) {
       var container = document.getElementById('metricsdiv');


### PR DESCRIPTION
Add lineGraph_CustomX() which draws a line graph with a custom starting
point ("floor") on x axis.
Convert lineGraph() to calling lineGraph_CustomX() with '0' as floor.
Changes 'Lane' graph to drawing lineGraph_CustomX with floor of '1', as
per ticket.

New function allows changing floor of any other line graphs in the future.