### PR TITLE
GLT-2578: allow all users to create attachment categories

### DIFF
--- a/miso-web/src/main/webapp/scripts/list_attachmentcategory.js
+++ b/miso-web/src/main/webapp/scripts/list_attachmentcategory.js
@@ -31,7 +31,7 @@ ListTarget.attachmentcategory = {
     return HotTarget.attachmentcategory.getBulkActions(config);
   },
   createStaticActions: function(config, projectId) {
-    return config.isAdmin ? [{
+    return [{
       "name": "Add",
       "handler": function() {
 
@@ -51,7 +51,7 @@ ListTarget.attachmentcategory = {
           });
         });
       }
-    }] : [];
+    }];
   },
   createColumns: function(config, projectId) {
     return [{


### PR DESCRIPTION
Service layer never had a check for admin, so this was probably just a copy/paste error on my part