### PR TITLE
Fix Cluster PF chart x-axis

### DIFF
--- a/miso-web/src/main/webapp/scripts/run_graph.js
+++ b/miso-web/src/main/webapp/scripts/run_graph.js
@@ -165,7 +165,7 @@ var RunGraph = (function() {
               },
               xAxis: {
                 allowDecimals: false,
-                floor: xStart,
+                floor: 0,
               },
               yAxis: {
                 floor: 0,
@@ -185,7 +185,8 @@ var RunGraph = (function() {
                   animation: false,
                   tooltip: {
                     valueDecimals: 2
-                  }
+                  },
+                  pointStart: xStart
                 }
               },
               series: metric.series


### PR DESCRIPTION
Fixes bug where the "Lane" chart mislabelled the lanes (off-by-one, so lane 2 data was being displayed as lane 1) and didn't display data for lane 1.
GLT-2572