### PR TITLE
limit height of bulk selection controls on box page

### DIFF
--- a/miso-web/src/main/webapp/pages/editBox.jsp
+++ b/miso-web/src/main/webapp/pages/editBox.jsp
@@ -244,7 +244,7 @@
     </table>
     <p class="warning" id="warningMessages"></p>
   </div>
-  <div id="bulkPositionControls" style="float:left;padding:20px;">
+  <div id="bulkPositionControls" style="float:left; padding:10px; margin:20px; border:1px solid darkgrey; max-height:340px; overflow-y:scroll;">
     <button class="ui-state-default" onclick="Box.ui.bulkRemoveItems();">Remove Selected</button>
     <button class="ui-state-default" onclick="Box.ui.bulkDiscardItems();">Discard Selected</button>
     <br/><br/>


### PR DESCRIPTION
It's sized to match the height of an 8x12 box, so it looks nice beside that, and is of reasonable size next to other boxes. Did not make it dynamic, as it would be annoyingly small next to a box much shorter than 8 rows, and boxes don't get much larger.