### PR TITLE
fixup set required attr (discards) on ghost slides

### DIFF
--- a/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
+++ b/miso-service/src/main/java/uk/ac/bbsrc/tgac/miso/service/impl/DefaultSampleService.java
@@ -509,6 +509,7 @@ public class DefaultSampleService implements SampleService, AuthorizedPaginatedD
       Integer slides = parentSlides.getSlides() == null ? 0 : parentSlides.getSlides();
       slides += ((SampleLCMTube) child).getSlidesConsumed();
       parentSlides.setSlides(slides);
+      parentSlides.setDiscards(0);
       if (parentSlides.getId() != SampleImpl.UNSAVED_ID) {
         update(parentSlides);
       }

--- a/sqlstore/src/main/resources/db/migration/V8242__discards_non-null.sql
+++ b/sqlstore/src/main/resources/db/migration/V8242__discards_non-null.sql
@@ -1,0 +1,2 @@
+UPDATE SampleSlide SET discards = 0 WHERE discards IS NULL;
+ALTER TABLE SampleSlide CHANGE COLUMN discards discards INT(11) NOT NULL DEFAULT 0;


### PR DESCRIPTION
Discards is a required field when saving via the UI, but is not currently set when creating ghost slides. This PR sets discards to zero on ghost slides so that users don't encounter an error when they try to save the ghost slide via the UI.