### PR TITLE
changed Help tab link to new User Manual

### DIFF
--- a/miso-web/src/main/webapp/header.jsp
+++ b/miso-web/src/main/webapp/header.jsp
@@ -143,7 +143,7 @@
 
       <sec:authorize access="isAuthenticated()">
         <li>
-          <a href="<c:url value="http://oicr-gsi.github.io/miso-docs-oicr/plain-index"/>"><span>Help</span></a>
+          <a href="<c:url value="http://tgac.github.io/miso-lims/usr/user-manual-table-of-contents.html"/>"><span>Help</span></a>
         </li>
       </sec:authorize>
 


### PR DESCRIPTION
Note: link is currently broken because "V2" was removed from the title/filename. That change will be deployed at the same time as this