### PR TITLE
Handle null Volume and Concentration units

### DIFF
--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractLibrary.java
@@ -675,8 +675,8 @@ public abstract class AbstractLibrary extends AbstractBoxable implements Library
 
   @Override
   public String getBarcodeSizeInfo() {
-    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits().getUnits(),
-        getConcentrationUnits().getUnits());
+    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits(),
+        getConcentrationUnits());
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/AbstractSample.java
@@ -498,8 +498,8 @@ public abstract class AbstractSample extends AbstractBoxable implements Sample {
 
   @Override
   public String getBarcodeSizeInfo() {
-    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits().getUnits(),
-        getConcentrationUnits().getUnits());
+    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits(),
+        getConcentrationUnits());
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/DetailedSampleImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/DetailedSampleImpl.java
@@ -237,8 +237,8 @@ public class DetailedSampleImpl extends SampleImpl implements DetailedSample {
 
   @Override
   public String getBarcodeSizeInfo() {
-    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits() == null ? null : getVolumeUnits().getUnits(),
-        getConcentrationUnits() == null ? null : getConcentrationUnits().getUnits());
+    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits(),
+        getConcentrationUnits());
   }
 
 }

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryDilution.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/LibraryDilution.java
@@ -430,8 +430,8 @@ public class LibraryDilution extends AbstractBoxable
 
   @Override
   public String getBarcodeSizeInfo() {
-    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits().getUnits(),
-        getConcentrationUnits().getUnits());
+    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits(),
+        getConcentrationUnits());
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoolImpl.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/data/impl/PoolImpl.java
@@ -578,8 +578,8 @@ public class PoolImpl extends AbstractBoxable implements Pool {
 
   @Override
   public String getBarcodeSizeInfo() {
-    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits().getUnits(),
-        getConcentrationUnits().getUnits());
+    return LimsUtils.makeVolumeAndConcentrationLabel(getVolume(), getConcentration(), getVolumeUnits(),
+        getConcentrationUnits());
   }
 
   @Override

--- a/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtils.java
+++ b/core/src/main/java/uk/ac/bbsrc/tgac/miso/core/util/LimsUtils.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 import com.eaglegenomics.simlims.core.SecurityProfile;
 
 import uk.ac.bbsrc.tgac.miso.core.data.Boxable;
+import uk.ac.bbsrc.tgac.miso.core.data.ConcentrationUnit;
 import uk.ac.bbsrc.tgac.miso.core.data.DetailedLibrary;
 import uk.ac.bbsrc.tgac.miso.core.data.DetailedSample;
 import uk.ac.bbsrc.tgac.miso.core.data.IlluminaRun;
@@ -73,6 +74,7 @@ import uk.ac.bbsrc.tgac.miso.core.data.SampleTissue;
 import uk.ac.bbsrc.tgac.miso.core.data.SampleTissueProcessing;
 import uk.ac.bbsrc.tgac.miso.core.data.SequencerPartitionContainer;
 import uk.ac.bbsrc.tgac.miso.core.data.SolidRun;
+import uk.ac.bbsrc.tgac.miso.core.data.VolumeUnit;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.LibraryDilution;
 import uk.ac.bbsrc.tgac.miso.core.data.impl.OxfordNanoporeContainer;
 import uk.ac.bbsrc.tgac.miso.core.data.type.ConsentLevel;
@@ -465,17 +467,18 @@ public class LimsUtils {
     return Arrays.stream(sets).flatMap(Collection::stream).collect(Collectors.toSet());
   }
 
-  public static String makeVolumeAndConcentrationLabel(Double volume, Double concentration, String volumeUnits, String concentrationUnits) {
-    volumeUnits = (volumeUnits == null ? "" : volumeUnits);
-    concentrationUnits = (concentrationUnits == null ? "" : concentrationUnits);
+  public static String makeVolumeAndConcentrationLabel(Double volume, Double concentration, VolumeUnit volumeUnits,
+      ConcentrationUnit concentrationUnits) {
+    String strVolumeUnits = (volumeUnits == null ? "" : volumeUnits.getUnits());
+    String strConcentrationUnits = (concentrationUnits == null ? "" : concentrationUnits.getUnits());
     if (volume != null && volume != 0 && concentration != null && concentration != 0) {
-      return String.format("%.0f%s@%.0f%s", volume, volumeUnits, concentration, concentrationUnits);
+      return String.format("%.0f%s@%.0f%s", volume, strVolumeUnits, concentration, strConcentrationUnits);
     }
     if (volume != null && volume != 0) {
-      return String.format("%.0f%s", volume, volumeUnits);
+      return String.format("%.0f%s", volume, strVolumeUnits);
     }
     if (concentration != null && concentration != 0) {
-      return String.format("%.0f%s", concentration, concentrationUnits);
+      return String.format("%.0f%s", concentration, strConcentrationUnits);
     }
     return null;
   }


### PR DESCRIPTION
Change LimsUtils.makeVolumeAndConcentrationLabel to accept VolumeUnit
and ConcentrationUnit types rather than String.
makeVolumeAndConcentrationLabel tests for null inside method, removing
need for testing getVolumeUnits() and getConcentrationUnits() for null
within the call to makeVolumeAndConcentrationLabel.