### PR TITLE
Comment out runscanner URLs by default

### DIFF
--- a/miso-web/src/main/resources/external/miso.properties
+++ b/miso-web/src/main/resources/external/miso.properties
@@ -55,7 +55,7 @@ miso.taxonLookup.enabled:false
 # miso.timeCorrection.uiZone:UTC
 
 # A white-space delimited list of run scanner instances to poll
-miso.runscanner.urls:http://your.runscann.er:8080/
+#miso.runscanner.urls:http://your.runscann.er:8080/
 # The delay between queries to the server, in milliseconds
 miso.runscanner.interval:300000
 

--- a/miso-web/src/main/resources/internal/miso.properties
+++ b/miso-web/src/main/resources/internal/miso.properties
@@ -55,7 +55,7 @@ miso.taxonLookup.enabled:false
 # miso.timeCorrection.uiZone:UTC
 
 # A white-space delimited list of run scanner instances to poll
-miso.runscanner.urls:http://your.runscann.er:8080/
+#miso.runscanner.urls:http://your.runscann.er:8080/
 # The delay between queries to the server, in milliseconds
 miso.runscanner.interval:300000
 


### PR DESCRIPTION
Prevents errors from being thrown when the fake URL doesn't resolve. As per issue raised on Gitter.