### PR TITLE
Accomodate Oxford Nanopore in Dtos.to()

### DIFF
--- a/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
+++ b/miso-dto/src/main/java/uk/ac/bbsrc/tgac/miso/dto/Dtos.java
@@ -1955,6 +1955,7 @@ public class Dtos {
 
     switch (to.getPlatformType()) {
     case PACBIO:
+    case OXFORDNANOPORE:
       break;
     case ILLUMINA:
       setIlluminaRunValues((IlluminaNotificationDto) from, (IlluminaRun) to);


### PR DESCRIPTION
to() was falling through to the default case and throwing NotImplementedException. This keeps it from doing that.