### PR TITLE
Fix unique dual index paste

### DIFF
--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -1890,7 +1890,7 @@ public class Dtos {
     dto.setName(from.getName());
     dto.setArchived(from.getArchived());
     if (includeChildren) {
-      dto.setIndices(from.getIndices().stream().map(x -> asDto(x, false)).collect(Collectors.toList()));
+      dto.setIndices(from.getIndices().stream().map(x -> asDto(x, true)).collect(Collectors.toList()));
     }
     dto.setMaximumNumber(from.getMaximumNumber());
     dto.setPlatformType(from.getPlatformType() == null ? null : from.getPlatformType().name());

--- a/miso-web/src/main/webapp/scripts/hot_library.js
+++ b/miso-web/src/main/webapp/scripts/hot_library.js
@@ -87,7 +87,7 @@ HotTarget.library = (function() {
             var indexName = (Utils.array.maybeGetProperty(indexFamily, 'indices') || []).filter(function(index) {
               return index.position == n - 1;
             }).find(function(index) {
-              return index.label == value
+              return index.label == value || index.sequence == value;
             }).name;
             if (indexName) {
               var dualIndex = (Utils.array.maybeGetProperty(indexFamily, 'indices') || []).filter(function(index) {


### PR DESCRIPTION
GLT-2548

Fixes issue where when selecting indices for an index family with `uniqueDualIndex == true`, an index sequence would get pasted into Index 1 but the function that finds the corresponding index 1 and index 2 would error before validating the index 1 value and before finding the correct index 2.