### PR TITLE
fix Sonar running on push builds

### DIFF
--- a/travis_jobs.sh
+++ b/travis_jobs.sh
@@ -2,7 +2,7 @@
 set -ev
 
 if [ "$JOB" = "SONAR_AND_UNIT_TESTS" ]; then
-    if [[ ${TRAVIS_PULL_REQUEST_SLUG} == ${TRAVIS_REPO_SLUG} ]] ; then 
+    if [[ ${TRAVIS_PULL_REQUEST} == "false" ]] || [[ ${TRAVIS_PULL_REQUEST_SLUG} == ${TRAVIS_REPO_SLUG} ]] ; then 
         # Sonar
         mvn org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar
     else 


### PR DESCRIPTION
Since this worked before, I'm guessing Travis used to set `TRAVIS_PULL_REQUEST_SLUG` even for non-pull-request builds, but it doesn't any more