### PR TITLE
GLT-2799: symlink /storage/files/freezermaps/ to be served statically

### DIFF
--- a/.docker/tomcat/ROOT.xml
+++ b/.docker/tomcat/ROOT.xml
@@ -1,4 +1,5 @@
 <Context path="/ROOT" docBase="${catalina.home}/webapps/ROOT">
+  <Resources allowLinking="true"/>
   <Resource name="jdbc/MISODB" type="javax.sql.DataSource"
   initialSize="32"
   maxIdle="10"

--- a/docs/_posts/2016-01-11-installation-guide.md
+++ b/docs/_posts/2016-01-11-installation-guide.md
@@ -173,6 +173,7 @@ Create a file called `ROOT.xml` in the following directory
 and populate it with the following information:
 
     <Context path="/ROOT" docBase="${catalina.home}/webapps/ROOT">
+      <Resources allowLinking="true"/>
       <Resource name="jdbc/MISODB" type="javax.sql.DataSource"
       driverClassName="com.mysql.jdbc.Driver"
       initialSize="32"

--- a/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/context/MisoAppListener.java
+++ b/miso-web/src/main/java/uk/ac/bbsrc/tgac/miso/webapp/context/MisoAppListener.java
@@ -24,6 +24,9 @@
 package uk.ac.bbsrc.tgac.miso.webapp.context;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
@@ -107,6 +110,7 @@ public class MisoAppListener implements ServletContextListener {
     } else {
       log.info(dirchecks.get("ok"));
     }
+    linkMapsDir(application, fileStoragePath);
 
     // set headless property so JFreeChart doesn't try to use the X rendering system to generate images
     System.setProperty("java.awt.headless", "true");
@@ -121,6 +125,22 @@ public class MisoAppListener implements ServletContextListener {
     }
 
     loadIssueTrackerManager(misoProperties, context);
+  }
+
+  private void linkMapsDir(ServletContext application, String fileStoragePath) {
+    try {
+      Path target = Paths.get(fileStoragePath, "freezermaps");
+      if (!Files.exists(target)) {
+        Files.createDirectory(target);
+      }
+      Path link = Paths.get(application.getRealPath("/"), "freezermaps");
+      if (Files.exists(link)) {
+        Files.delete(link);
+      }
+      Files.createSymbolicLink(link, target);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to link freezer maps directory", e);
+    }
   }
 
   private void loadIssueTrackerManager(Map<String, String> misoProperties, XmlWebApplicationContext context) {


### PR DESCRIPTION
Anything you put in `/storage/files/freezermaps/` (depending on your `miso.properties` settings - this is the default location) will be statically served at `<host>/freezermaps/`. Note that similar to the `scripts` and `styles` directories, it will not be under `/miso`