### PR TITLE
GLT-2562: add properties for default LCM Tube group ID/desc

### DIFF
--- a/miso-web/.settings/org.eclipse.wst.jsdt.core.prefs
+++ b/miso-web/.settings/org.eclipse.wst.jsdt.core.prefs
@@ -16,7 +16,7 @@ org.eclipse.wst.jsdt.core.formatter.alignment_for_arguments_in_qualified_allocat
 org.eclipse.wst.jsdt.core.formatter.alignment_for_assignment=0
 org.eclipse.wst.jsdt.core.formatter.alignment_for_binary_expression=16
 org.eclipse.wst.jsdt.core.formatter.alignment_for_compact_if=16
-org.eclipse.wst.jsdt.core.formatter.alignment_for_conditional_expression=80
+org.eclipse.wst.jsdt.core.formatter.alignment_for_conditional_expression=16
 org.eclipse.wst.jsdt.core.formatter.alignment_for_enum_constants=0
 org.eclipse.wst.jsdt.core.formatter.alignment_for_expressions_in_array_initializer=16
 org.eclipse.wst.jsdt.core.formatter.alignment_for_multiple_fields=16

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
@@ -264,6 +264,10 @@ public class EditSampleController {
   private Boolean detailedSample;
   @Value("${miso.defaults.sample.bulk.scientificname:}")
   private String defaultSciName;
+  @Value("${miso.defaults.sample.lcmtube.groupid:}")
+  private String defaultLcmTubeGroupId;
+  @Value("${miso.defaults.sample.lcmtube.groupdescription:}")
+  private String defaultLcmTubeGroupDesc;
 
   private Boolean isDetailedSampleEnabled() {
     return detailedSample;
@@ -281,6 +285,8 @@ public class EditSampleController {
     private static final String HAS_PROJECT = "hasProject";
     private static final String DNASE_TREATABLE = "dnaseTreatable";
     private static final String DEFAULT_SCI_NAME = "defaultSciName";
+    private static final String DEFAULT_LCM_TUBE_GROUP_ID = "defaultLcmTubeGroupId";
+    private static final String DEFAULT_LCM_TUBE_GROUP_DESC = "defaultLcmTubeGroupDescription";
     private static final String SOURCE_SAMPLE_CLASS = "sourceSampleClass";
     private static final String TARGET_SAMPLE_CLASS = "targetSampleClass";
     private static final String BOX = "box";
@@ -993,6 +999,8 @@ public class EditSampleController {
       config.putPOJO(Config.TARGET_SAMPLE_CLASS, Dtos.asDto(targetSampleClass));
       config.putPOJO(Config.SOURCE_SAMPLE_CLASS, Dtos.asDto(sourceSampleClass));
       config.putPOJO(Config.BOX, newBox);
+      config.put(Config.DEFAULT_LCM_TUBE_GROUP_ID, defaultLcmTubeGroupId);
+      config.put(Config.DEFAULT_LCM_TUBE_GROUP_DESC, defaultLcmTubeGroupDesc);
     }
   };
 
@@ -1019,6 +1027,8 @@ public class EditSampleController {
       }
       config.put(Config.CREATE, true);
       config.put(Config.HAS_PROJECT, project != null);
+      config.put(Config.DEFAULT_LCM_TUBE_GROUP_ID, defaultLcmTubeGroupId);
+      config.put(Config.DEFAULT_LCM_TUBE_GROUP_DESC, defaultLcmTubeGroupDesc);
       if (project == null) {
         projectService.listAllProjects().stream().map(Dtos::asDto).forEach(config.putArray("projects")::addPOJO);
         config.put(Config.DEFAULT_SCI_NAME, defaultSciName);

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/controller/EditSampleController.java
@@ -947,7 +947,7 @@ public class EditSampleController {
       config.put(Config.PROPAGATE, false);
       config.put(Config.EDIT, true);
     }
-  };
+  }
 
   private final class BulkPropagateSampleBackend extends BulkPropagateTableBackend<Sample, SampleDto> {
     private SampleClass sourceSampleClass;
@@ -1002,7 +1002,7 @@ public class EditSampleController {
       config.put(Config.DEFAULT_LCM_TUBE_GROUP_ID, defaultLcmTubeGroupId);
       config.put(Config.DEFAULT_LCM_TUBE_GROUP_DESC, defaultLcmTubeGroupDesc);
     }
-  };
+  }
 
   private final class BulkCreateSampleBackend extends BulkCreateTableBackend<SampleDto> {
     private final SampleClass targetSampleClass;
@@ -1042,6 +1042,6 @@ public class EditSampleController {
       }
       config.putPOJO(Config.BOX, box);
     }
-  };
+  }
 
 }

--- a/miso-web/src/main/webapp/scripts/hot.js
+++ b/miso-web/src/main/webapp/scripts/hot.js
@@ -941,7 +941,7 @@ var HotUtils = {
     }
   },
 
-  makeColumnForText: function(headerName, include, property, baseobj) {
+  makeColumnForText: function(headerName, include, property, baseobj, defaultValue) {
     baseobj.header = headerName;
     baseobj.data = property;
     baseobj.type = 'text';
@@ -949,6 +949,9 @@ var HotUtils = {
     if (!baseobj.hasOwnProperty('unpack')) {
       baseobj.unpack = function(obj, flat, setCellMeta) {
         flat[property] = Utils.valOrNull(obj[property]);
+        if (flat[property] == null) {
+          flat[property] = Utils.valOrNull(defaultValue);
+        }
       };
     }
     baseobj.pack = function(obj, flat, errorHandler) {

--- a/miso-web/src/main/webapp/scripts/hot_sample.js
+++ b/miso-web/src/main/webapp/scripts/hot_sample.js
@@ -530,8 +530,9 @@ HotTarget.sample = (function() {
           },
           HotUtils.makeColumnForText('Group ID', Constants.isDetailedSample && !config.isLibraryReceipt, 'groupId', {
             validator: HotUtils.validator.optionalTextAlphanumeric
-          }),
-          HotUtils.makeColumnForText('Group Desc.', Constants.isDetailedSample && !config.isLibraryReceipt, 'groupDescription', {}),
+          }, config.targetSampleClass.alias === 'LCM Tube' && !config.edit ? config.defaultLcmTubeGroupId : null),
+          HotUtils.makeColumnForText('Group Desc.', Constants.isDetailedSample && !config.isLibraryReceipt, 'groupDescription', {},
+              config.targetSampleClass.alias === 'LCM Tube' && !config.edit ? config.defaultLcmTubeGroupDescription : null),
           {
             header: 'Date of Creation',
             data: 'creationDate',

--- a/miso-web/src/main/webapp/scripts/hot_sample.js
+++ b/miso-web/src/main/webapp/scripts/hot_sample.js
@@ -530,9 +530,11 @@ HotTarget.sample = (function() {
           },
           HotUtils.makeColumnForText('Group ID', Constants.isDetailedSample && !config.isLibraryReceipt, 'groupId', {
             validator: HotUtils.validator.optionalTextAlphanumeric
-          }, config.targetSampleClass.alias === 'LCM Tube' && !config.edit ? config.defaultLcmTubeGroupId : null),
+          }, config.targetSampleClass && config.targetSampleClass.alias === 'LCM Tube' && !config.edit ? config.defaultLcmTubeGroupId
+              : null),
           HotUtils.makeColumnForText('Group Desc.', Constants.isDetailedSample && !config.isLibraryReceipt, 'groupDescription', {},
-              config.targetSampleClass.alias === 'LCM Tube' && !config.edit ? config.defaultLcmTubeGroupDescription : null),
+              config.targetSampleClass && config.targetSampleClass.alias === 'LCM Tube' && !config.edit
+                  ? config.defaultLcmTubeGroupDescription : null),
           {
             header: 'Date of Creation',
             data: 'creationDate',


### PR DESCRIPTION
Intentionally left out of the default `miso.properties` and not documented because it is a strangely specific setting that nobody outside of OICR would ever care about