### PR TITLE
Return empty set of Unreadables

### DIFF
--- a/runscanner/src/main/java/uk/ac/bbsrc/tgac/miso/runscanner/Scheduler.java
+++ b/runscanner/src/main/java/uk/ac/bbsrc/tgac/miso/runscanner/Scheduler.java
@@ -275,7 +275,15 @@ public class Scheduler {
   }
 
   public Set<File> getUnreadableDirectories() {
-    return unreadableDirectories.getRejects();
+    Set<File> unreadables;
+
+    if (getScanLastStarted() != null) {
+      unreadables = unreadableDirectories.getRejects();
+    } else {
+      unreadables = Collections.emptySet();
+    }
+
+    return unreadables;
   }
 
   public boolean isConfigurationGood() {


### PR DESCRIPTION
If scanning has not yet started, return an empty set when getting list
of Unreadable runs. This prevents a NullPointerException when accessing
the Unreadable page on the web interface before scanning has started.